### PR TITLE
Run coverage separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,23 @@ jobs:
       # - name: "Pylint Tests"
       #   run: "poetry run pylint infrahub_sdk/"
       - name: "Unit Tests"
-        run: "poetry run pytest tests/unit/"
+        run: "poetry run pytest --cov infrahub_sdk tests/unit/"
       - name: "Upload coverage to Codecov"
         run: |
           codecov --flags python-${{ matrix.python-version }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      # The pytest-cov plugin doesn't quite work with content that is
+      # auto-imported by our own infrahub pytest plugin, this workaround
+      # reports the missing lines
+      - name: "Report coverage for pytest-plugin"
+        if: matrix.python-version == '3.12'
+        run: |
+          source $(poetry env info --path)/bin/activate
+          coverage run -m pytest tests/unit/pytest_plugin
+          coverage report -m
+          coverage xml
+          codecov --flags python-filler-${{ matrix.python-version }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
     "ignore:Deprecated call to",
 ]
-addopts = "-vs --cov infrahub_sdk --cov-report term-missing --cov-report xml --dist loadscope"
+addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope"
 
 [tool.mypy]
 pretty = true


### PR DESCRIPTION
Runs "coverage" as a separate task in order to get around problems with our own pytest plugin being loaded before pytest-cov starts to calculate coverage which causes the parts of our files that get auto imported to be marked as missed in the coverage report.

@dgarros, this was what I had in mind. Should also work fine with regards to xdist etc.