### PR TITLE
Change ctl check to not use InfrahubCheck.init()

### DIFF
--- a/changelog/+89d1d0b7.deprecated.md
+++ b/changelog/+89d1d0b7.deprecated.md
@@ -1,0 +1,1 @@
+Marked InfrahubCheck.init() as deprecated and scheduled to be removed in Infrahub SDK 2.0.0

--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import os
+import warnings
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -10,15 +11,17 @@ import ujson
 from git.repo import Repo
 from pydantic import BaseModel, Field
 
-from . import InfrahubClient
 from .exceptions import InfrahubCheckNotFoundError, UninitializedError
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from . import InfrahubClient
     from .schema import InfrahubCheckDefinitionConfig
 
 INFRAHUB_CHECK_VARIABLE_TO_IMPORT = "INFRAHUB_CHECKS"
+
+_client_class = "InfrahubClient"
 
 
 class InfrahubCheckInitializer(BaseModel):
@@ -81,11 +84,17 @@ class InfrahubCheck:
     @classmethod
     async def init(cls, client: Optional[InfrahubClient] = None, *args: Any, **kwargs: Any) -> InfrahubCheck:
         """Async init method, If an existing InfrahubClient client hasn't been provided, one will be created automatically."""
-
-        instance = cls(*args, **kwargs)
-        instance.client = client or InfrahubClient()
-
-        return instance
+        warnings.warn(
+            "InfrahubCheck.init has been deprecated and will be removed in the version in Infrahub SDK 2.0.0",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        if not client:
+            client_module = importlib.import_module("infrahub_sdk.client")
+            client_class = getattr(client_module, _client_class)
+            client = client_class()
+        kwargs["client"] = client
+        return cls(*args, **kwargs)
 
     @property
     def errors(self) -> list[dict[str, Any]]:

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -5,7 +5,7 @@ from asyncio import run as aiorun
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Optional
+from typing import Optional, Type
 
 import typer
 from rich.console import Console
@@ -30,7 +30,7 @@ class CheckModule:
     module: ModuleType
     definition: InfrahubCheckDefinitionConfig
 
-    def get_check(self) -> InfrahubCheck:
+    def get_check(self) -> Type[InfrahubCheck]:
         return getattr(self.module, self.definition.class_name)
 
 
@@ -100,7 +100,7 @@ async def run_check(
     log = logging.getLogger("infrahub")
     passed = True
     check_class = check_module.get_check()
-    check = await check_class.init(client=client, params=params, output=output, root_directory=path, branch=branch)
+    check = check_class(client=client, params=params, output=output, root_directory=path, branch=branch)
     param_log = f" - {params}" if params else ""
     try:
         data = execute_graphql_query(


### PR DESCRIPTION
This work relates to https://github.com/opsmill/infrahub/issues/3932 as a goal to have a consistent way of loading modules that behaves the same way. An issue that might come up is that of circular imports as the check.py is importing InfrahubClient.

We're removing the use of InfrahubCheck.init() from the CTL as it doesn't provide much value and also marking that method as deprecated.