### PR TITLE
List available transforms if no name is provided

### DIFF
--- a/changelog/140.fixed.md
+++ b/changelog/140.fixed.md
@@ -1,0 +1,1 @@
+CTL: List available transforms if no name is provided

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -317,7 +317,7 @@ def transform(
     variables_dict = parse_cli_vars(variables)
     repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
 
-    if list_available:
+    if list_available or not transform_name:
         list_transforms(config=repository_config)
         return
 


### PR DESCRIPTION
Fixes #140

@wvandeun, did you have some other solution in mind? We could also return an error if you used this command without a name and didn't specify "--list".