### PR TITLE
Return a proper error message when executing `schema load` with the wrong credential

### DIFF
--- a/changelog/127.fixed.md
+++ b/changelog/127.fixed.md
@@ -1,0 +1,1 @@
+CTL: `schema load` return a proper error message when authentication is missing or when the user doesn't have the permission to update the schema.

--- a/infrahub_sdk/schema.py
+++ b/infrahub_sdk/schema.py
@@ -539,10 +539,12 @@ class InfrahubSchemaBase:
             status = response.json()
             return SchemaLoadResponse(hash=status["hash"], previous_hash=status["previous_hash"])
 
-        if response.status_code == httpx.codes.BAD_REQUEST:
-            return SchemaLoadResponse(errors=response.json())
-
-        if response.status_code == httpx.codes.UNPROCESSABLE_ENTITY:
+        if response.status_code in [
+            httpx.codes.BAD_REQUEST,
+            httpx.codes.UNPROCESSABLE_ENTITY,
+            httpx.codes.UNAUTHORIZED,
+            httpx.codes.FORBIDDEN,
+        ]:
             return SchemaLoadResponse(errors=response.json())
 
         response.raise_for_status()


### PR DESCRIPTION
Fixes #127 

I also have a PR coming to improve the error codes and the message returned by the backend 