### PR TITLE
Change the default connection timeout to 60s

### DIFF
--- a/changelog/+connection-timeout.fixed.md
+++ b/changelog/+connection-timeout.fixed.md
@@ -1,0 +1,1 @@
+Changed the default connection timeout in the SDK to 60s.

--- a/infrahub_sdk/config.py
+++ b/infrahub_sdk/config.py
@@ -54,7 +54,7 @@ class ConfigBase(BaseSettings):
     pagination_size: int = Field(default=50, description="Page size for queries to the server")
     retry_delay: int = Field(default=5, description="Number of seconds to wait until attempting a retry.")
     retry_on_failure: bool = Field(default=False, description="Retry operation in case of failure")
-    timeout: int = Field(default=10, description="Default connection timeout in seconds")
+    timeout: int = Field(default=60, description="Default connection timeout in seconds")
     transport: RequesterTransport = Field(
         default=RequesterTransport.HTTPX, description="Set an alternate transport using a predefined option"
     )


### PR DESCRIPTION
Change the default connection timeout of the Python SDK to 60s.

This is mainly to resolve some issue we see with implementations that implement large datasets on:
- failing to start the Infrahub CI pipeline
- requests in large batches of concurrent mutations timing out
- request to retrieve generator group with large amount of members timing out

This should be revisited as soon as we have more through solutions for the above.