### PR TITLE
Convert import paths to use relative Package name

### DIFF
--- a/infrahub_sdk/__init__.py
+++ b/infrahub_sdk/__init__.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import importlib.metadata
 
-from infrahub_sdk.analyzer import GraphQLOperation, GraphQLQueryAnalyzer, GraphQLQueryVariable
-from infrahub_sdk.batch import InfrahubBatch
-from infrahub_sdk.branch import InfrahubBranchManager, InfrahubBranchManagerSync
-from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
-from infrahub_sdk.config import Config
-from infrahub_sdk.exceptions import (
+from .analyzer import GraphQLOperation, GraphQLQueryAnalyzer, GraphQLQueryVariable
+from .batch import InfrahubBatch
+from .branch import InfrahubBranchManager, InfrahubBranchManagerSync
+from .client import InfrahubClient, InfrahubClientSync
+from .config import Config
+from .exceptions import (
     AuthenticationError,
     Error,
     GraphQLError,
@@ -16,9 +16,9 @@ from infrahub_sdk.exceptions import (
     ServerNotResponsiveError,
     ValidationError,
 )
-from infrahub_sdk.graphql import Mutation, Query
-from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
-from infrahub_sdk.schema import (
+from .graphql import Mutation, Query
+from .node import InfrahubNode, InfrahubNodeSync
+from .schema import (
     AttributeSchema,
     GenericSchema,
     InfrahubRepositoryConfig,
@@ -31,9 +31,9 @@ from infrahub_sdk.schema import (
     RelationshipSchema,
     SchemaRoot,
 )
-from infrahub_sdk.store import NodeStore, NodeStoreSync
-from infrahub_sdk.timestamp import Timestamp
-from infrahub_sdk.uuidt import UUIDT, generate_uuid
+from .store import NodeStore, NodeStoreSync
+from .timestamp import Timestamp
+from .uuidt import UUIDT, generate_uuid
 
 __all__ = [
     "AttributeSchema",

--- a/infrahub_sdk/_importer.py
+++ b/infrahub_sdk/_importer.py
@@ -4,7 +4,7 @@ import importlib
 import sys
 from typing import TYPE_CHECKING, Optional
 
-from infrahub_sdk.exceptions import ModuleImportError
+from .exceptions import ModuleImportError
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/infrahub_sdk/analyzer.py
+++ b/infrahub_sdk/analyzer.py
@@ -12,7 +12,7 @@ from graphql import (
 )
 from pydantic import BaseModel
 
-from infrahub_sdk.utils import calculate_dict_depth, calculate_dict_height, extract_fields
+from .utils import calculate_dict_depth, calculate_dict_height, extract_fields
 
 
 class GraphQLQueryVariable(BaseModel):

--- a/infrahub_sdk/batch.py
+++ b/infrahub_sdk/batch.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Awaitable, Callable, Optional
 
-from infrahub_sdk.node import InfrahubNode
+from .node import InfrahubNode
 
 
 @dataclass

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import BaseModel
 
-from infrahub_sdk.exceptions import BranchNotFoundError
-from infrahub_sdk.graphql import Mutation, Query
-from infrahub_sdk.utils import decode_json
+from .exceptions import BranchNotFoundError
+from .graphql import Mutation, Query
+from .utils import decode_json
 
 if TYPE_CHECKING:
-    from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
+    from .client import InfrahubClient, InfrahubClientSync
 
 
 class BranchData(BaseModel):

--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -10,13 +10,13 @@ import ujson
 from git.repo import Repo
 from pydantic import BaseModel, Field
 
-from infrahub_sdk import InfrahubClient
-from infrahub_sdk.exceptions import InfrahubCheckNotFoundError
+from . import InfrahubClient
+from .exceptions import InfrahubCheckNotFoundError
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from infrahub_sdk.schema import InfrahubCheckDefinitionConfig
+    from .schema import InfrahubCheckDefinitionConfig
 
 INFRAHUB_CHECK_VARIABLE_TO_IMPORT = "INFRAHUB_CHECKS"
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -23,17 +23,17 @@ import httpx
 import ujson
 from typing_extensions import Self
 
-from infrahub_sdk.batch import InfrahubBatch
-from infrahub_sdk.branch import (
+from .batch import InfrahubBatch
+from .branch import (
     BranchData,
     InfrahubBranchManager,
     InfrahubBranchManagerSync,
 )
-from infrahub_sdk.config import Config
-from infrahub_sdk.constants import InfrahubClientMode
-from infrahub_sdk.data import RepositoryBranchInfo, RepositoryData
-from infrahub_sdk.diff import NodeDiff, diff_tree_node_to_node_diff, get_diff_summary_query
-from infrahub_sdk.exceptions import (
+from .config import Config
+from .constants import InfrahubClientMode
+from .data import RepositoryBranchInfo, RepositoryData
+from .diff import NodeDiff, diff_tree_node_to_node_diff, get_diff_summary_query
+from .exceptions import (
     AuthenticationError,
     Error,
     GraphQLError,
@@ -41,20 +41,20 @@ from infrahub_sdk.exceptions import (
     ServerNotReachableError,
     ServerNotResponsiveError,
 )
-from infrahub_sdk.graphql import Mutation, Query
-from infrahub_sdk.node import (
+from .graphql import Mutation, Query
+from .node import (
     InfrahubNode,
     InfrahubNodeSync,
 )
-from infrahub_sdk.object_store import ObjectStore, ObjectStoreSync
-from infrahub_sdk.protocols_base import CoreNode, CoreNodeSync
-from infrahub_sdk.queries import get_commit_update_mutation
-from infrahub_sdk.query_groups import InfrahubGroupContext, InfrahubGroupContextSync
-from infrahub_sdk.schema import InfrahubSchema, InfrahubSchemaSync, NodeSchema
-from infrahub_sdk.store import NodeStore, NodeStoreSync
-from infrahub_sdk.timestamp import Timestamp
-from infrahub_sdk.types import AsyncRequester, HTTPMethod, SyncRequester
-from infrahub_sdk.utils import decode_json, is_valid_uuid
+from .object_store import ObjectStore, ObjectStoreSync
+from .protocols_base import CoreNode, CoreNodeSync
+from .queries import get_commit_update_mutation
+from .query_groups import InfrahubGroupContext, InfrahubGroupContextSync
+from .schema import InfrahubSchema, InfrahubSchemaSync, NodeSchema
+from .store import NodeStore, NodeStoreSync
+from .timestamp import Timestamp
+from .types import AsyncRequester, HTTPMethod, SyncRequester
+from .utils import decode_json, is_valid_uuid
 
 if TYPE_CHECKING:
     from types import TracebackType

--- a/infrahub_sdk/code_generator.py
+++ b/infrahub_sdk/code_generator.py
@@ -2,9 +2,9 @@ from typing import Any, Mapping, Optional
 
 import jinja2
 
-from infrahub_sdk import protocols as sdk_protocols
-from infrahub_sdk.ctl.constants import PROTOCOLS_TEMPLATE
-from infrahub_sdk.schema import (
+from . import protocols as sdk_protocols
+from .ctl.constants import PROTOCOLS_TEMPLATE
+from .schema import (
     AttributeSchema,
     GenericSchema,
     MainSchemaTypes,

--- a/infrahub_sdk/config.py
+++ b/infrahub_sdk/config.py
@@ -4,11 +4,11 @@ from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
-from infrahub_sdk.constants import InfrahubClientMode
-from infrahub_sdk.playback import JSONPlayback
-from infrahub_sdk.recorder import JSONRecorder, NoRecorder, Recorder, RecorderType
-from infrahub_sdk.types import AsyncRequester, InfrahubLoggers, RequesterTransport, SyncRequester
-from infrahub_sdk.utils import get_branch, is_valid_url
+from .constants import InfrahubClientMode
+from .playback import JSONPlayback
+from .recorder import JSONRecorder, NoRecorder, Recorder, RecorderType
+from .types import AsyncRequester, InfrahubLoggers, RequesterTransport, SyncRequester
+from .utils import get_branch, is_valid_url
 
 
 class ProxyMountsConfig(BaseSettings):

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -4,10 +4,9 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.utils import calculate_time_diff, catch_exception
-
+from ..async_typer import AsyncTyper
+from ..ctl.client import initialize_client
+from ..ctl.utils import calculate_time_diff, catch_exception
 from .parameters import CONFIG_PARAM
 
 app = AsyncTyper()

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -11,14 +11,14 @@ import typer
 from rich.console import Console
 from rich.logging import RichHandler
 
-from infrahub_sdk import InfrahubClient
-from infrahub_sdk.checks import InfrahubCheck
-from infrahub_sdk.ctl import config
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.exceptions import QueryNotFoundError
-from infrahub_sdk.ctl.repository import get_repository_config
-from infrahub_sdk.ctl.utils import catch_exception, execute_graphql_query
-from infrahub_sdk.schema import InfrahubCheckDefinitionConfig, InfrahubRepositoryConfig
+from .. import InfrahubClient
+from ..checks import InfrahubCheck
+from ..ctl import config
+from ..ctl.client import initialize_client
+from ..ctl.exceptions import QueryNotFoundError
+from ..ctl.repository import get_repository_config
+from ..ctl.utils import catch_exception, execute_graphql_query
+from ..schema import InfrahubCheckDefinitionConfig, InfrahubRepositoryConfig
 
 app = typer.Typer()
 console = Console()

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -13,40 +13,39 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.traceback import Traceback
 
-from infrahub_sdk import __version__ as sdk_version
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.code_generator import CodeGenerator
-from infrahub_sdk.ctl import config
-from infrahub_sdk.ctl.branch import app as branch_app
-from infrahub_sdk.ctl.check import run as run_check
-from infrahub_sdk.ctl.client import initialize_client, initialize_client_sync
-from infrahub_sdk.ctl.exceptions import QueryNotFoundError
-from infrahub_sdk.ctl.generator import run as run_generator
-from infrahub_sdk.ctl.menu import app as menu_app
-from infrahub_sdk.ctl.object import app as object_app
-from infrahub_sdk.ctl.render import list_jinja2_transforms
-from infrahub_sdk.ctl.repository import app as repository_app
-from infrahub_sdk.ctl.repository import get_repository_config
-from infrahub_sdk.ctl.schema import app as schema_app
-from infrahub_sdk.ctl.transform import list_transforms
-from infrahub_sdk.ctl.utils import (
+from .. import __version__ as sdk_version
+from ..async_typer import AsyncTyper
+from ..code_generator import CodeGenerator
+from ..ctl import config
+from ..ctl.branch import app as branch_app
+from ..ctl.check import run as run_check
+from ..ctl.client import initialize_client, initialize_client_sync
+from ..ctl.exceptions import QueryNotFoundError
+from ..ctl.generator import run as run_generator
+from ..ctl.menu import app as menu_app
+from ..ctl.object import app as object_app
+from ..ctl.render import list_jinja2_transforms
+from ..ctl.repository import app as repository_app
+from ..ctl.repository import get_repository_config
+from ..ctl.schema import app as schema_app
+from ..ctl.transform import list_transforms
+from ..ctl.utils import (
     catch_exception,
     execute_graphql_query,
     load_yamlfile_from_disk_and_exit,
     parse_cli_vars,
 )
-from infrahub_sdk.ctl.validate import app as validate_app
-from infrahub_sdk.exceptions import GraphQLError, InfrahubTransformNotFoundError
-from infrahub_sdk.jinja2 import identify_faulty_jinja_code
-from infrahub_sdk.schema import (
+from ..ctl.validate import app as validate_app
+from ..exceptions import GraphQLError, InfrahubTransformNotFoundError
+from ..jinja2 import identify_faulty_jinja_code
+from ..schema import (
     InfrahubRepositoryConfig,
     MainSchemaTypes,
     SchemaRoot,
 )
-from infrahub_sdk.transforms import get_transform_class_instance
-from infrahub_sdk.utils import get_branch, write_to_file
-from infrahub_sdk.yaml import SchemaFile
-
+from ..transforms import get_transform_class_instance
+from ..utils import get_branch, write_to_file
+from ..yaml import SchemaFile
 from .exporter import dump
 from .importer import load
 from .parameters import CONFIG_PARAM

--- a/infrahub_sdk/ctl/client.py
+++ b/infrahub_sdk/ctl/client.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
-from infrahub_sdk import InfrahubClient, InfrahubClientSync
-from infrahub_sdk.config import Config
-from infrahub_sdk.ctl import config
+from .. import InfrahubClient, InfrahubClientSync
+from ..config import Config
+from ..ctl import config
 
 
 async def initialize_client(

--- a/infrahub_sdk/ctl/exporter.py
+++ b/infrahub_sdk/ctl/exporter.py
@@ -6,10 +6,9 @@ from typing import List
 import typer
 from rich.console import Console
 
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.transfer.exceptions import TransferError
-from infrahub_sdk.transfer.exporter.json import LineDelimitedJSONExporter
-
+from ..ctl.client import initialize_client
+from ..transfer.exceptions import TransferError
+from ..transfer.exporter.json import LineDelimitedJSONExporter
 from .parameters import CONFIG_PARAM
 
 

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -3,12 +3,12 @@ from typing import Optional
 
 from rich.console import Console
 
-from infrahub_sdk import InfrahubNode
-from infrahub_sdk.ctl import config
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.repository import get_repository_config
-from infrahub_sdk.ctl.utils import execute_graphql_query, parse_cli_vars
-from infrahub_sdk.schema import InfrahubRepositoryConfig
+from .. import InfrahubNode
+from ..ctl import config
+from ..ctl.client import initialize_client
+from ..ctl.repository import get_repository_config
+from ..ctl.utils import execute_graphql_query, parse_cli_vars
+from ..schema import InfrahubRepositoryConfig
 
 
 async def run(

--- a/infrahub_sdk/ctl/importer.py
+++ b/infrahub_sdk/ctl/importer.py
@@ -4,11 +4,10 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.transfer.exceptions import TransferError
-from infrahub_sdk.transfer.importer.json import LineDelimitedJSONImporter
-from infrahub_sdk.transfer.schema_sorter import InfrahubSchemaTopologicalSorter
-
+from ..ctl.client import initialize_client
+from ..transfer.exceptions import TransferError
+from ..transfer.importer.json import LineDelimitedJSONImporter
+from ..transfer.schema_sorter import InfrahubSchemaTopologicalSorter
 from .parameters import CONFIG_PARAM
 
 

--- a/infrahub_sdk/ctl/menu.py
+++ b/infrahub_sdk/ctl/menu.py
@@ -4,11 +4,10 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.utils import catch_exception, init_logging
-from infrahub_sdk.spec.menu import MenuFile
-
+from ..async_typer import AsyncTyper
+from ..ctl.client import initialize_client
+from ..ctl.utils import catch_exception, init_logging
+from ..spec.menu import MenuFile
 from .parameters import CONFIG_PARAM
 from .utils import load_yamlfile_from_disk_and_exit
 

--- a/infrahub_sdk/ctl/object.py
+++ b/infrahub_sdk/ctl/object.py
@@ -4,11 +4,10 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.utils import catch_exception, init_logging
-from infrahub_sdk.spec.object import ObjectFile
-
+from ..async_typer import AsyncTyper
+from ..ctl.client import initialize_client
+from ..ctl.utils import catch_exception, init_logging
+from ..spec.object import ObjectFile
 from .parameters import CONFIG_PARAM
 from .utils import load_yamlfile_from_disk_and_exit
 

--- a/infrahub_sdk/ctl/parameters.py
+++ b/infrahub_sdk/ctl/parameters.py
@@ -1,6 +1,6 @@
 import typer
 
-from infrahub_sdk.ctl import config
+from ..ctl import config
 
 
 def load_configuration(value: str) -> str:

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -5,13 +5,12 @@ import yaml
 from pydantic import ValidationError
 from rich.console import Console
 
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.exceptions import FileNotValidError
-from infrahub_sdk.ctl.utils import init_logging
-from infrahub_sdk.graphql import Mutation
-from infrahub_sdk.schema import InfrahubRepositoryConfig
-
+from ..async_typer import AsyncTyper
+from ..ctl.client import initialize_client
+from ..ctl.exceptions import FileNotValidError
+from ..ctl.utils import init_logging
+from ..graphql import Mutation
+from ..schema import InfrahubRepositoryConfig
 from .parameters import CONFIG_PARAM
 
 app = AsyncTyper()

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -8,13 +8,12 @@ import yaml
 from pydantic import ValidationError
 from rich.console import Console
 
-from infrahub_sdk import InfrahubClient
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.utils import catch_exception, init_logging
-from infrahub_sdk.queries import SCHEMA_HASH_SYNC_STATUS
-from infrahub_sdk.yaml import SchemaFile
-
+from .. import InfrahubClient
+from ..async_typer import AsyncTyper
+from ..ctl.client import initialize_client
+from ..ctl.utils import catch_exception, init_logging
+from ..queries import SCHEMA_HASH_SYNC_STATUS
+from ..yaml import SchemaFile
 from .parameters import CONFIG_PARAM
 from .utils import load_yamlfile_from_disk_and_exit
 

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -14,8 +14,8 @@ from rich.console import Console
 from rich.logging import RichHandler
 from rich.markup import escape
 
-from infrahub_sdk.ctl.exceptions import FileNotValidError, QueryNotFoundError
-from infrahub_sdk.exceptions import (
+from ..ctl.exceptions import FileNotValidError, QueryNotFoundError
+from ..exceptions import (
     AuthenticationError,
     Error,
     GraphQLError,
@@ -24,9 +24,8 @@ from infrahub_sdk.exceptions import (
     ServerNotReachableError,
     ServerNotResponsiveError,
 )
-from infrahub_sdk.schema import InfrahubRepositoryConfig
-from infrahub_sdk.yaml import YamlFile
-
+from ..schema import InfrahubRepositoryConfig
+from ..yaml import YamlFile
 from .client import initialize_client_sync
 
 YamlFileVar = TypeVar("YamlFileVar", bound=YamlFile)

--- a/infrahub_sdk/ctl/validate.py
+++ b/infrahub_sdk/ctl/validate.py
@@ -9,13 +9,12 @@ from pydantic import ValidationError
 from rich.console import Console
 from ujson import JSONDecodeError
 
-from infrahub_sdk.async_typer import AsyncTyper
-from infrahub_sdk.ctl.client import initialize_client, initialize_client_sync
-from infrahub_sdk.ctl.exceptions import QueryNotFoundError
-from infrahub_sdk.ctl.utils import catch_exception, find_graphql_query, parse_cli_vars
-from infrahub_sdk.exceptions import GraphQLError
-from infrahub_sdk.utils import get_branch, write_to_file
-
+from ..async_typer import AsyncTyper
+from ..ctl.client import initialize_client, initialize_client_sync
+from ..ctl.exceptions import QueryNotFoundError
+from ..ctl.utils import catch_exception, find_graphql_query, parse_cli_vars
+from ..exceptions import GraphQLError
+from ..utils import get_branch, write_to_file
 from .parameters import CONFIG_PARAM
 
 app = AsyncTyper()

--- a/infrahub_sdk/data.py
+++ b/infrahub_sdk/data.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from infrahub_sdk.node import InfrahubNode
+from .node import InfrahubNode
 
 
 class RepositoryBranchInfo(BaseModel):

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Optional
 
 from git.repo import Repo
 
-from infrahub_sdk.exceptions import UninitializedError
+from .exceptions import UninitializedError
 
 if TYPE_CHECKING:
-    from infrahub_sdk.client import InfrahubClient
-    from infrahub_sdk.node import InfrahubNode
-    from infrahub_sdk.store import NodeStore
+    from .client import InfrahubClient
+    from .node import InfrahubNode
+    from .store import NodeStore
 
 
 class InfrahubGenerator:

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -5,23 +5,23 @@ import re
 from copy import copy
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Union, get_args
 
-from infrahub_sdk.constants import InfrahubClientMode
-from infrahub_sdk.exceptions import (
+from .constants import InfrahubClientMode
+from .exceptions import (
     Error,
     FeatureNotSupportedError,
     NodeNotFoundError,
     UninitializedError,
 )
-from infrahub_sdk.graphql import Mutation, Query
-from infrahub_sdk.schema import GenericSchema, RelationshipCardinality, RelationshipKind
-from infrahub_sdk.utils import compare_lists, get_flat_value
-from infrahub_sdk.uuidt import UUIDT
+from .graphql import Mutation, Query
+from .schema import GenericSchema, RelationshipCardinality, RelationshipKind
+from .utils import compare_lists, get_flat_value
+from .uuidt import UUIDT
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
-    from infrahub_sdk.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
+    from .client import InfrahubClient, InfrahubClientSync
+    from .schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
 
 # pylint: disable=too-many-lines
 

--- a/infrahub_sdk/object_store.py
+++ b/infrahub_sdk/object_store.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Optional
 
 import httpx
 
-from infrahub_sdk.exceptions import AuthenticationError, ServerNotReachableError
+from .exceptions import AuthenticationError, ServerNotReachableError
 
 if TYPE_CHECKING:
-    from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
+    from .client import InfrahubClient, InfrahubClientSync
 
 
 class ObjectStoreBase:

--- a/infrahub_sdk/playback.py
+++ b/infrahub_sdk/playback.py
@@ -7,8 +7,8 @@ import ujson
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from infrahub_sdk.types import HTTPMethod
-from infrahub_sdk.utils import generate_request_filename
+from .types import HTTPMethod
+from .utils import generate_request_filename
 
 
 class JSONPlayback(BaseSettings):

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING
 from .protocols_base import CoreNode, CoreNodeSync
 
 if TYPE_CHECKING:
-    from infrahub_sdk.node import RelatedNode, RelatedNodeSync, RelationshipManager, RelationshipManagerSync
-
+    from .node import RelatedNode, RelatedNodeSync, RelationshipManager, RelationshipManagerSync
     from .protocols_base import (
         URL,
         Boolean,

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, runtime_checka
 if TYPE_CHECKING:
     import ipaddress
 
-    from infrahub_sdk.schema import MainSchemaTypes
+    from .schema import MainSchemaTypes
 
 
 @runtime_checkable

--- a/infrahub_sdk/pytest_plugin/items/base.py
+++ b/infrahub_sdk/pytest_plugin/items/base.py
@@ -13,8 +13,7 @@ from ..models import InfrahubInputOutputTest
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from infrahub_sdk.schema import InfrahubRepositoryConfigElement
-
+    from ...schema import InfrahubRepositoryConfigElement
     from ..models import InfrahubTest
 
 

--- a/infrahub_sdk/pytest_plugin/items/check.py
+++ b/infrahub_sdk/pytest_plugin/items/check.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import ujson
 from httpx import HTTPStatusError
 
-from infrahub_sdk.checks import get_check_class_instance
-
+from ...checks import get_check_class_instance
 from ..exceptions import CheckDefinitionError, CheckResultError
 from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
@@ -15,9 +14,9 @@ from .base import InfrahubItem
 if TYPE_CHECKING:
     from pytest import ExceptionInfo
 
-    from infrahub_sdk.checks import InfrahubCheck
-    from infrahub_sdk.pytest_plugin.models import InfrahubTest
-    from infrahub_sdk.schema import InfrahubRepositoryConfigElement
+    from ...checks import InfrahubCheck
+    from ...schema import InfrahubRepositoryConfigElement
+    from ..models import InfrahubTest
 
 
 class InfrahubCheckItem(InfrahubItem):

--- a/infrahub_sdk/pytest_plugin/items/graphql_query.py
+++ b/infrahub_sdk/pytest_plugin/items/graphql_query.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import ujson
 from httpx import HTTPStatusError
 
-from infrahub_sdk.analyzer import GraphQLQueryAnalyzer
-
+from ...analyzer import GraphQLQueryAnalyzer
 from ..exceptions import OutputMatchError
 from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem

--- a/infrahub_sdk/pytest_plugin/items/python_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/python_transform.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import ujson
 from httpx import HTTPStatusError
 
-from infrahub_sdk.transforms import get_transform_class_instance
-
+from ...transforms import get_transform_class_instance
 from ..exceptions import OutputMatchError, PythonTransformDefinitionError
 from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
@@ -15,9 +14,9 @@ from .base import InfrahubItem
 if TYPE_CHECKING:
     from pytest import ExceptionInfo
 
-    from infrahub_sdk.pytest_plugin.models import InfrahubTest
-    from infrahub_sdk.schema import InfrahubRepositoryConfigElement
-    from infrahub_sdk.transforms import InfrahubTransform
+    from ...schema import InfrahubRepositoryConfigElement
+    from ...transforms import InfrahubTransform
+    from ..models import InfrahubTest
 
 
 class InfrahubPythonTransformItem(InfrahubItem):

--- a/infrahub_sdk/pytest_plugin/plugin.py
+++ b/infrahub_sdk/pytest_plugin/plugin.py
@@ -5,9 +5,8 @@ from typing import Optional, Union
 from pytest import Collector, Config, Item, Parser, Session
 from pytest import exit as exit_test
 
-from infrahub_sdk import InfrahubClientSync
-from infrahub_sdk.utils import is_valid_url
-
+from .. import InfrahubClientSync
+from ..utils import is_valid_url
 from .loader import InfrahubYamlFile
 from .utils import load_repository_config
 

--- a/infrahub_sdk/pytest_plugin/utils.py
+++ b/infrahub_sdk/pytest_plugin/utils.py
@@ -2,8 +2,7 @@ from pathlib import Path
 
 import yaml
 
-from infrahub_sdk.schema import InfrahubRepositoryConfig
-
+from ..schema import InfrahubRepositoryConfig
 from .exceptions import FileNotValidError
 
 

--- a/infrahub_sdk/query_groups.py
+++ b/infrahub_sdk/query_groups.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from infrahub_sdk.constants import InfrahubClientMode
-from infrahub_sdk.exceptions import NodeNotFoundError
-from infrahub_sdk.utils import dict_hash
+from .constants import InfrahubClientMode
+from .exceptions import NodeNotFoundError
+from .utils import dict_hash
 
 if TYPE_CHECKING:
-    from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
-    from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync, RelatedNodeBase
-    from infrahub_sdk.schema import MainSchemaTypes
+    from .client import InfrahubClient, InfrahubClientSync
+    from .node import InfrahubNode, InfrahubNodeSync, RelatedNodeBase
+    from .schema import MainSchemaTypes
 
 
 class InfrahubGroupContextBase:

--- a/infrahub_sdk/recorder.py
+++ b/infrahub_sdk/recorder.py
@@ -8,7 +8,7 @@ import httpx
 import ujson
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from infrahub_sdk.utils import generate_request_filename
+from .utils import generate_request_filename
 
 
 class RecorderType(str, enum.Enum):

--- a/infrahub_sdk/schema.py
+++ b/infrahub_sdk/schema.py
@@ -10,15 +10,15 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import TypeAlias
 
-from infrahub_sdk._importer import import_module
-from infrahub_sdk.exceptions import InvalidResponseError, ModuleImportError, SchemaNotFoundError, ValidationError
-from infrahub_sdk.generator import InfrahubGenerator
-from infrahub_sdk.graphql import Mutation
-from infrahub_sdk.utils import duplicates
+from ._importer import import_module
+from .exceptions import InvalidResponseError, ModuleImportError, SchemaNotFoundError, ValidationError
+from .generator import InfrahubGenerator
+from .graphql import Mutation
+from .utils import duplicates
 
 if TYPE_CHECKING:
-    from infrahub_sdk.client import InfrahubClient, InfrahubClientSync, SchemaType, SchemaTypeSync
-    from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
+    from .client import InfrahubClient, InfrahubClientSync, SchemaType, SchemaTypeSync
+    from .node import InfrahubNode, InfrahubNodeSync
 
     InfrahubNodeTypes = Union[InfrahubNode, InfrahubNodeSync]
 

--- a/infrahub_sdk/spec/menu.py
+++ b/infrahub_sdk/spec/menu.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from infrahub_sdk.yaml import InfrahubFile, InfrahubFileKind
-
+from ..yaml import InfrahubFile, InfrahubFileKind
 from .object import InfrahubObjectFileData
 
 

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -2,9 +2,9 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
-from infrahub_sdk.client import InfrahubClient
-from infrahub_sdk.schema import MainSchemaTypes
-from infrahub_sdk.yaml import InfrahubFile, InfrahubFileKind
+from ..client import InfrahubClient
+from ..schema import MainSchemaTypes
+from ..yaml import InfrahubFile, InfrahubFileKind
 
 
 class InfrahubObjectFileData(BaseModel):

--- a/infrahub_sdk/store.py
+++ b/infrahub_sdk/store.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
-from infrahub_sdk.exceptions import NodeNotFoundError
+from .exceptions import NodeNotFoundError
 
 if TYPE_CHECKING:
-    from infrahub_sdk.client import SchemaType
-    from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
+    from .client import SchemaType
+    from .node import InfrahubNode, InfrahubNodeSync
 
 
 def get_schema_name(schema: Optional[Union[str, type[SchemaType]]] = None) -> Optional[str]:

--- a/infrahub_sdk/task_report.py
+++ b/infrahub_sdk/task_report.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING, Any, Final, Optional, Protocol, TypedDict, Uni
 
 from typing_extensions import Self
 
-from infrahub_sdk.uuidt import generate_uuid
+from .uuidt import generate_uuid
 
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from infrahub_sdk.client import InfrahubClient
+    from .client import InfrahubClient
 
 
 class Log(TypedDict):

--- a/infrahub_sdk/transfer/exporter/json.py
+++ b/infrahub_sdk/transfer/exporter/json.py
@@ -6,16 +6,15 @@ import ujson
 from rich.console import Console
 from rich.progress import Progress
 
-from infrahub_sdk.client import InfrahubClient
-from infrahub_sdk.queries import QUERY_RELATIONSHIPS
-from infrahub_sdk.schema import MainSchemaTypes, NodeSchema
-
+from ...client import InfrahubClient
+from ...queries import QUERY_RELATIONSHIPS
+from ...schema import MainSchemaTypes, NodeSchema
 from ..constants import ILLEGAL_NAMESPACES
 from ..exceptions import FileAlreadyExistsError, InvalidNamespaceError
 from .interface import ExporterInterface
 
 if TYPE_CHECKING:
-    from infrahub_sdk.node import InfrahubNode
+    from .node import InfrahubNode
 
 
 class LineDelimitedJSONExporter(ExporterInterface):

--- a/infrahub_sdk/transfer/importer/json.py
+++ b/infrahub_sdk/transfer/importer/json.py
@@ -8,17 +8,16 @@ import ujson
 from rich.console import Console
 from rich.progress import Progress
 
-from infrahub_sdk.batch import InfrahubBatch
-from infrahub_sdk.client import InfrahubClient
-from infrahub_sdk.exceptions import GraphQLError
-from infrahub_sdk.node import InfrahubNode, RelatedNode, RelationshipManager
-from infrahub_sdk.transfer.schema_sorter import InfrahubSchemaTopologicalSorter
-
+from ...batch import InfrahubBatch
+from ...client import InfrahubClient
+from ...exceptions import GraphQLError
+from ...node import InfrahubNode, RelatedNode, RelationshipManager
+from ...transfer.schema_sorter import InfrahubSchemaTopologicalSorter
 from ..exceptions import TransferFileNotFoundError
 from .interface import ImporterInterface
 
 if TYPE_CHECKING:
-    from infrahub_sdk.schema import NodeSchema, RelationshipSchema
+    from .schema import NodeSchema, RelationshipSchema
 
 
 class LineDelimitedJSONImporter(ImporterInterface):

--- a/infrahub_sdk/transfer/schema_sorter.py
+++ b/infrahub_sdk/transfer/schema_sorter.py
@@ -1,7 +1,6 @@
 from typing import Optional, Sequence
 
-from infrahub_sdk.schema import BaseNodeSchema
-
+from ..schema import BaseNodeSchema
 from ..topological_sort import DependencyCycleExistsError, topological_sort
 from .exceptions import SchemaImportError
 

--- a/infrahub_sdk/transforms.py
+++ b/infrahub_sdk/transforms.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from git import Repo
 
-from infrahub_sdk import InfrahubClient
-
+from . import InfrahubClient
 from .exceptions import InfrahubTransformNotFoundError
 
 if TYPE_CHECKING:

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -16,7 +16,7 @@ from graphql import (
     SelectionSetNode,
 )
 
-from infrahub_sdk.exceptions import JsonDecodeError
+from .exceptions import JsonDecodeError
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo

--- a/infrahub_sdk/uuidt.py
+++ b/infrahub_sdk/uuidt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 from uuid import UUID
 
-from infrahub_sdk.utils import base16encode
+from .utils import base16encode
 
 BASE = 16
 DIVISOR = BASE - 1

--- a/infrahub_sdk/yaml.py
+++ b/infrahub_sdk/yaml.py
@@ -6,8 +6,8 @@ import yaml
 from pydantic import BaseModel, Field
 from typing_extensions import Self
 
-from infrahub_sdk.ctl.exceptions import FileNotValidError
-from infrahub_sdk.utils import find_files
+from .ctl.exceptions import FileNotValidError
+from .utils import find_files
 
 
 class InfrahubFileApiVersion(str, Enum):


### PR DESCRIPTION
Related to https://github.com/opsmill/infrahub/issues/4234

In order to use a different package name within Infrahub, we need to convert the internal hardcoded import paths into relative paths.

