### PR TITLE
Fix typehints and remove type ignores for ctl.importer & ctl.exporter

### DIFF
--- a/infrahub_sdk/ctl/exporter.py
+++ b/infrahub_sdk/ctl/exporter.py
@@ -13,7 +13,7 @@ from infrahub_sdk.transfer.exporter.json import LineDelimitedJSONExporter
 from .parameters import CONFIG_PARAM
 
 
-def directory_name_with_timestamp():
+def directory_name_with_timestamp() -> str:
     right_now = datetime.now(timezone.utc).astimezone()
     timestamp = right_now.strftime("%Y%m%d-%H%M%S")
     return f"infrahubexport-{timestamp}"
@@ -39,9 +39,10 @@ def dump(
     """Export nodes and their relationships out of the database."""
     console = Console()
 
-    client = aiorun(
-        initialize_client(branch=branch, timeout=timeout, max_concurrent_execution=concurrent, retry_on_failure=True)
+    client = initialize_client(
+        branch=branch, timeout=timeout, max_concurrent_execution=concurrent, retry_on_failure=True
     )
+
     exporter = LineDelimitedJSONExporter(client, console=Console() if not quiet else None)
     try:
         aiorun(exporter.export(export_directory=directory, namespaces=namespace, branch=branch, exclude=exclude))

--- a/infrahub_sdk/ctl/importer.py
+++ b/infrahub_sdk/ctl/importer.py
@@ -12,7 +12,7 @@ from infrahub_sdk.transfer.schema_sorter import InfrahubSchemaTopologicalSorter
 from .parameters import CONFIG_PARAM
 
 
-def local_directory():
+def local_directory() -> Path:
     # We use a function here to avoid failure when generating the documentation due to directory name
     return Path().resolve()
 
@@ -35,9 +35,10 @@ def load(
     """Import nodes and their relationships into the database."""
     console = Console()
 
-    client = aiorun(
-        initialize_client(branch=branch, timeout=timeout, max_concurrent_execution=concurrent, retry_on_failure=True)
+    client = initialize_client(
+        branch=branch, timeout=timeout, max_concurrent_execution=concurrent, retry_on_failure=True
     )
+
     importer = LineDelimitedJSONImporter(
         client,
         InfrahubSchemaTopologicalSorter(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,15 +160,7 @@ module = "infrahub_sdk.ctl.cli_commands"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub_sdk.ctl.exporter"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub_sdk.ctl.generator"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "infrahub_sdk.ctl.importer"
 ignore_errors = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
This change also highlighted an issue as we were still running aiorun to get the client.