### PR TITLE
fix: urlencode query params

### DIFF
--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
+from urllib.parse import urlencode
 
 from pydantic import BaseModel
 
@@ -55,14 +56,16 @@ class InfraHubBranchManagerBase:
         time_to: Optional[str] = None,
     ) -> str:
         """Generate the URL for the diff_data function."""
-        url = f"{client.address}/api/diff/data?branch={branch_name}"
-        url += f"&branch_only={str(branch_only).lower()}"
+        url = f"{client.address}/api/diff/data"
+        url_params = {}
+        url_params["branch"] = branch_name
+        url_params["branch_only"] = str(branch_only).lower()
         if time_from:
-            url += f"&time_from={time_from}"
+            url_params["time_from"] = time_from
         if time_to:
-            url += f"&time_to={time_to}"
+            url_params["time_to"] = time_to
 
-        return url
+        return url + urlencode(url_params)
 
 
 class InfrahubBranchManager(InfraHubBranchManagerBase):

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
     overload,
 )
+from urllib.parse import urlencode
 
 import httpx
 import ujson
@@ -228,7 +229,7 @@ class BaseClient:
         if at:
             at = Timestamp(at)
             url_params["at"] = at.to_string()
-            url += "?" + "&".join([f"{key}={value}" for key, value in url_params.items()])
+            url += "?" + urlencode(url_params)
 
         return url
 
@@ -979,14 +980,19 @@ class InfrahubClient(BaseClient):
 
         if url_params:
             url_params_str = []
+            url_params_dict = {}
             for key, value in url_params.items():
                 if isinstance(value, (list)):
                     for item in value:
-                        url_params_str.append(f"{key}={item}")
+                        url_params_str.append((key, item))
                 else:
-                    url_params_str.append(f"{key}={value}")
+                    url_params_dict[key] = value
 
-            url += "?" + "&".join(url_params_str)
+            url += "?"
+            if url_params_dict:
+                url += urlencode(url_params_dict) + "&"
+            if url_params_str:
+                url += urlencode(url_params_str)
 
         payload = {}
         if variables:
@@ -1971,14 +1977,19 @@ class InfrahubClientSync(BaseClient):
 
         if url_params:
             url_params_str = []
+            url_params_dict = {}
             for key, value in url_params.items():
                 if isinstance(value, (list)):
                     for item in value:
-                        url_params_str.append(f"{key}={item}")
+                        url_params_str.append((key, item))
                 else:
-                    url_params_str.append(f"{key}={value}")
+                    url_params_dict[key] = value
 
-            url += "?" + "&".join(url_params_str)
+            url += "?"
+            if url_params_dict:
+                url += urlencode(url_params_dict) + "&"
+            if url_params_str:
+                url += urlencode(url_params_str)
 
         payload = {}
         if variables:


### PR DESCRIPTION
This fixes issues when using timestamps containing reserved characters.
Such query wouldn't work as expected due to the plus sign:

```
client.get(kind="Instance", id="17fa68ba-dfe1-f94e-3267-c513e00993b4", at="2024-10-02T15:03:43.328091+00:00")
```