### PR TITLE
Limit coverage run to --source=infrahub_sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         if: matrix.python-version == '3.12'
         run: |
           source $(poetry env info --path)/bin/activate
-          coverage run -m pytest tests/unit/pytest_plugin
+          coverage run --source=infrahub_sdk -m pytest tests/unit/pytest_plugin
           coverage report -m
           coverage xml
           codecov --flags python-filler-${{ matrix.python-version }}


### PR DESCRIPTION
This is to avoid having the coverage being reported for the test folder when using `coverage run`.