### PR TITLE
Add `infrahubctl menu load` command to load menu items from a file

### DIFF
--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -22,13 +22,19 @@ from infrahub_sdk.ctl.check import run as run_check
 from infrahub_sdk.ctl.client import initialize_client, initialize_client_sync
 from infrahub_sdk.ctl.exceptions import QueryNotFoundError
 from infrahub_sdk.ctl.generator import run as run_generator
+from infrahub_sdk.ctl.menu import app as menu_app
+from infrahub_sdk.ctl.object import app as object_app
 from infrahub_sdk.ctl.render import list_jinja2_transforms
 from infrahub_sdk.ctl.repository import app as repository_app
 from infrahub_sdk.ctl.repository import get_repository_config
 from infrahub_sdk.ctl.schema import app as schema_app
-from infrahub_sdk.ctl.schema import load_schemas_from_disk_and_exit
 from infrahub_sdk.ctl.transform import list_transforms
-from infrahub_sdk.ctl.utils import catch_exception, execute_graphql_query, parse_cli_vars
+from infrahub_sdk.ctl.utils import (
+    catch_exception,
+    execute_graphql_query,
+    load_yamlfile_from_disk_and_exit,
+    parse_cli_vars,
+)
 from infrahub_sdk.ctl.validate import app as validate_app
 from infrahub_sdk.exceptions import GraphQLError, InfrahubTransformNotFoundError
 from infrahub_sdk.jinja2 import identify_faulty_jinja_code
@@ -39,6 +45,7 @@ from infrahub_sdk.schema import (
 )
 from infrahub_sdk.transforms import get_transform_class_instance
 from infrahub_sdk.utils import get_branch, write_to_file
+from infrahub_sdk.yaml import SchemaFile
 
 from .exporter import dump
 from .importer import load
@@ -50,6 +57,9 @@ app.add_typer(branch_app, name="branch")
 app.add_typer(schema_app, name="schema")
 app.add_typer(validate_app, name="validate")
 app.add_typer(repository_app, name="repository")
+app.add_typer(menu_app, name="menu")
+app.add_typer(object_app, name="object", hidden=True)
+
 app.command(name="dump")(dump)
 app.command(name="load")(load)
 
