### PR TITLE
Add [project] section to pyproject.toml

### DIFF
--- a/infrahub_sdk/batch.py
+++ b/infrahub_sdk/batch.py
@@ -1,6 +1,7 @@
 import asyncio
+from collections.abc import AsyncGenerator, Awaitable
 from dataclasses import dataclass
-from typing import Any, AsyncGenerator, Awaitable, Callable, Optional
+from typing import Any, Callable, Optional
 
 from .node import InfrahubNode
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
+from collections.abc import Coroutine, MutableMapping
 from functools import wraps
 from time import sleep
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Coroutine,
     Literal,
-    MutableMapping,
     Optional,
     TypedDict,
     TypeVar,

--- a/infrahub_sdk/code_generator.py
+++ b/infrahub_sdk/code_generator.py
@@ -1,4 +1,5 @@
-from typing import Any, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any, Optional
 
 import jinja2
 

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -1,9 +1,10 @@
 import asyncio
 import logging
 import traceback
+from collections.abc import Coroutine
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Coroutine, NoReturn, Optional, TypeVar, Union
+from typing import Any, Callable, NoReturn, Optional, TypeVar, Union
 
 import pendulum
 import typer

--- a/infrahub_sdk/exceptions.py
+++ b/infrahub_sdk/exceptions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any, Optional
 
 
 class Error(Exception):

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import ipaddress
 import re
+from collections.abc import Iterable
 from copy import copy
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, get_args
 
 from .constants import InfrahubClientMode
 from .exceptions import (

--- a/infrahub_sdk/pytest_plugin/loader.py
+++ b/infrahub_sdk/pytest_plugin/loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import pytest
 import yaml

--- a/infrahub_sdk/schema.py
+++ b/infrahub_sdk/schema.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import MutableMapping
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, MutableMapping, Optional, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, TypeVar, Union
 from urllib.parse import urlencode
 
 import httpx

--- a/infrahub_sdk/topological_sort.py
+++ b/infrahub_sdk/topological_sort.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 from itertools import chain
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any
 
 
 class DependencyCycleExistsError(Exception):

--- a/infrahub_sdk/transfer/exporter/json.py
+++ b/infrahub_sdk/transfer/exporter/json.py
@@ -1,6 +1,7 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import ujson
 from rich.console import Console

--- a/infrahub_sdk/transfer/importer/json.py
+++ b/infrahub_sdk/transfer/importer/json.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
+from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional
 
 import pyarrow.json as pa_json
 import ujson

--- a/infrahub_sdk/transfer/schema_sorter.py
+++ b/infrahub_sdk/transfer/schema_sorter.py
@@ -1,4 +1,5 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 from ..schema import BaseNodeSchema
 from ..topological_sort import DependencyCycleExistsError, topological_sort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+name = "infrahub-sdk"
+version = "1.0.1"
+requires-python = ">=3.9"
+
 [tool.poetry]
 name = "infrahub-sdk"
 version = "1.0.1"
@@ -276,8 +281,11 @@ ignore = [
     "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM118",  # Use `key in dict` instead of `key in dict.keys)
     "SIM910",  # Use `data.get(key)` instead of `data.get(key, None)`
+    "TCH003",  # Move standard library import `collections.abc.Iterable` into a type-checking block
+    "UP006",   # Use `dict` instead of `Dict` for type annotation
     "UP007",   # Use X | Y for type annotations
     "UP031",   # Use format specifiers instead of percent format
+    "UP035",   # `typing.Dict` is deprecated, use `dict` instead
 ]
 
 

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -2,8 +2,8 @@
 
 import os
 import re
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 
 @contextmanager

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -1,9 +1,10 @@
 import re
 import sys
+from collections.abc import AsyncGenerator, Mapping
 from dataclasses import dataclass
 from inspect import Parameter
 from io import StringIO
-from typing import AsyncGenerator, Mapping, Optional
+from typing import Optional
 
 import pytest
 import ujson


### PR DESCRIPTION
Sets the required Python version so that ruff can pick this up when linting our code. Also fixed some auto fixable rules based on the changed ruleset (going from the default of Python 3.8 to 3.9).

Added new violations to the ignore section for now.