@@ -338,7 +348,7 @@ def protocols(  # noqa: PLR0915
     schema: dict[str, MainSchemaTypes] = {}
 
     if schemas:
-        schemas_data = load_schemas_from_disk_and_exit(schemas=schemas)
+        schemas_data = load_yamlfile_from_disk_and_exit(paths=schemas, file_type=SchemaFile, console=console)
 
         for data in schemas_data:
             data.load_content()

--- a/infrahub_sdk/ctl/menu.py
+++ b/infrahub_sdk/ctl/menu.py
@@ -40,13 +40,8 @@ async def load(
     files = load_yamlfile_from_disk_and_exit(paths=menus, file_type=MenuFile, console=console)
     client = await initialize_client()
 
-    default_kind = "CoreMenuItem"
-
     for file in files:
         file.validate_content()
-        if not file.spec.kind:
-            file.spec.kind = default_kind
-
         schema = await client.schema.get(kind=file.spec.kind, branch=branch)
 
         for idx, item in enumerate(file.spec.data):
@@ -55,6 +50,6 @@ async def load(
                 schema=schema,
                 data=item,
                 branch=branch,
-                default_schema_kind=default_kind,
+                default_schema_kind=file.spec.kind,
                 context={"list_index": idx},
             )

--- a/infrahub_sdk/ctl/object.py
+++ b/infrahub_sdk/ctl/object.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import typer
@@ -5,7 +6,6 @@ from rich.console import Console
 
 from infrahub_sdk.async_typer import AsyncTyper
 from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.exceptions import FileNotValidError
 from infrahub_sdk.ctl.utils import catch_exception, init_logging
 from infrahub_sdk.spec.object import ObjectFile
 
@@ -35,13 +35,13 @@ async def load(
 
     init_logging(debug=debug)
 
+    logging.getLogger("infrahub_sdk").setLevel(logging.INFO)
+
     files = load_yamlfile_from_disk_and_exit(paths=paths, file_type=ObjectFile, console=console)
     client = await initialize_client()
 
     for file in files:
         file.validate_content()
-        if not file.spec.kind:
-            raise FileNotValidError(name=str(file.location), message="kind must be specified.")
         schema = await client.schema.get(kind=file.spec.kind, branch=branch)
 
         for item in file.spec.data:

--- a/infrahub_sdk/ctl/object.py
+++ b/infrahub_sdk/ctl/object.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from infrahub_sdk.async_typer import AsyncTyper
+from infrahub_sdk.ctl.client import initialize_client
+from infrahub_sdk.ctl.exceptions import FileNotValidError
+from infrahub_sdk.ctl.utils import catch_exception, init_logging
+from infrahub_sdk.spec.object import ObjectFile
+
+from .parameters import CONFIG_PARAM
+from .utils import load_yamlfile_from_disk_and_exit
+
+app = AsyncTyper()
+console = Console()
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Manage objects in a remote Infrahub instance.
+    """
+
+
+@app.command()
+@catch_exception(console=console)
+async def load(
+    paths: list[Path],
+    debug: bool = False,
+    branch: str = typer.Option("main", help="Branch on which to load the objects."),
+    _: str = CONFIG_PARAM,
+) -> None:
+    """Load one or multiple objects files into Infrahub."""
+
+    init_logging(debug=debug)
+
+    files = load_yamlfile_from_disk_and_exit(paths=paths, file_type=ObjectFile, console=console)
+    client = await initialize_client()
+
+    for file in files:
+        file.validate_content()
+        if not file.spec.kind:
+            raise FileNotValidError(name=str(file.location), message="kind must be specified.")
+        schema = await client.schema.get(kind=file.spec.kind, branch=branch)
+
+        for item in file.spec.data:
+            await file.spec.create_node(client=client, schema=schema, data=item, branch=branch)

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -143,6 +143,7 @@ class CoreMenu(CoreNode):
     namespace: String
     name: String
     label: StringOptional
+    kind: StringOptional
     path: StringOptional
     description: StringOptional
     icon: StringOptional
@@ -607,6 +608,7 @@ class CoreMenuSync(CoreNodeSync):
     namespace: String
     name: String
     label: StringOptional
+    kind: StringOptional
     path: StringOptional
     description: StringOptional
     icon: StringOptional

--- a/infrahub_sdk/spec/menu.py
+++ b/infrahub_sdk/spec/menu.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from infrahub_sdk.yaml import InfrahubFile, InfrahubFileKind
+
+from .object import InfrahubObjectFileData
+
+
+class InfrahubMenuFileData(InfrahubObjectFileData):
+    @classmethod
+    def enrich_node(cls, data: dict, context: dict) -> dict:
+        if "kind" in data and "path" not in data:
+            data["path"] = "/objects/" + data["kind"]
+
+        if "list_index" in context and "order_weight" not in data:
+            data["order_weight"] = (context["list_index"] + 1) * 1000
+
+        return data
+
+
+class MenuFile(InfrahubFile):
+    _spec: Optional[InfrahubMenuFileData] = None
+
+    @property
+    def spec(self) -> InfrahubMenuFileData:
+        if not self._spec:
+            self._spec = InfrahubMenuFileData(**self.data.spec)
+        return self._spec
+
+    def validate_content(self) -> None:
+        super().validate_content()
+        if self.kind != InfrahubFileKind.MENU:
+            raise ValueError("File is not an Infrahub Menu file")
+        self._spec = InfrahubMenuFileData(**self.data.spec)

--- a/infrahub_sdk/spec/menu.py
+++ b/infrahub_sdk/spec/menu.py
@@ -6,6 +6,8 @@ from .object import InfrahubObjectFileData
 
 
 class InfrahubMenuFileData(InfrahubObjectFileData):
+    kind: str = "CoreMenuItem"
+
     @classmethod
     def enrich_node(cls, data: dict, context: dict) -> dict:
         if "kind" in data and "path" not in data:

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -8,7 +8,7 @@ from infrahub_sdk.yaml import InfrahubFile, InfrahubFileKind
 
 
 class InfrahubObjectFileData(BaseModel):
-    kind: str | None = None
+    kind: Optional[str] = None
     data: list[dict[str, Any]] = Field(default_factory=list)
 
     @classmethod

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -1,0 +1,128 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from infrahub_sdk.client import InfrahubClient
+from infrahub_sdk.schema import MainSchemaTypes
+from infrahub_sdk.yaml import InfrahubFile, InfrahubFileKind
+
+
+class InfrahubObjectFileData(BaseModel):
+    kind: str | None = None
+    data: list[dict[str, Any]] = Field(default_factory=list)
+
+    @classmethod
+    def enrich_node(cls, data: dict, context: dict) -> dict:
+        return data
+
+    @classmethod
+    async def create_node(
+        cls,
+        client: InfrahubClient,
+        schema: MainSchemaTypes,
+        data: dict,
+        context: Optional[dict] = None,
+        branch: Optional[str] = None,
+        default_schema_kind: Optional[str] = None,
+    ) -> None:
+        # First validate of all mandatory fields are present
+        for element in schema.mandatory_attribute_names + schema.mandatory_relationship_names:
+            if element not in data.keys():
+                raise ValueError(f"{element} is mandatory")
+
+        clean_data: dict[str, Any] = {}
+
+        remaining_rels = []
+        for key, value in data.items():
+            if key in schema.attribute_names:
+                # NOTE we could validate the format of the data but the API will do it as well
+                clean_data[key] = value
+
+            if key in schema.relationship_names:
+                rel_schema = schema.get_relationship(name=key)
+
+                if not isinstance(value, dict) and "data" in value:
+                    raise ValueError(f"relationship {key} must be a dict with 'data'")
+
+                if rel_schema.cardinality == "one" or rel_schema.optional is False:
+                    raise ValueError(
+                        "Not supported yet, we need to have a way to define connect object before they exist"
+                    )
+                    # clean_data[key] = value[data]
+                remaining_rels.append(key)
+
+        if context:
+            clean_context = {
+                ckey: cvalue
+                for ckey, cvalue in context.items()
+                if ckey in schema.relationship_names + schema.attribute_names
+            }
+            clean_data.update(clean_context)
+
+        clean_data = cls.enrich_node(data=clean_data, context=context or {})
+
+        node = await client.create(kind=schema.kind, branch=branch, data=clean_data)
+        await node.save(allow_upsert=True)
+        display_label = node.get_human_friendly_id_as_string() or f"{node.get_kind()} : {node.id}"
+        client.log.info(f"Node: {display_label}")
+
+        for rel in remaining_rels:
+            # identify what is the name of the relationship on the other side
+            if not isinstance(data[rel], dict) and "data" in data[rel]:
+                raise ValueError(f"relationship {rel} must be a dict with 'data'")
+
+            rel_schema = schema.get_relationship(name=rel)
+            peer_kind = data[rel].get("kind", default_schema_kind) or rel_schema.peer
+            peer_schema = await client.schema.get(kind=peer_kind, branch=branch)
+
+            if rel_schema.identifier is None:
+                raise ValueError("identifier must be defined")
+
+            peer_rel = peer_schema.get_relationship_by_identifier(id=rel_schema.identifier)
+
+            rel_data = data[rel]["data"]
+            context = {}
+            if peer_rel:
+                context[peer_rel.name] = node.id
+
+            if rel_schema.cardinality == "one" and isinstance(rel_data, dict):
+                await cls.create_node(
+                    client=client,
+                    schema=peer_schema,
+                    data=rel_data,
+                    context=context,
+                    branch=branch,
+                    default_schema_kind=default_schema_kind,
+                )
+
+            elif rel_schema.cardinality == "many" and isinstance(rel_data, list):
+                for idx, peer_data in enumerate(rel_data):
+                    context["list_index"] = idx
+                    await cls.create_node(
+                        client=client,
+                        schema=peer_schema,
+                        data=peer_data,
+                        context=context,
+                        branch=branch,
+                        default_schema_kind=default_schema_kind,
+                    )
+            else:
+                raise ValueError(
+                    f"Relationship {rel_schema.name} doesn't have the right format {rel_schema.cardinality} / {type(rel_data)}"
+                )
+
+
+class ObjectFile(InfrahubFile):
+    _spec: Optional[InfrahubObjectFileData] = None
+
+    @property
+    def spec(self) -> InfrahubObjectFileData:
+        if not self._spec:
+            self._spec = InfrahubObjectFileData(**self.data.spec)
+        return self._spec
+
+    def validate_content(self) -> None:
+        super().validate_content()
+        if self.kind != InfrahubFileKind.OBJECT:
+            raise ValueError("File is not an Infrahub Object file")
+        self._spec = InfrahubObjectFileData(**self.data.spec)

--- a/infrahub_sdk/yaml.py
+++ b/infrahub_sdk/yaml.py
@@ -1,17 +1,40 @@
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from infrahub_sdk.ctl.exceptions import FileNotValidError
+from infrahub_sdk.utils import find_files
 
 
-class SchemaFile(BaseModel):
+class InfrahubFileApiVersion(str, Enum):
+    V1 = "infrahub.app/v1"
+
+
+class InfrahubFileKind(str, Enum):
+    MENU = "Menu"
+    OBJECT = "Object"
+
+
+class InfrahubFileData(BaseModel):
+    api_version: InfrahubFileApiVersion = Field(InfrahubFileApiVersion.V1, alias="apiVersion")
+    kind: InfrahubFileKind
+    spec: dict
+    metadata: Optional[dict] = Field(default_factory=dict)
+
+
+class LocalFile(BaseModel):
     identifier: Optional[str] = None
     location: Path
     content: Optional[dict] = None
     valid: bool = True
     error_message: Optional[str] = None
 
+
+class YamlFile(LocalFile):
     def load_content(self) -> None:
         try:
             self.content = yaml.safe_load(self.location.read_text())
@@ -23,3 +46,52 @@ class SchemaFile(BaseModel):
         if not self.content:
             self.error_message = "Empty YAML/JSON file"
             self.valid = False
+
+    def validate_content(self) -> None:
+        pass
+
+    @classmethod
+    def load_from_disk(cls, paths: list[Path]) -> list[Self]:
+        yaml_files: list[Self] = []
+        for file_path in paths:
+            if file_path.is_file():
+                yaml_file = cls(location=file_path)
+                yaml_file.load_content()
+                yaml_files.append(yaml_file)
+            elif file_path.is_dir():
+                files = find_files(extension=["yaml", "yml", "json"], directory=file_path)
+                for item in files:
+                    yaml_file = cls(location=item)
+                    yaml_file.load_content()
+                    yaml_files.append(yaml_file)
+            else:
+                raise FileNotValidError(name=str(file_path), message=f"{file_path} does not exist!")
+
+        return yaml_files
+
+
+class InfrahubFile(YamlFile):
+    _data: Optional[InfrahubFileData] = None
+
+    @property
+    def data(self) -> InfrahubFileData:
+        if not self._data:
+            raise ValueError("_data hasn't been initialized yet")
+        return self._data
+
+    @property
+    def version(self) -> InfrahubFileApiVersion:
+        return self.data.api_version
+
+    @property
+    def kind(self) -> InfrahubFileKind:
+        return self.data.kind
+
+    def validate_content(self) -> None:
+        if not self.content:
+            raise ValueError("Content hasn't been loaded yet")
+        self._data = InfrahubFileData(**self.content)
+
+
+class SchemaFile(YamlFile):
+    pass


### PR DESCRIPTION
This PR adds a new cli command `infrahubctl menu load` to load menu items from one or multiple files
> This effort is part of the upcoming release of Infrahub and it is required to load the new menu items

The menu file need to have the following format.

in Summary
- The first 4 lines are mandatory
- The format under `data` must be compatible with `CoreMenuItem`
- If `kind` is provided, the path will be automatically generated to `/objects/<kind>`

```yaml
---
apiVersion: infrahub.app/v1
kind: Menu
spec:
  data:
  - namespace: Location
    name: MainMenu
    label: Location
    icon: "mingcute:location-line"
    children:
      data:
      - namespace: Location
        name: ContinentMenu
        label: Continent
        kind: LocationContinent
        icon: "jam:world"
        order_weight: 1000
```

## More than just the menu

Because, it felt silly to create yet another specific command for the menu, I tried to make it as generic as possible.
With a tiny difference, this format should work for all type of objects in the near future.
I've also added the command `infrahubctl object load` (hidden for now) to explore this feature.

I was able to successfully load this file with `location` data but more work is required to properly support all types of relationships

```yaml
---
apiVersion: infrahub.app/v1
kind: Object
spec:
  kind: LocationContinent
  data:
  - name: North America
    children:
      kind: LocationCountry
      data:
      - name: "United States of America"
      - name: "Canada"
  - name: South America
    children:
      kind: LocationCountry
      data:
      - name: "Mexico"
      - name: "Brazil"
```

