### PR TITLE
Cleanup and restructure Pydantic models to manage the Schema

### DIFF
--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from . import InfrahubClient
-    from .schema import InfrahubCheckDefinitionConfig
+    from .schema.repository import InfrahubCheckDefinitionConfig
 
 INFRAHUB_CHECK_VARIABLE_TO_IMPORT = "INFRAHUB_CHECKS"
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -50,7 +50,7 @@ from .object_store import ObjectStore, ObjectStoreSync
 from .protocols_base import CoreNode, CoreNodeSync
 from .queries import get_commit_update_mutation
 from .query_groups import InfrahubGroupContext, InfrahubGroupContextSync
-from .schema import InfrahubSchema, InfrahubSchemaSync, NodeSchema
+from .schema import InfrahubSchema, InfrahubSchemaSync, NodeSchemaAPI
 from .store import NodeStore, NodeStoreSync
 from .timestamp import Timestamp
 from .types import AsyncRequester, HTTPMethod, SyncRequester
@@ -448,12 +448,12 @@ class InfrahubClient(BaseClient):
         filters: MutableMapping[str, Any] = {}
 
         if id:
-            if not is_valid_uuid(id) and isinstance(schema, NodeSchema) and schema.default_filter:
+            if not is_valid_uuid(id) and isinstance(schema, NodeSchemaAPI) and schema.default_filter:
                 filters[schema.default_filter] = id
             else:
                 filters["ids"] = [id]
         if hfid:
-            if isinstance(schema, NodeSchema) and schema.human_friendly_id:
+            if isinstance(schema, NodeSchemaAPI) and schema.human_friendly_id:
                 filters["hfid"] = hfid
             else:
                 raise ValueError("Cannot filter by HFID if the node doesn't have an HFID defined")
@@ -1916,12 +1916,12 @@ class InfrahubClientSync(BaseClient):
         filters: MutableMapping[str, Any] = {}
 
         if id:
-            if not is_valid_uuid(id) and isinstance(schema, NodeSchema) and schema.default_filter:
+            if not is_valid_uuid(id) and isinstance(schema, NodeSchemaAPI) and schema.default_filter:
                 filters[schema.default_filter] = id
             else:
                 filters["ids"] = [id]
         if hfid:
-            if isinstance(schema, NodeSchema) and schema.human_friendly_id:
+            if isinstance(schema, NodeSchemaAPI) and schema.human_friendly_id:
                 filters["hfid"] = hfid
             else:
                 raise ValueError("Cannot filter by HFID if the node doesn't have an HFID defined")

--- a/infrahub_sdk/code_generator.py
+++ b/infrahub_sdk/code_generator.py
@@ -1,17 +1,19 @@
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import jinja2
 
 from . import protocols as sdk_protocols
 from .ctl.constants import PROTOCOLS_TEMPLATE
 from .schema import (
-    AttributeSchema,
+    AttributeSchemaAPI,
     GenericSchema,
-    MainSchemaTypes,
+    GenericSchemaAPI,
+    MainSchemaTypesAll,
     NodeSchema,
-    ProfileSchema,
-    RelationshipSchema,
+    NodeSchemaAPI,
+    ProfileSchemaAPI,
+    RelationshipSchemaAPI,
 )
 
 ATTRIBUTE_KIND_MAP = {
@@ -40,17 +42,17 @@ ATTRIBUTE_KIND_MAP = {
 
 
 class CodeGenerator:
-    def __init__(self, schema: dict[str, MainSchemaTypes]):
-        self.generics: dict[str, GenericSchema] = {}
-        self.nodes: dict[str, NodeSchema] = {}
-        self.profiles: dict[str, ProfileSchema] = {}
+    def __init__(self, schema: dict[str, MainSchemaTypesAll]):
+        self.generics: dict[str, Union[GenericSchemaAPI, GenericSchema]] = {}
+        self.nodes: dict[str, Union[NodeSchemaAPI, NodeSchema]] = {}
+        self.profiles: dict[str, ProfileSchemaAPI] = {}
 
         for name, schema_type in schema.items():
-            if isinstance(schema_type, GenericSchema):
+            if isinstance(schema_type, (GenericSchemaAPI, GenericSchema)):
                 self.generics[name] = schema_type
-            if isinstance(schema_type, NodeSchema):
+            if isinstance(schema_type, (NodeSchemaAPI, NodeSchema)):
                 self.nodes[name] = schema_type
-            if isinstance(schema_type, ProfileSchema):
+            if isinstance(schema_type, ProfileSchemaAPI):
                 self.profiles[name] = schema_type
 
         self.base_protocols = [
@@ -92,7 +94,7 @@ class CodeGenerator:
         return ", ".join(inherit_from)
 
     @staticmethod
-    def _jinja2_filter_render_attribute(value: AttributeSchema) -> str:
+    def _jinja2_filter_render_attribute(value: AttributeSchemaAPI) -> str:
         attribute_kind: str = ATTRIBUTE_KIND_MAP[value.kind]
 
         if value.optional:
@@ -101,7 +103,7 @@ class CodeGenerator:
         return f"{value.name}: {attribute_kind}"
 
     @staticmethod
-    def _jinja2_filter_render_relationship(value: RelationshipSchema, sync: bool = False) -> str:
+    def _jinja2_filter_render_relationship(value: RelationshipSchemaAPI, sync: bool = False) -> str:
         name = value.name
         cardinality = value.cardinality
 
@@ -116,12 +118,12 @@ class CodeGenerator:
 
     @staticmethod
     def _sort_and_filter_models(
-        models: Mapping[str, MainSchemaTypes], filters: Optional[list[str]] = None
-    ) -> list[MainSchemaTypes]:
+        models: Mapping[str, MainSchemaTypesAll], filters: Optional[list[str]] = None
+    ) -> list[MainSchemaTypesAll]:
         if filters is None:
             filters = ["CoreNode"]
 
-        filtered: list[MainSchemaTypes] = []
+        filtered: list[MainSchemaTypesAll] = []
         for name, model in models.items():
             if name in filters:
                 continue

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -17,7 +17,7 @@ from ..ctl.exceptions import QueryNotFoundError
 from ..ctl.repository import get_repository_config
 from ..ctl.utils import catch_exception, execute_graphql_query
 from ..exceptions import ModuleImportError
-from ..schema import InfrahubCheckDefinitionConfig, InfrahubRepositoryConfig
+from ..schema.repository import InfrahubCheckDefinitionConfig, InfrahubRepositoryConfig
 
 app = typer.Typer()
 console = Console()

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -38,11 +38,8 @@ from ..ctl.utils import (
 from ..ctl.validate import app as validate_app
 from ..exceptions import GraphQLError, ModuleImportError
 from ..jinja2 import identify_faulty_jinja_code
-from ..schema import (
-    InfrahubRepositoryConfig,
-    MainSchemaTypes,
-    SchemaRoot,
-)
+from ..schema import MainSchemaTypesAll, SchemaRoot
+from ..schema.repository import InfrahubRepositoryConfig
 from ..utils import get_branch, write_to_file
 from ..yaml import SchemaFile
 from .exporter import dump
@@ -364,7 +361,7 @@ def protocols(
 ) -> None:
     """Export Python protocols corresponding to a schema."""
 
-    schema: dict[str, MainSchemaTypes] = {}
+    schema: dict[str, MainSchemaTypesAll] = {}
 
     if schemas:
         schemas_data = load_yamlfile_from_disk_and_exit(paths=schemas, file_type=SchemaFile, console=console)

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -10,7 +10,7 @@ from ..ctl.repository import get_repository_config
 from ..ctl.utils import execute_graphql_query, parse_cli_vars
 from ..exceptions import ModuleImportError
 from ..node import InfrahubNode
-from ..schema import InfrahubRepositoryConfig
+from ..schema.repository import InfrahubRepositoryConfig
 
 
 async def run(

--- a/infrahub_sdk/ctl/render.py
+++ b/infrahub_sdk/ctl/render.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 
-from ..schema import InfrahubRepositoryConfig
+from ..schema.repository import InfrahubRepositoryConfig
 
 
 def list_jinja2_transforms(config: InfrahubRepositoryConfig) -> None:

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -12,7 +12,7 @@ from ..async_typer import AsyncTyper
 from ..ctl.exceptions import FileNotValidError
 from ..ctl.utils import init_logging
 from ..graphql import Mutation
-from ..schema import InfrahubRepositoryConfig
+from ..schema.repository import InfrahubRepositoryConfig
 from ._file import read_file
 from .parameters import CONFIG_PARAM
 

--- a/infrahub_sdk/ctl/transform.py
+++ b/infrahub_sdk/ctl/transform.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 
-from ..schema import InfrahubRepositoryConfig
+from ..schema.repository import InfrahubRepositoryConfig
 
 
 def list_transforms(config: InfrahubRepositoryConfig) -> None:

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -26,7 +26,7 @@ from ..exceptions import (
     ServerNotReachableError,
     ServerNotResponsiveError,
 )
-from ..schema import InfrahubRepositoryConfig
+from ..schema.repository import InfrahubRepositoryConfig
 from ..yaml import YamlFile
 from .client import initialize_client_sync
 

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -14,7 +14,7 @@ from .exceptions import (
     UninitializedError,
 )
 from .graphql import Mutation, Query
-from .schema import GenericSchema, RelationshipCardinality, RelationshipKind
+from .schema import GenericSchemaAPI, RelationshipCardinality, RelationshipKind
 from .utils import compare_lists, get_flat_value
 from .uuidt import UUIDT
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .client import InfrahubClient, InfrahubClientSync
-    from .schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
+    from .schema import AttributeSchemaAPI, MainSchemaTypesAPI, RelationshipSchemaAPI
 
 # pylint: disable=too-many-lines
 
@@ -46,7 +46,7 @@ ARTIFACT_DEFINITION_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE = (
 class Attribute:
     """Represents an attribute of a Node, including its schema, value, and properties."""
 
-    def __init__(self, name: str, schema: AttributeSchema, data: Union[Any, dict]):
+    def __init__(self, name: str, schema: AttributeSchemaAPI, data: Union[Any, dict]):
         """
         Args:
             name (str): The name of the attribute.
@@ -143,7 +143,7 @@ class Attribute:
 class RelatedNodeBase:
     """Base class for representing a related node in a relationship."""
 
-    def __init__(self, branch: str, schema: RelationshipSchema, data: Union[Any, dict], name: Optional[str] = None):
+    def __init__(self, branch: str, schema: RelationshipSchemaAPI, data: Union[Any, dict], name: Optional[str] = None):
         """
         Args:
             branch (str): The branch where the related node resides.
@@ -300,7 +300,7 @@ class RelatedNode(RelatedNodeBase):
         self,
         client: InfrahubClient,
         branch: str,
-        schema: RelationshipSchema,
+        schema: RelationshipSchemaAPI,
         data: Union[Any, dict],
         name: Optional[str] = None,
     ):
@@ -347,7 +347,7 @@ class RelatedNodeSync(RelatedNodeBase):
         self,
         client: InfrahubClientSync,
         branch: str,
-        schema: RelationshipSchema,
+        schema: RelationshipSchemaAPI,
         data: Union[Any, dict],
         name: Optional[str] = None,
     ):
@@ -390,7 +390,7 @@ class RelatedNodeSync(RelatedNodeBase):
 class RelationshipManagerBase:
     """Base class for RelationshipManager and RelationshipManagerSync"""
 
-    def __init__(self, name: str, branch: str, schema: RelationshipSchema):
+    def __init__(self, name: str, branch: str, schema: RelationshipSchemaAPI):
         """
         Args:
             name (str): The name of the relationship.
@@ -473,7 +473,7 @@ class RelationshipManager(RelationshipManagerBase):
         client: InfrahubClient,
         node: InfrahubNode,
         branch: str,
-        schema: RelationshipSchema,
+        schema: RelationshipSchemaAPI,
         data: Union[Any, dict],
     ):
         """
@@ -568,7 +568,7 @@ class RelationshipManagerSync(RelationshipManagerBase):
         client: InfrahubClientSync,
         node: InfrahubNodeSync,
         branch: str,
-        schema: RelationshipSchema,
+        schema: RelationshipSchemaAPI,
         data: Union[Any, dict],
     ):
         """
@@ -657,12 +657,12 @@ class RelationshipManagerSync(RelationshipManagerBase):
 class InfrahubNodeBase:
     """Base class for InfrahubNode and InfrahubNodeSync"""
 
-    def __init__(self, schema: MainSchemaTypes, branch: str, data: Optional[dict] = None) -> None:
+    def __init__(self, schema: MainSchemaTypesAPI, branch: str, data: Optional[dict] = None) -> None:
         """
         Args:
-            schema (MainSchemaTypes): The schema of the node.
-            branch (str): The branch where the node resides.
-            data (Optional[dict]): Optional data to initialize the node.
+            schema: The schema of the node.
+            branch: The branch where the node resides.
+            data: Optional data to initialize the node.
         """
         self._schema = schema
         self._data = data
@@ -1035,16 +1035,16 @@ class InfrahubNode(InfrahubNodeBase):
     def __init__(
         self,
         client: InfrahubClient,
-        schema: MainSchemaTypes,
+        schema: MainSchemaTypesAPI,
         branch: Optional[str] = None,
         data: Optional[dict] = None,
     ) -> None:
         """
         Args:
-            client (InfrahubClient): The client used to interact with the backend.
-            schema (MainSchemaTypes): The schema of the node.
-            branch (Optional[str]): The branch where the node resides.
-            data (Optional[dict]): Optional data to initialize the node.
+            client: The client used to interact with the backend.
+            schema: The schema of the node.
+            branch: The branch where the node resides.
+            data: Optional data to initialize the node.
         """
         self._client = client
         self.__class__ = type(f"{schema.kind}InfrahubNode", (self.__class__,), {})
@@ -1060,7 +1060,7 @@ class InfrahubNode(InfrahubNodeBase):
         client: InfrahubClient,
         branch: str,
         data: dict,
-        schema: Optional[MainSchemaTypes] = None,
+        schema: Optional[MainSchemaTypesAPI] = None,
         timeout: Optional[int] = None,
     ) -> Self:
         if not schema:
@@ -1146,7 +1146,7 @@ class InfrahubNode(InfrahubNodeBase):
         if update_group_context is None and self._client.mode == InfrahubClientMode.TRACKING:
             update_group_context = True
 
-        if not isinstance(self._schema, GenericSchema):
+        if not isinstance(self._schema, GenericSchemaAPI):
             if "CoreGroup" in self._schema.inherit_from:
                 await self._client.group_context.add_related_groups(
                     ids=[self.id], update_group_context=update_group_context
@@ -1183,7 +1183,7 @@ class InfrahubNode(InfrahubNodeBase):
             )
         )
 
-        if isinstance(self._schema, GenericSchema) and fragment:
+        if isinstance(self._schema, GenericSchemaAPI) and fragment:
             for child in self._schema.used_by:
                 child_schema = await self._client.schema.get(kind=child)
                 child_node = InfrahubNode(client=self._client, schema=child_schema)
@@ -1540,7 +1540,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
     def __init__(
         self,
         client: InfrahubClientSync,
-        schema: MainSchemaTypes,
+        schema: MainSchemaTypesAPI,
         branch: Optional[str] = None,
         data: Optional[dict] = None,
     ) -> None:
@@ -1565,7 +1565,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         client: InfrahubClientSync,
         branch: str,
         data: dict,
-        schema: Optional[MainSchemaTypes] = None,
+        schema: Optional[MainSchemaTypesAPI] = None,
         timeout: Optional[int] = None,
     ) -> Self:
         if not schema:
@@ -1648,7 +1648,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         if update_group_context is None and self._client.mode == InfrahubClientMode.TRACKING:
             update_group_context = True
 
-        if not isinstance(self._schema, GenericSchema):
+        if not isinstance(self._schema, GenericSchemaAPI):
             if "CoreGroup" in self._schema.inherit_from:
                 self._client.group_context.add_related_groups(ids=[self.id], update_group_context=update_group_context)
             else:
@@ -1681,7 +1681,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
             )
         )
 
-        if isinstance(self._schema, GenericSchema) and fragment:
+        if isinstance(self._schema, GenericSchemaAPI) and fragment:
             for child in self._schema.used_by:
                 child_schema = self._client.schema.get(kind=child)
                 child_node = InfrahubNodeSync(client=self._client, schema=child_schema)

--- a/infrahub_sdk/pytest_plugin/items/base.py
+++ b/infrahub_sdk/pytest_plugin/items/base.py
@@ -13,7 +13,7 @@ from ..models import InfrahubInputOutputTest
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from ...schema import InfrahubRepositoryConfigElement
+    from ...schema.repository import InfrahubRepositoryConfigElement
     from ..models import InfrahubTest
 
 

--- a/infrahub_sdk/pytest_plugin/items/check.py
+++ b/infrahub_sdk/pytest_plugin/items/check.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from pytest import ExceptionInfo
 
     from ...checks import InfrahubCheck
-    from ...schema import InfrahubRepositoryConfigElement
+    from ...schema.repository import InfrahubRepositoryConfigElement
     from ..models import InfrahubTest
 
 

--- a/infrahub_sdk/pytest_plugin/items/python_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/python_transform.py
@@ -14,7 +14,7 @@ from .base import InfrahubItem
 if TYPE_CHECKING:
     from pytest import ExceptionInfo
 
-    from ...schema import InfrahubRepositoryConfigElement
+    from ...schema.repository import InfrahubRepositoryConfigElement
     from ...transforms import InfrahubTransform
     from ..models import InfrahubTest
 

--- a/infrahub_sdk/pytest_plugin/utils.py
+++ b/infrahub_sdk/pytest_plugin/utils.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import yaml
 
-from ..schema import InfrahubRepositoryConfig
+from ..schema.repository import InfrahubRepositoryConfig
 from .exceptions import FileNotValidError
 
 

--- a/infrahub_sdk/query_groups.py
+++ b/infrahub_sdk/query_groups.py
@@ -9,7 +9,7 @@ from .utils import dict_hash
 if TYPE_CHECKING:
     from .client import InfrahubClient, InfrahubClientSync
     from .node import InfrahubNode, InfrahubNodeSync, RelatedNodeBase
-    from .schema import MainSchemaTypes
+    from .schema import MainSchemaTypesAPI
 
 
 class InfrahubGroupContextBase:
@@ -63,7 +63,7 @@ class InfrahubGroupContextBase:
 
         return group_name
 
-    def _generate_group_description(self, schema: MainSchemaTypes) -> str:
+    def _generate_group_description(self, schema: MainSchemaTypesAPI) -> str:
         """Generate the description of the group from the params
         and ensure it's not longer than the maximum length of the description field."""
         if not self.params:

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -4,35 +4,62 @@ import asyncio
 from collections import defaultdict
 from collections.abc import MutableMapping
 from enum import Enum
-from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union
 from urllib.parse import urlencode
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field
 from typing_extensions import TypeAlias
 
-from ._importer import import_module
-from .checks import InfrahubCheck
-from .exceptions import (
+from ..exceptions import (
     InvalidResponseError,
-    ModuleImportError,
-    ResourceNotDefinedError,
     SchemaNotFoundError,
     ValidationError,
 )
-from .generator import InfrahubGenerator
-from .graphql import Mutation
-from .queries import SCHEMA_HASH_SYNC_STATUS
-from .transforms import InfrahubTransform
-from .utils import duplicates
+from ..graphql import Mutation
+from ..queries import SCHEMA_HASH_SYNC_STATUS
+from .main import (
+    AttributeSchema,
+    AttributeSchemaAPI,
+    GenericSchema,
+    GenericSchemaAPI,
+    NodeSchema,
+    NodeSchemaAPI,
+    ProfileSchemaAPI,
+    RelationshipCardinality,
+    RelationshipKind,
+    RelationshipSchema,
+    RelationshipSchemaAPI,
+    SchemaRoot,
+    SchemaRootAPI,
+)
+from .repository import InfrahubRepositoryConfig
 
 if TYPE_CHECKING:
-    from .client import InfrahubClient, InfrahubClientSync, SchemaType, SchemaTypeSync
-    from .node import InfrahubNode, InfrahubNodeSync
+    from ..client import InfrahubClient, InfrahubClientSync, SchemaType, SchemaTypeSync
+    from ..node import InfrahubNode, InfrahubNodeSync
 
     InfrahubNodeTypes = Union[InfrahubNode, InfrahubNodeSync]
+
+
+__all__ = [
+    "AttributeSchema",
+    "AttributeSchemaAPI",
+    "GenericSchema",
+    "GenericSchemaAPI",
+    "InfrahubRepositoryConfig",
+    "NodeSchema",
+    "NodeSchemaAPI",
+    "ProfileSchemaAPI",
+    "RelationshipCardinality",
+    "RelationshipKind",
+    "RelationshipSchema",
+    "RelationshipSchemaAPI",
+    "SchemaRoot",
+    "SchemaRootAPI",
+]
+
 
 # pylint: disable=redefined-builtin
 
@@ -41,267 +68,6 @@ class DropdownMutationOptionalArgs(TypedDict):
     color: Optional[str]
     description: Optional[str]
     label: Optional[str]
-
-
-ResourceClass = TypeVar("ResourceClass")
-
-# ---------------------------------------------------------------------------------
-# Repository Configuration file
-# ---------------------------------------------------------------------------------
-
-
-class InfrahubRepositoryConfigElement(BaseModel):
-    """Class to regroup all elements of the infrahub configuration for a repository for typing purpose."""
-
-
-class InfrahubRepositoryArtifactDefinitionConfig(InfrahubRepositoryConfigElement):
-    model_config = ConfigDict(extra="forbid")
-    name: str = Field(..., description="The name of the artifact definition")
-    artifact_name: Optional[str] = Field(default=None, description="Name of the artifact created from this definition")
-    parameters: dict[str, Any] = Field(..., description="The input parameters required to render this artifact")
-    content_type: str = Field(..., description="The content type of the rendered artifact")
-    targets: str = Field(..., description="The group to target when creating artifacts")
-    transformation: str = Field(..., description="The transformation to use.")
-
-
-class InfrahubJinja2TransformConfig(InfrahubRepositoryConfigElement):
-    model_config = ConfigDict(extra="forbid")
-    name: str = Field(..., description="The name of the transform")
-    query: str = Field(..., description="The name of the GraphQL Query")
-    template_path: Path = Field(..., description="The path within the repository of the template file")
-    description: Optional[str] = Field(default=None, description="Description for this transform")
-
-    @property
-    def template_path_value(self) -> str:
-        return str(self.template_path)
-
-    @property
-    def payload(self) -> dict[str, str]:
-        data = self.model_dump(exclude_none=True)
-        data["template_path"] = self.template_path_value
-        return data
-
-
-class InfrahubCheckDefinitionConfig(InfrahubRepositoryConfigElement):
-    model_config = ConfigDict(extra="forbid")
-    name: str = Field(..., description="The name of the Check Definition")
-    file_path: Path = Field(..., description="The file within the repository with the check code.")
-    parameters: dict[str, Any] = Field(
-        default_factory=dict, description="The input parameters required to run this check"
-    )
-    targets: Optional[str] = Field(
-        default=None, description="The group to target when running this check, leave blank for global checks"
-    )
-    class_name: str = Field(default="Check", description="The name of the check class to run.")
-
-    def load_class(self, import_root: Optional[str] = None, relative_path: Optional[str] = None) -> type[InfrahubCheck]:
-        module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)
-
-        if self.class_name not in dir(module):
-            raise ModuleImportError(message=f"The specified class {self.class_name} was not found within the module")
-
-        check_class = getattr(module, self.class_name)
-
-        if not issubclass(check_class, InfrahubCheck):
-            raise ModuleImportError(message=f"The specified class {self.class_name} is not an Infrahub Check")
-
-        return check_class
-
-
-class InfrahubGeneratorDefinitionConfig(InfrahubRepositoryConfigElement):
-    model_config = ConfigDict(extra="forbid")
-    name: str = Field(..., description="The name of the Generator Definition")
-    file_path: Path = Field(..., description="The file within the repository with the generator code.")
-    query: str = Field(..., description="The GraphQL query to use as input.")
-    parameters: dict[str, Any] = Field(
-        default_factory=dict, description="The input parameters required to run this check"
-    )
-    targets: str = Field(..., description="The group to target when running this generator")
-    class_name: str = Field(default="Generator", description="The name of the generator class to run.")
-    convert_query_response: bool = Field(
-        default=False,
-        description="Decide if the generator should convert the result of the GraphQL query to SDK InfrahubNode objects.",
-    )
-
-    def load_class(
-        self, import_root: Optional[str] = None, relative_path: Optional[str] = None
-    ) -> type[InfrahubGenerator]:
-        module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)
-
-        if self.class_name not in dir(module):
-            raise ModuleImportError(message=f"The specified class {self.class_name} was not found within the module")
-
-        generator_class = getattr(module, self.class_name)
-
-        if not issubclass(generator_class, InfrahubGenerator):
-            raise ModuleImportError(message=f"The specified class {self.class_name} is not an Infrahub Generator")
-
-        return generator_class
-
-
-class InfrahubPythonTransformConfig(InfrahubRepositoryConfigElement):
-    model_config = ConfigDict(extra="forbid")
-    name: str = Field(..., description="The name of the Transform")
-    file_path: Path = Field(..., description="The file within the repository with the transform code.")
-    class_name: str = Field(default="Transform", description="The name of the transform class to run.")
-
-    def load_class(
-        self, import_root: Optional[str] = None, relative_path: Optional[str] = None
-    ) -> type[InfrahubTransform]:
-        module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)
-
-        if self.class_name not in dir(module):
-            raise ModuleImportError(message=f"The specified class {self.class_name} was not found within the module")
-
-        transform_class = getattr(module, self.class_name)
-
-        if not issubclass(transform_class, InfrahubTransform):
-            raise ModuleImportError(message=f"The specified class {self.class_name} is not an Infrahub Transform")
-
-        return transform_class
-
-
-class InfrahubRepositoryGraphQLConfig(InfrahubRepositoryConfigElement):
-    model_config = ConfigDict(extra="forbid")
-    name: str = Field(..., description="The name of the GraphQL Query")
-    file_path: Path = Field(..., description="The file within the repository with the query code.")
-
-    def load_query(self, relative_path: str = ".") -> str:
-        file_name = Path(f"{relative_path}/{self.file_path}")
-        with file_name.open("r", encoding="UTF-8") as file:
-            return file.read()
-
-
-RESOURCE_MAP: dict[Any, str] = {
-    InfrahubJinja2TransformConfig: "jinja2_transforms",
-    InfrahubCheckDefinitionConfig: "check_definitions",
-    InfrahubRepositoryArtifactDefinitionConfig: "artifact_definitions",
-    InfrahubPythonTransformConfig: "python_transforms",
-    InfrahubGeneratorDefinitionConfig: "generator_definitions",
-    InfrahubRepositoryGraphQLConfig: "queries",
-}
-
-
-class InfrahubRepositoryConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    check_definitions: list[InfrahubCheckDefinitionConfig] = Field(
-        default_factory=list, description="User defined checks"
-    )
-    schemas: list[Path] = Field(default_factory=list, description="Schema files")
-    jinja2_transforms: list[InfrahubJinja2TransformConfig] = Field(
-        default_factory=list, description="Jinja2 data transformations"
-    )
-    artifact_definitions: list[InfrahubRepositoryArtifactDefinitionConfig] = Field(
-        default_factory=list, description="Artifact definitions"
-    )
-    python_transforms: list[InfrahubPythonTransformConfig] = Field(
-        default_factory=list, description="Python data transformations"
-    )
-    generator_definitions: list[InfrahubGeneratorDefinitionConfig] = Field(
-        default_factory=list, description="Generator definitions"
-    )
-    queries: list[InfrahubRepositoryGraphQLConfig] = Field(default_factory=list, description="GraphQL Queries")
-
-    @field_validator(
-        "check_definitions",
-        "jinja2_transforms",
-        "artifact_definitions",
-        "python_transforms",
-        "generator_definitions",
-        "queries",
-    )
-    @classmethod
-    def unique_items(cls, v: list[Any]) -> list[Any]:
-        names = [item.name for item in v]
-        if dups := duplicates(names):
-            raise ValueError(f"Found multiples element with the same names: {dups}")
-        return v
-
-    def _has_resource(self, resource_id: str, resource_type: type[ResourceClass], resource_field: str = "name") -> bool:
-        for item in getattr(self, RESOURCE_MAP[resource_type]):
-            if getattr(item, resource_field) == resource_id:
-                return True
-        return False
-
-    def _get_resource(
-        self, resource_id: str, resource_type: type[ResourceClass], resource_field: str = "name"
-    ) -> ResourceClass:
-        for item in getattr(self, RESOURCE_MAP[resource_type]):
-            if getattr(item, resource_field) == resource_id:
-                return item
-        raise ResourceNotDefinedError(f"Unable to find {resource_id!r} in {RESOURCE_MAP[resource_type]!r}")
-
-    def has_jinja2_transform(self, name: str) -> bool:
-        return self._has_resource(resource_id=name, resource_type=InfrahubJinja2TransformConfig)
-
-    def get_jinja2_transform(self, name: str) -> InfrahubJinja2TransformConfig:
-        return self._get_resource(resource_id=name, resource_type=InfrahubJinja2TransformConfig)
-
-    def has_check_definition(self, name: str) -> bool:
-        return self._has_resource(resource_id=name, resource_type=InfrahubCheckDefinitionConfig)
-
-    def get_check_definition(self, name: str) -> InfrahubCheckDefinitionConfig:
-        return self._get_resource(resource_id=name, resource_type=InfrahubCheckDefinitionConfig)
-
-    def has_artifact_definition(self, name: str) -> bool:
-        return self._has_resource(resource_id=name, resource_type=InfrahubRepositoryArtifactDefinitionConfig)
-
-    def get_artifact_definition(self, name: str) -> InfrahubRepositoryArtifactDefinitionConfig:
-        return self._get_resource(resource_id=name, resource_type=InfrahubRepositoryArtifactDefinitionConfig)
-
-    def has_generator_definition(self, name: str) -> bool:
-        return self._has_resource(resource_id=name, resource_type=InfrahubGeneratorDefinitionConfig)
-
-    def get_generator_definition(self, name: str) -> InfrahubGeneratorDefinitionConfig:
-        return self._get_resource(resource_id=name, resource_type=InfrahubGeneratorDefinitionConfig)
-
-    def has_python_transform(self, name: str) -> bool:
-        return self._has_resource(resource_id=name, resource_type=InfrahubPythonTransformConfig)
-
-    def get_python_transform(self, name: str) -> InfrahubPythonTransformConfig:
-        return self._get_resource(resource_id=name, resource_type=InfrahubPythonTransformConfig)
-
-    def has_query(self, name: str) -> bool:
-        return self._has_resource(resource_id=name, resource_type=InfrahubRepositoryGraphQLConfig)
-
-    def get_query(self, name: str) -> InfrahubRepositoryGraphQLConfig:
-        return self._get_resource(resource_id=name, resource_type=InfrahubRepositoryGraphQLConfig)
-
-
-# ---------------------------------------------------------------------------------
-# Main Infrahub Schema File
-# ---------------------------------------------------------------------------------
-class FilterSchema(BaseModel):
-    name: str
-    kind: str
-    description: Optional[str] = None
-
-
-class RelationshipCardinality(str, Enum):
-    ONE = "one"
-    MANY = "many"
-
-
-class RelationshipDirection(str, Enum):
-    BIDIR = "bidirectional"
-    OUTBOUND = "outbound"
-    INBOUND = "inbound"
-
-
-class BranchSupportType(str, Enum):
-    AWARE = "aware"
-    AGNOSTIC = "agnostic"
-    LOCAL = "local"
-
-
-class RelationshipKind(str, Enum):
-    GENERIC = "Generic"
-    ATTRIBUTE = "Attribute"
-    COMPONENT = "Component"
-    PARENT = "Parent"
-    GROUP = "Group"
-    HIERARCHY = "Hierarchy"
-    PROFILE = "Profile"
 
 
 class DropdownMutation(str, Enum):
@@ -314,205 +80,16 @@ class EnumMutation(str, Enum):
     remove = "SchemaEnumRemove"
 
 
-class SchemaState(str, Enum):
-    PRESENT = "present"
-    ABSENT = "absent"
-
-
-class AttributeSchema(BaseModel):
-    id: Optional[str] = None
-    state: SchemaState = SchemaState.PRESENT
-    name: str
-    kind: str
-    label: Optional[str] = None
-    description: Optional[str] = None
-    default_value: Optional[Any] = None
-    inherited: bool = False
-    unique: bool = False
-    branch: Optional[BranchSupportType] = None
-    optional: bool = False
-    read_only: bool = False
-    choices: Optional[list[dict[str, Any]]] = None
-    enum: Optional[list[Union[str, int]]] = None
-    max_length: Optional[int] = None
-    min_length: Optional[int] = None
-    regex: Optional[str] = None
-    order_weight: Optional[int] = None
-
-
-class RelationshipSchema(BaseModel):
-    id: Optional[str] = None
-    state: SchemaState = SchemaState.PRESENT
-    name: str
-    peer: str
-    direction: RelationshipDirection = RelationshipDirection.BIDIR
-    kind: RelationshipKind = RelationshipKind.GENERIC
-    label: Optional[str] = None
-    description: Optional[str] = None
-    identifier: Optional[str] = None
-    inherited: bool = False
-    cardinality: str = "many"
-    branch: Optional[BranchSupportType] = None
-    optional: bool = True
-    read_only: bool = False
-    filters: list[FilterSchema] = Field(default_factory=list)
-    order_weight: Optional[int] = None
-
-
-class BaseNodeSchema(BaseModel):
-    id: Optional[str] = None
-    state: SchemaState = SchemaState.PRESENT
-    name: str
-    label: Optional[str] = None
-    namespace: str
-    description: Optional[str] = None
-    attributes: list[AttributeSchema] = Field(default_factory=list)
-    relationships: list[RelationshipSchema] = Field(default_factory=list)
-    filters: list[FilterSchema] = Field(default_factory=list)
-
-    @property
-    def kind(self) -> str:
-        return self.namespace + self.name
-
-    def get_field(self, name: str, raise_on_error: bool = True) -> Union[AttributeSchema, RelationshipSchema, None]:
-        if attribute_field := self.get_attribute_or_none(name=name):
-            return attribute_field
-
-        if relationship_field := self.get_relationship_or_none(name=name):
-            return relationship_field
-
-        if not raise_on_error:
-            return None
-
-        raise ValueError(f"Unable to find the field {name}")
-
-    def get_attribute(self, name: str) -> AttributeSchema:
-        for item in self.attributes:
-            if item.name == name:
-                return item
-        raise ValueError(f"Unable to find the attribute {name}")
-
-    def get_attribute_or_none(self, name: str) -> Optional[AttributeSchema]:
-        for item in self.attributes:
-            if item.name == name:
-                return item
-        return None
-
-    def get_relationship(self, name: str) -> RelationshipSchema:
-        for item in self.relationships:
-            if item.name == name:
-                return item
-        raise ValueError(f"Unable to find the relationship {name}")
-
-    def get_relationship_or_none(self, name: str) -> Optional[RelationshipSchema]:
-        for item in self.relationships:
-            if item.name == name:
-                return item
-        return None
-
-    def get_relationship_by_identifier(self, id: str, raise_on_error: bool = True) -> Union[RelationshipSchema, None]:
-        for item in self.relationships:
-            if item.identifier == id:
-                return item
-
-        if not raise_on_error:
-            return None
-
-        raise ValueError(f"Unable to find the relationship {id}")
-
-    def get_matching_relationship(
-        self, id: str, direction: RelationshipDirection = RelationshipDirection.BIDIR
-    ) -> RelationshipSchema:
-        valid_direction = RelationshipDirection.BIDIR
-        if direction == RelationshipDirection.INBOUND:
-            valid_direction = RelationshipDirection.OUTBOUND
-        elif direction == RelationshipDirection.OUTBOUND:
-            valid_direction = RelationshipDirection.INBOUND
-
-        for item in self.relationships:
-            if item.identifier == id and item.direction == valid_direction:
-                return item
-
-        raise ValueError(f"Unable to find the relationship {id} / ({valid_direction.value})")
-
-    @property
-    def attribute_names(self) -> list[str]:
-        return [item.name for item in self.attributes]
-
-    @property
-    def relationship_names(self) -> list[str]:
-        return [item.name for item in self.relationships]
-
-    @property
-    def mandatory_input_names(self) -> list[str]:
-        return self.mandatory_attribute_names + self.mandatory_relationship_names
-
-    @property
-    def mandatory_attribute_names(self) -> list[str]:
-        return [item.name for item in self.attributes if not item.optional and item.default_value is None]
-
-    @property
-    def mandatory_relationship_names(self) -> list[str]:
-        return [item.name for item in self.relationships if not item.optional]
-
-    @property
-    def local_attributes(self) -> list[AttributeSchema]:
-        return [item for item in self.attributes if not item.inherited]
-
-    @property
-    def local_relationships(self) -> list[RelationshipSchema]:
-        return [item for item in self.relationships if not item.inherited]
-
-    @property
-    def unique_attributes(self) -> list[AttributeSchema]:
-        return [item for item in self.attributes if item.unique]
-
-
-class GenericSchema(BaseNodeSchema):
-    """A Generic can be either an Interface or a Union depending if there are some Attributes or Relationships defined."""
-
-    used_by: list[str] = Field(default_factory=list)
-
-
-class NodeSchema(BaseNodeSchema):
-    inherit_from: list[str] = Field(default_factory=list)
-    branch: Optional[BranchSupportType] = None
-    default_filter: Optional[str] = None
-    human_friendly_id: Optional[list[str]] = None
-
-
-class ProfileSchema(BaseNodeSchema):
-    inherit_from: list[str] = Field(default_factory=list)
-
-
-class NodeExtensionSchema(BaseModel):
-    name: Optional[str] = None
-    kind: str
-    description: Optional[str] = None
-    label: Optional[str] = None
-    inherit_from: list[str] = Field(default_factory=list)
-    branch: Optional[BranchSupportType] = None
-    default_filter: Optional[str] = None
-    attributes: list[AttributeSchema] = Field(default_factory=list)
-    relationships: list[RelationshipSchema] = Field(default_factory=list)
-
-
-class SchemaRoot(BaseModel):
-    version: str
-    generics: list[GenericSchema] = Field(default_factory=list)
-    nodes: list[NodeSchema] = Field(default_factory=list)
-    profiles: list[ProfileSchema] = Field(default_factory=list)
-    # node_extensions: list[NodeExtensionSchema] = Field(default_factory=list)
-
-
-MainSchemaTypes: TypeAlias = Union[NodeSchema, GenericSchema, ProfileSchema]
+MainSchemaTypes: TypeAlias = Union[NodeSchema, GenericSchema]
+MainSchemaTypesAPI: TypeAlias = Union[NodeSchemaAPI, GenericSchemaAPI, ProfileSchemaAPI]
+MainSchemaTypesAll: TypeAlias = Union[NodeSchema, GenericSchema, NodeSchemaAPI, GenericSchemaAPI, ProfileSchemaAPI]
 
 
 class InfrahubSchemaBase:
     def validate(self, data: dict[str, Any]) -> None:
         SchemaRoot(**data)
 
-    def validate_data_against_schema(self, schema: MainSchemaTypes, data: dict) -> None:
+    def validate_data_against_schema(self, schema: MainSchemaTypesAPI, data: dict) -> None:
         for key in data.keys():
             if key not in schema.relationship_names + schema.attribute_names:
                 identifier = f"{schema.kind}"
@@ -523,7 +100,7 @@ class InfrahubSchemaBase:
 
     def generate_payload_create(
         self,
-        schema: MainSchemaTypes,
+        schema: MainSchemaTypesAPI,
         data: dict,
         source: Optional[str] = None,
         owner: Optional[str] = None,
@@ -599,7 +176,7 @@ class InfrahubSchema(InfrahubSchemaBase):
         branch: Optional[str] = None,
         refresh: bool = False,
         timeout: Optional[int] = None,
-    ) -> MainSchemaTypes:
+    ) -> MainSchemaTypesAPI:
         branch = branch or self.client.default_branch
 
         kind_str = self._get_schema_name(schema=kind)
@@ -622,7 +199,7 @@ class InfrahubSchema(InfrahubSchemaBase):
 
     async def all(
         self, branch: Optional[str] = None, refresh: bool = False, namespaces: Optional[list[str]] = None
-    ) -> MutableMapping[str, MainSchemaTypes]:
+    ) -> MutableMapping[str, MainSchemaTypesAPI]:
         """Retrieve the entire schema for a given branch.
 
         if present in cache, the schema will be served from the cache, unless refresh is set to True
@@ -809,7 +386,7 @@ class InfrahubSchema(InfrahubSchemaBase):
 
     async def fetch(
         self, branch: str, namespaces: Optional[list[str]] = None, timeout: Optional[int] = None
-    ) -> MutableMapping[str, MainSchemaTypes]:
+    ) -> MutableMapping[str, MainSchemaTypesAPI]:
         """Fetch the schema from the server for a given branch.
 
         Args:
@@ -830,17 +407,17 @@ class InfrahubSchema(InfrahubSchemaBase):
 
         data: MutableMapping[str, Any] = response.json()
 
-        nodes: MutableMapping[str, MainSchemaTypes] = {}
+        nodes: MutableMapping[str, MainSchemaTypesAPI] = {}
         for node_schema in data.get("nodes", []):
-            node = NodeSchema(**node_schema)
+            node = NodeSchemaAPI(**node_schema)
             nodes[node.kind] = node
 
         for generic_schema in data.get("generics", []):
-            generic = GenericSchema(**generic_schema)
+            generic = GenericSchemaAPI(**generic_schema)
             nodes[generic.kind] = generic
 
         for profile_schema in data.get("profiles", []):
-            profile = ProfileSchema(**profile_schema)
+            profile = ProfileSchemaAPI(**profile_schema)
             nodes[profile.kind] = profile
 
         return nodes
@@ -853,7 +430,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
 
     def all(
         self, branch: Optional[str] = None, refresh: bool = False, namespaces: Optional[list[str]] = None
-    ) -> MutableMapping[str, MainSchemaTypes]:
+    ) -> MutableMapping[str, MainSchemaTypesAPI]:
         """Retrieve the entire schema for a given branch.
 
         if present in cache, the schema will be served from the cache, unless refresh is set to True
@@ -878,7 +455,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
         branch: Optional[str] = None,
         refresh: bool = False,
         timeout: Optional[int] = None,
-    ) -> MainSchemaTypes:
+    ) -> MainSchemaTypesAPI:
         branch = branch or self.client.default_branch
 
         kind_str = self._get_schema_name(schema=kind)
@@ -901,7 +478,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
 
     def _get_kind_and_attribute_schema(
         self, kind: Union[str, InfrahubNodeTypes], attribute: str, branch: Optional[str] = None
-    ) -> tuple[str, AttributeSchema]:
+    ) -> tuple[str, AttributeSchemaAPI]:
         node_kind: str = kind._schema.kind if not isinstance(kind, str) else kind
         node_schema = self.client.schema.get(kind=node_kind, branch=branch)
         schema_attr = node_schema.get_attribute(name=attribute)
@@ -1013,7 +590,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
 
     def fetch(
         self, branch: str, namespaces: Optional[list[str]] = None, timeout: Optional[int] = None
-    ) -> MutableMapping[str, MainSchemaTypes]:
+    ) -> MutableMapping[str, MainSchemaTypesAPI]:
         """Fetch the schema from the server for a given branch.
 
         Args:
@@ -1034,17 +611,17 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
 
         data: MutableMapping[str, Any] = response.json()
 
-        nodes: MutableMapping[str, MainSchemaTypes] = {}
+        nodes: MutableMapping[str, MainSchemaTypesAPI] = {}
         for node_schema in data.get("nodes", []):
-            node = NodeSchema(**node_schema)
+            node = NodeSchemaAPI(**node_schema)
             nodes[node.kind] = node
 
         for generic_schema in data.get("generics", []):
-            generic = GenericSchema(**generic_schema)
+            generic = GenericSchemaAPI(**generic_schema)
             nodes[generic.kind] = generic
 
         for profile_schema in data.get("profiles", []):
-            profile = ProfileSchema(**profile_schema)
+            profile = ProfileSchemaAPI(**profile_schema)
             nodes[profile.kind] = profile
 
         return nodes

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -22,6 +22,7 @@ from ..queries import SCHEMA_HASH_SYNC_STATUS
 from .main import (
     AttributeSchema,
     AttributeSchemaAPI,
+    BranchSupportType,
     GenericSchema,
     GenericSchemaAPI,
     NodeSchema,
@@ -34,7 +35,6 @@ from .main import (
     SchemaRoot,
     SchemaRootAPI,
 )
-from .repository import InfrahubRepositoryConfig
 
 if TYPE_CHECKING:
     from ..client import InfrahubClient, InfrahubClientSync, SchemaType, SchemaTypeSync
@@ -46,9 +46,9 @@ if TYPE_CHECKING:
 __all__ = [
     "AttributeSchema",
     "AttributeSchemaAPI",
+    "BranchSupportType",
     "GenericSchema",
     "GenericSchemaAPI",
-    "InfrahubRepositoryConfig",
     "NodeSchema",
     "NodeSchemaAPI",
     "ProfileSchemaAPI",

--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -41,6 +42,7 @@ class RelationshipDirection(str, Enum):
 class AttributeKind(str, Enum):
     ID = "ID"
     TEXT = "Text"
+    STRING = "String"  # deprecated
     TEXTAREA = "TextArea"
     DATETIME = "DateTime"
     NUMBER = "Number"
@@ -60,6 +62,15 @@ class AttributeKind(str, Enum):
     LIST = "List"
     JSON = "JSON"
     ANY = "Any"
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "STRING":
+            warnings.warn(
+                f"{name} is deprecated and will be removed in future versions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().__getattribute__(name)
 
 
 class SchemaState(str, Enum):
@@ -252,7 +263,8 @@ class BaseSchema(BaseModel):
 
 
 class GenericSchema(BaseSchema, BaseSchemaAttrRel):
-    pass
+    def convert_api(self) -> GenericSchemaAPI:
+        return GenericSchemaAPI(**self.model_dump())
 
 
 class GenericSchemaAPI(BaseSchema, BaseSchemaAttrRelAPI):
@@ -273,7 +285,8 @@ class BaseNodeSchema(BaseSchema):
 
 
 class NodeSchema(BaseNodeSchema, BaseSchemaAttrRel):
-    pass
+    def convert_api(self) -> NodeSchemaAPI:
+        return NodeSchemaAPI(**self.model_dump())
 
 
 class NodeSchemaAPI(BaseNodeSchema, BaseSchemaAttrRelAPI):

--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from ..node import InfrahubNode, InfrahubNodeSync
+
+    InfrahubNodeTypes = Union[InfrahubNode, InfrahubNodeSync]
+
+
+class RelationshipCardinality(str, Enum):
+    ONE = "one"
+    MANY = "many"
+
+
+class BranchSupportType(str, Enum):
+    AWARE = "aware"
+    AGNOSTIC = "agnostic"
+    LOCAL = "local"
+
+
+class RelationshipKind(str, Enum):
+    GENERIC = "Generic"
+    ATTRIBUTE = "Attribute"
+    COMPONENT = "Component"
+    PARENT = "Parent"
+    GROUP = "Group"
+    HIERARCHY = "Hierarchy"
+    PROFILE = "Profile"
+
+
+class RelationshipDirection(str, Enum):
+    BIDIR = "bidirectional"
+    OUTBOUND = "outbound"
+    INBOUND = "inbound"
+
+
+class AttributeKind(str, Enum):
+    ID = "ID"
+    TEXT = "Text"
+    TEXTAREA = "TextArea"
+    DATETIME = "DateTime"
+    NUMBER = "Number"
+    DROPDOWN = "Dropdown"
+    EMAIL = "Email"
+    PASSWORD = "Password"  # noqa: S105
+    HASHEDPASSWORD = "HashedPassword"
+    URL = "URL"
+    FILE = "File"
+    MAC_ADDRESS = "MacAddress"
+    COLOR = "Color"
+    BANDWIDTH = "Bandwidth"
+    IPHOST = "IPHost"
+    IPNETWORK = "IPNetwork"
+    BOOLEAN = "Boolean"
+    CHECKBOX = "Checkbox"
+    LIST = "List"
+    JSON = "JSON"
+    ANY = "Any"
+
+
+class SchemaState(str, Enum):
+    PRESENT = "present"
+    ABSENT = "absent"
+
+
+class AllowOverrideType(str, Enum):
+    NONE = "none"
+    ANY = "any"
+
+
+class RelationshipDeleteBehavior(str, Enum):
+    NO_ACTION = "no-action"
+    CASCADE = "cascade"
+
+
+class AttributeSchema(BaseModel):
+    id: Optional[str] = None
+    state: SchemaState = SchemaState.PRESENT
+    name: str
+    kind: AttributeKind
+    label: Optional[str] = None
+    description: Optional[str] = None
+    default_value: Optional[Any] = None
+    unique: bool = False
+    branch: Optional[BranchSupportType] = None
+    optional: bool = False
+    choices: Optional[list[dict[str, Any]]] = None
+    enum: Optional[list[Union[str, int]]] = None
+    max_length: Optional[int] = None
+    min_length: Optional[int] = None
+    regex: Optional[str] = None
+    order_weight: Optional[int] = None
+
+
+class AttributeSchemaAPI(AttributeSchema):
+    inherited: bool = False
+    read_only: bool = False
+    allow_override: AllowOverrideType = AllowOverrideType.ANY
+
+
+class RelationshipSchema(BaseModel):
+    id: Optional[str] = None
+    state: SchemaState = SchemaState.PRESENT
+    name: str
+    peer: str
+    kind: RelationshipKind = RelationshipKind.GENERIC
+    label: Optional[str] = None
+    description: Optional[str] = None
+    identifier: Optional[str] = None
+    min_count: Optional[int] = None
+    max_count: Optional[int] = None
+    direction: RelationshipDirection = RelationshipDirection.BIDIR
+    on_delete: Optional[RelationshipDeleteBehavior] = None
+    cardinality: str = "many"
+    branch: Optional[BranchSupportType] = None
+    optional: bool = True
+    order_weight: Optional[int] = None
+
+
+class RelationshipSchemaAPI(RelationshipSchema):
+    inherited: bool = False
+    read_only: bool = False
+    hierarchical: Optional[str] = None
+    allow_override: AllowOverrideType = AllowOverrideType.ANY
+
+
+class BaseSchemaAttrRel(BaseModel):
+    attributes: list[AttributeSchema] = Field(default_factory=list)
+    relationships: list[RelationshipSchema] = Field(default_factory=list)
+
+
+class BaseSchemaAttrRelAPI(BaseModel):
+    attributes: list[AttributeSchemaAPI] = Field(default_factory=list)
+    relationships: list[RelationshipSchemaAPI] = Field(default_factory=list)
+
+    def get_field(
+        self, name: str, raise_on_error: bool = True
+    ) -> Union[AttributeSchemaAPI, RelationshipSchemaAPI, None]:
+        if attribute_field := self.get_attribute_or_none(name=name):
+            return attribute_field
+
+        if relationship_field := self.get_relationship_or_none(name=name):
+            return relationship_field
+
+        if not raise_on_error:
+            return None
+
+        raise ValueError(f"Unable to find the field {name}")
+
+    def get_attribute(self, name: str) -> AttributeSchemaAPI:
+        for item in self.attributes:
+            if item.name == name:
+                return item
+        raise ValueError(f"Unable to find the attribute {name}")
+
+    def get_attribute_or_none(self, name: str) -> Optional[AttributeSchemaAPI]:
+        for item in self.attributes:
+            if item.name == name:
+                return item
+        return None
+
+    def get_relationship(self, name: str) -> RelationshipSchemaAPI:
+        for item in self.relationships:
+            if item.name == name:
+                return item
+        raise ValueError(f"Unable to find the relationship {name}")
+
+    def get_relationship_or_none(self, name: str) -> Optional[RelationshipSchemaAPI]:
+        for item in self.relationships:
+            if item.name == name:
+                return item
+        return None
+
+    def get_relationship_by_identifier(
+        self, id: str, raise_on_error: bool = True
+    ) -> Union[RelationshipSchemaAPI, None]:
+        for item in self.relationships:
+            if item.identifier == id:
+                return item
+
+        if not raise_on_error:
+            return None
+
+        raise ValueError(f"Unable to find the relationship {id}")
+
+    def get_matching_relationship(
+        self, id: str, direction: RelationshipDirection = RelationshipDirection.BIDIR
+    ) -> RelationshipSchemaAPI:
+        valid_direction = RelationshipDirection.BIDIR
+        if direction == RelationshipDirection.INBOUND:
+            valid_direction = RelationshipDirection.OUTBOUND
+        elif direction == RelationshipDirection.OUTBOUND:
+            valid_direction = RelationshipDirection.INBOUND
+        for item in self.relationships:
+            if item.identifier == id and item.direction == valid_direction:
+                return item
+        raise ValueError(f"Unable to find the relationship {id} / ({valid_direction.value})")
+
+    @property
+    def attribute_names(self) -> list[str]:
+        return [item.name for item in self.attributes]
+
+    @property
+    def relationship_names(self) -> list[str]:
+        return [item.name for item in self.relationships]
+
+    @property
+    def mandatory_input_names(self) -> list[str]:
+        return self.mandatory_attribute_names + self.mandatory_relationship_names
+
+    @property
+    def mandatory_attribute_names(self) -> list[str]:
+        return [item.name for item in self.attributes if not item.optional and item.default_value is None]
+
+    @property
+    def mandatory_relationship_names(self) -> list[str]:
+        return [item.name for item in self.relationships if not item.optional]
+
+    @property
+    def local_attributes(self) -> list[AttributeSchemaAPI]:
+        return [item for item in self.attributes if not item.inherited]
+
+    @property
+    def local_relationships(self) -> list[RelationshipSchemaAPI]:
+        return [item for item in self.relationships if not item.inherited]
+
+    @property
+    def unique_attributes(self) -> list[AttributeSchemaAPI]:
+        return [item for item in self.attributes if item.unique]
+
+
+class BaseSchema(BaseModel):
+    id: Optional[str] = None
+    state: SchemaState = SchemaState.PRESENT
+    name: str
+    label: Optional[str] = None
+    namespace: str
+    description: Optional[str] = None
+    include_in_menu: Optional[bool] = None
+    menu_placement: Optional[str] = None
+    icon: Optional[str] = None
+    uniqueness_constraints: Optional[list[list[str]]] = None
+    documentation: Optional[str] = None
+
+    @property
+    def kind(self) -> str:
+        return self.namespace + self.name
+
+
+class GenericSchema(BaseSchema, BaseSchemaAttrRel):
+    pass
+
+
+class GenericSchemaAPI(BaseSchema, BaseSchemaAttrRelAPI):
+    """A Generic can be either an Interface or a Union depending if there are some Attributes or Relationships defined."""
+
+    hash: Optional[str] = None
+    used_by: list[str] = Field(default_factory=list)
+
+
+class BaseNodeSchema(BaseSchema):
+    inherit_from: list[str] = Field(default_factory=list)
+    branch: Optional[BranchSupportType] = None
+    default_filter: Optional[str] = None
+    human_friendly_id: Optional[list[str]] = None
+    generate_profile: Optional[bool] = None
+    parent: Optional[str] = None
+    children: Optional[str] = None
+
+
+class NodeSchema(BaseNodeSchema, BaseSchemaAttrRel):
+    pass
+
+
+class NodeSchemaAPI(BaseNodeSchema, BaseSchemaAttrRelAPI):
+    hash: Optional[str] = None
+    hierarchy: Optional[str] = None
+
+
+class ProfileSchemaAPI(BaseSchema, BaseSchemaAttrRelAPI):
+    inherit_from: list[str] = Field(default_factory=list)
+
+
+class NodeExtensionSchema(BaseModel):
+    name: Optional[str] = None
+    kind: str
+    description: Optional[str] = None
+    label: Optional[str] = None
+    inherit_from: list[str] = Field(default_factory=list)
+    branch: Optional[BranchSupportType] = None
+    default_filter: Optional[str] = None
+    attributes: list[AttributeSchema] = Field(default_factory=list)
+    relationships: list[RelationshipSchema] = Field(default_factory=list)
+
+
+class SchemaRoot(BaseModel):
+    version: str
+    generics: list[GenericSchema] = Field(default_factory=list)
+    nodes: list[NodeSchema] = Field(default_factory=list)
+    node_extensions: list[NodeExtensionSchema] = Field(default_factory=list)
+
+
+class SchemaRootAPI(BaseModel):
+    version: str
+    generics: list[GenericSchemaAPI] = Field(default_factory=list)
+    nodes: list[NodeSchemaAPI] = Field(default_factory=list)
+    profiles: list[ProfileSchemaAPI] = Field(default_factory=list)

--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .._importer import import_module
+from ..checks import InfrahubCheck
+from ..exceptions import (
+    ModuleImportError,
+    ResourceNotDefinedError,
+)
+from ..generator import InfrahubGenerator
+from ..transforms import InfrahubTransform
+from ..utils import duplicates
+
+if TYPE_CHECKING:
+    from ..node import InfrahubNode, InfrahubNodeSync
+
+    InfrahubNodeTypes = Union[InfrahubNode, InfrahubNodeSync]
+
+ResourceClass = TypeVar("ResourceClass")
+
+
+class InfrahubRepositoryConfigElement(BaseModel):
+    """Class to regroup all elements of the infrahub configuration for a repository for typing purpose."""
+
+
+class InfrahubRepositoryArtifactDefinitionConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="The name of the artifact definition")
+    artifact_name: Optional[str] = Field(default=None, description="Name of the artifact created from this definition")
+    parameters: dict[str, Any] = Field(..., description="The input parameters required to render this artifact")
+    content_type: str = Field(..., description="The content type of the rendered artifact")
+    targets: str = Field(..., description="The group to target when creating artifacts")
+    transformation: str = Field(..., description="The transformation to use.")
+
+
+class InfrahubJinja2TransformConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="The name of the transform")
+    query: str = Field(..., description="The name of the GraphQL Query")
+    template_path: Path = Field(..., description="The path within the repository of the template file")
+    description: Optional[str] = Field(default=None, description="Description for this transform")
+
+    @property
+    def template_path_value(self) -> str:
+        return str(self.template_path)
+
+    @property
+    def payload(self) -> dict[str, str]:
+        data = self.model_dump(exclude_none=True)
+        data["template_path"] = self.template_path_value
+        return data
+
+
+class InfrahubCheckDefinitionConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="The name of the Check Definition")
+    file_path: Path = Field(..., description="The file within the repository with the check code.")
+    parameters: dict[str, Any] = Field(
+        default_factory=dict, description="The input parameters required to run this check"
+    )
+    targets: Optional[str] = Field(
+        default=None, description="The group to target when running this check, leave blank for global checks"
+    )
+    class_name: str = Field(default="Check", description="The name of the check class to run.")
+
+    def load_class(self, import_root: Optional[str] = None, relative_path: Optional[str] = None) -> type[InfrahubCheck]:
+        module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)
+
+        if self.class_name not in dir(module):
+            raise ModuleImportError(message=f"The specified class {self.class_name} was not found within the module")
+
+        check_class = getattr(module, self.class_name)
+
+        if not issubclass(check_class, InfrahubCheck):
+            raise ModuleImportError(message=f"The specified class {self.class_name} is not an Infrahub Check")
+
+        return check_class
+
+
+class InfrahubGeneratorDefinitionConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="The name of the Generator Definition")
+    file_path: Path = Field(..., description="The file within the repository with the generator code.")
+    query: str = Field(..., description="The GraphQL query to use as input.")
+    parameters: dict[str, Any] = Field(
+        default_factory=dict, description="The input parameters required to run this check"
+    )
+    targets: str = Field(..., description="The group to target when running this generator")
+    class_name: str = Field(default="Generator", description="The name of the generator class to run.")
+    convert_query_response: bool = Field(
+        default=False,
+        description="Decide if the generator should convert the result of the GraphQL query to SDK InfrahubNode objects.",
+    )
+
+    def load_class(
+        self, import_root: Optional[str] = None, relative_path: Optional[str] = None
+    ) -> type[InfrahubGenerator]:
+        module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)
+
+        if self.class_name not in dir(module):
+            raise ModuleImportError(message=f"The specified class {self.class_name} was not found within the module")
+
+        generator_class = getattr(module, self.class_name)
+
+        if not issubclass(generator_class, InfrahubGenerator):
+            raise ModuleImportError(message=f"The specified class {self.class_name} is not an Infrahub Generator")
+
+        return generator_class
+
+
+class InfrahubPythonTransformConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="The name of the Transform")
+    file_path: Path = Field(..., description="The file within the repository with the transform code.")
+    class_name: str = Field(default="Transform", description="The name of the transform class to run.")
+
+    def load_class(
+        self, import_root: Optional[str] = None, relative_path: Optional[str] = None
+    ) -> type[InfrahubTransform]:
+        module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)
+
+        if self.class_name not in dir(module):
+            raise ModuleImportError(message=f"The specified class {self.class_name} was not found within the module")
+
+        transform_class = getattr(module, self.class_name)
+
+        if not issubclass(transform_class, InfrahubTransform):
+            raise ModuleImportError(message=f"The specified class {self.class_name} is not an Infrahub Transform")
+
+        return transform_class
+
+
+class InfrahubRepositoryGraphQLConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="The name of the GraphQL Query")
+    file_path: Path = Field(..., description="The file within the repository with the query code.")
+
+    def load_query(self, relative_path: str = ".") -> str:
+        file_name = Path(f"{relative_path}/{self.file_path}")
+        with file_name.open("r", encoding="UTF-8") as file:
+            return file.read()
+
+
+RESOURCE_MAP: dict[Any, str] = {
+    InfrahubJinja2TransformConfig: "jinja2_transforms",
+    InfrahubCheckDefinitionConfig: "check_definitions",
+    InfrahubRepositoryArtifactDefinitionConfig: "artifact_definitions",
+    InfrahubPythonTransformConfig: "python_transforms",
+    InfrahubGeneratorDefinitionConfig: "generator_definitions",
+    InfrahubRepositoryGraphQLConfig: "queries",
+}
+
+
+class InfrahubRepositoryConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    check_definitions: list[InfrahubCheckDefinitionConfig] = Field(
+        default_factory=list, description="User defined checks"
+    )
+    schemas: list[Path] = Field(default_factory=list, description="Schema files")
+    jinja2_transforms: list[InfrahubJinja2TransformConfig] = Field(
+        default_factory=list, description="Jinja2 data transformations"
+    )
+    artifact_definitions: list[InfrahubRepositoryArtifactDefinitionConfig] = Field(
+        default_factory=list, description="Artifact definitions"
+    )
+    python_transforms: list[InfrahubPythonTransformConfig] = Field(
+        default_factory=list, description="Python data transformations"
+    )
+    generator_definitions: list[InfrahubGeneratorDefinitionConfig] = Field(
+        default_factory=list, description="Generator definitions"
+    )
+    queries: list[InfrahubRepositoryGraphQLConfig] = Field(default_factory=list, description="GraphQL Queries")
+
+    @field_validator(
+        "check_definitions",
+        "jinja2_transforms",
+        "artifact_definitions",
+        "python_transforms",
+        "generator_definitions",
+        "queries",
+    )
+    @classmethod
+    def unique_items(cls, v: list[Any]) -> list[Any]:
+        names = [item.name for item in v]
+        if dups := duplicates(names):
+            raise ValueError(f"Found multiples element with the same names: {dups}")
+        return v
+
+    def _has_resource(self, resource_id: str, resource_type: type[ResourceClass], resource_field: str = "name") -> bool:
+        for item in getattr(self, RESOURCE_MAP[resource_type]):
+            if getattr(item, resource_field) == resource_id:
+                return True
+        return False
+
+    def _get_resource(
+        self, resource_id: str, resource_type: type[ResourceClass], resource_field: str = "name"
+    ) -> ResourceClass:
+        for item in getattr(self, RESOURCE_MAP[resource_type]):
+            if getattr(item, resource_field) == resource_id:
+                return item
+        raise ResourceNotDefinedError(f"Unable to find {resource_id!r} in {RESOURCE_MAP[resource_type]!r}")
+
+    def has_jinja2_transform(self, name: str) -> bool:
+        return self._has_resource(resource_id=name, resource_type=InfrahubJinja2TransformConfig)
+
+    def get_jinja2_transform(self, name: str) -> InfrahubJinja2TransformConfig:
+        return self._get_resource(resource_id=name, resource_type=InfrahubJinja2TransformConfig)
+
+    def has_check_definition(self, name: str) -> bool:
+        return self._has_resource(resource_id=name, resource_type=InfrahubCheckDefinitionConfig)
+
+    def get_check_definition(self, name: str) -> InfrahubCheckDefinitionConfig:
+        return self._get_resource(resource_id=name, resource_type=InfrahubCheckDefinitionConfig)
+
+    def has_artifact_definition(self, name: str) -> bool:
+        return self._has_resource(resource_id=name, resource_type=InfrahubRepositoryArtifactDefinitionConfig)
+
+    def get_artifact_definition(self, name: str) -> InfrahubRepositoryArtifactDefinitionConfig:
+        return self._get_resource(resource_id=name, resource_type=InfrahubRepositoryArtifactDefinitionConfig)
+
+    def has_generator_definition(self, name: str) -> bool:
+        return self._has_resource(resource_id=name, resource_type=InfrahubGeneratorDefinitionConfig)
+
+    def get_generator_definition(self, name: str) -> InfrahubGeneratorDefinitionConfig:
+        return self._get_resource(resource_id=name, resource_type=InfrahubGeneratorDefinitionConfig)
+
+    def has_python_transform(self, name: str) -> bool:
+        return self._has_resource(resource_id=name, resource_type=InfrahubPythonTransformConfig)
+
+    def get_python_transform(self, name: str) -> InfrahubPythonTransformConfig:
+        return self._get_resource(resource_id=name, resource_type=InfrahubPythonTransformConfig)
+
+    def has_query(self, name: str) -> bool:
+        return self._has_resource(resource_id=name, resource_type=InfrahubRepositoryGraphQLConfig)
+
+    def get_query(self, name: str) -> InfrahubRepositoryGraphQLConfig:
+        return self._get_resource(resource_id=name, resource_type=InfrahubRepositoryGraphQLConfig)

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from pydantic import BaseModel, Field
 
 from ..client import InfrahubClient
-from ..schema import MainSchemaTypes
+from ..schema import MainSchemaTypesAPI
 from ..yaml import InfrahubFile, InfrahubFileKind
 
 
@@ -19,7 +19,7 @@ class InfrahubObjectFileData(BaseModel):
     async def create_node(
         cls,
         client: InfrahubClient,
-        schema: MainSchemaTypes,
+        schema: MainSchemaTypesAPI,
         data: dict,
         context: Optional[dict] = None,
         branch: Optional[str] = None,

--- a/infrahub_sdk/transfer/exporter/json.py
+++ b/infrahub_sdk/transfer/exporter/json.py
@@ -9,13 +9,13 @@ from rich.progress import Progress
 
 from ...client import InfrahubClient
 from ...queries import QUERY_RELATIONSHIPS
-from ...schema import MainSchemaTypes, NodeSchema
+from ...schema import MainSchemaTypesAPI, NodeSchema
 from ..constants import ILLEGAL_NAMESPACES
 from ..exceptions import FileAlreadyExistsError, InvalidNamespaceError
 from .interface import ExporterInterface
 
 if TYPE_CHECKING:
-    from .node import InfrahubNode
+    from ...node import InfrahubNode
 
 
 class LineDelimitedJSONExporter(ExporterInterface):
@@ -32,7 +32,7 @@ class LineDelimitedJSONExporter(ExporterInterface):
             self.console.print(f"{end}")
 
     def identify_many_to_many_relationships(
-        self, node_schema_map: dict[str, MainSchemaTypes]
+        self, node_schema_map: dict[str, MainSchemaTypesAPI]
     ) -> dict[tuple[str, str], str]:
         # Identify many to many relationships by src/dst couples
         many_relationship_identifiers: dict[tuple[str, str], str] = {}
@@ -60,7 +60,7 @@ class LineDelimitedJSONExporter(ExporterInterface):
         return many_relationship_identifiers
 
     async def retrieve_many_to_many_relationships(
-        self, node_schema_map: dict[str, MainSchemaTypes], branch: str
+        self, node_schema_map: dict[str, MainSchemaTypesAPI], branch: str
     ) -> list[dict[str, Any]]:
         has_remaining_items = True
         page_number = 1

--- a/infrahub_sdk/transfer/exporter/json.py
+++ b/infrahub_sdk/transfer/exporter/json.py
@@ -9,7 +9,7 @@ from rich.progress import Progress
 
 from ...client import InfrahubClient
 from ...queries import QUERY_RELATIONSHIPS
-from ...schema import MainSchemaTypesAPI, NodeSchema
+from ...schema import MainSchemaTypesAPI, NodeSchemaAPI
 from ..constants import ILLEGAL_NAMESPACES
 from ..exceptions import FileAlreadyExistsError, InvalidNamespaceError
 from .interface import ExporterInterface
@@ -113,7 +113,7 @@ class LineDelimitedJSONExporter(ExporterInterface):
             node_schema_map = {
                 kind: schema
                 for kind, schema in node_schema_map.items()
-                if isinstance(schema, NodeSchema)
+                if isinstance(schema, NodeSchemaAPI)
                 and schema.namespace not in illegal_namespaces
                 and (not exclude or kind not in exclude)
             }

--- a/infrahub_sdk/transfer/schema_sorter.py
+++ b/infrahub_sdk/transfer/schema_sorter.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import Optional
 
-from ..schema import BaseNodeSchema
+from ..schema import NodeSchema
 from ..topological_sort import DependencyCycleExistsError, topological_sort
 from .exceptions import SchemaImportError
 
@@ -9,7 +9,7 @@ from .exceptions import SchemaImportError
 class InfrahubSchemaTopologicalSorter:
     def get_sorted_node_schema(
         self,
-        schemas: Sequence[BaseNodeSchema],
+        schemas: Sequence[NodeSchema],
         required_relationships_only: bool = True,
         include: Optional[list[str]] = None,
     ) -> list[set[str]]:

--- a/infrahub_sdk/transforms.py
+++ b/infrahub_sdk/transforms.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from . import InfrahubClient
-    from .schema import InfrahubPythonTransformConfig
+    from .schema.repository import InfrahubPythonTransformConfig
 
 INFRAHUB_TRANSFORM_VARIABLE_TO_IMPORT = "INFRAHUB_TRANSFORMS"
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -3,7 +3,7 @@ from infrahub.core.schema import core_models
 from infrahub.server import app
 
 from infrahub_sdk import Config, InfrahubClient
-from infrahub_sdk.schema import NodeSchema
+from infrahub_sdk.schema import NodeSchemaAPI
 
 from .conftest import InfrahubTestClient
 
@@ -28,14 +28,14 @@ class TestInfrahubSchema:
 
         assert len(schema_nodes) == len(nodes) + len(generics) + len(profiles)
         assert "BuiltinTag" in schema_nodes
-        assert isinstance(schema_nodes["BuiltinTag"], NodeSchema)
+        assert isinstance(schema_nodes["BuiltinTag"], NodeSchemaAPI)
 
     async def test_schema_get(self, client, init_db_base):
         config = Config(username="admin", password="infrahub", requester=client.async_request)
         ifc = InfrahubClient(config=config)
         schema_node = await ifc.schema.get(kind="BuiltinTag")
 
-        assert isinstance(schema_node, NodeSchema)
+        assert isinstance(schema_node, NodeSchemaAPI)
         assert ifc.default_branch in ifc.schema.cache
         nodes = [node for node in core_models["nodes"] if node["namespace"] != "Internal"]
         generics = [node for node in core_models["generics"] if node["namespace"] != "Internal"]

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -11,7 +11,7 @@ import ujson
 from pytest_httpx import HTTPXMock
 
 from infrahub_sdk import Config, InfrahubClient, InfrahubClientSync
-from infrahub_sdk.schema import BranchSupportType, NodeSchema
+from infrahub_sdk.schema import BranchSupportType, NodeSchema, NodeSchemaAPI
 from infrahub_sdk.utils import get_fixtures_dir
 
 # pylint: disable=redefined-outer-name,unused-argument
@@ -125,7 +125,7 @@ def replace_sync_parameter_annotations(replace_sync_return_annotation):
 
 
 @pytest.fixture
-async def location_schema() -> NodeSchema:
+async def location_schema() -> NodeSchemaAPI:
     data = {
         "name": "Location",
         "namespace": "Builtin",
@@ -157,11 +157,11 @@ async def location_schema() -> NodeSchema:
             },
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
-async def schema_with_hfid() -> dict[str, NodeSchema]:
+async def schema_with_hfid() -> dict[str, NodeSchemaAPI]:
     data = {
         "location": {
             "name": "Location",
@@ -222,11 +222,11 @@ async def schema_with_hfid() -> dict[str, NodeSchema]:
             ],
         },
     }
-    return {k: NodeSchema(**v) for k, v in data.items()}  # type: ignore
+    return {k: NodeSchema(**v).convert_api() for k, v in data.items()}  # type: ignore
 
 
 @pytest.fixture
-async def std_group_schema() -> NodeSchema:
+async def std_group_schema() -> NodeSchemaAPI:
     data = {
         "name": "StandardGroup",
         "namespace": "Core",
@@ -236,7 +236,7 @@ async def std_group_schema() -> NodeSchema:
             {"name": "description", "kind": "String", "optional": True},
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
@@ -506,17 +506,17 @@ async def location_data02():
 
 
 @pytest.fixture
-async def tag_schema() -> NodeSchema:
+async def tag_schema() -> NodeSchemaAPI:
     data = {
         "name": "Tag",
         "namespace": "Builtin",
         "default_filter": "name__value",
         "attributes": [
-            {"name": "name", "kind": "String", "unique": True},
-            {"name": "description", "kind": "String", "optional": True},
+            {"name": "name", "kind": "Text", "unique": True},
+            {"name": "description", "kind": "Text", "optional": True},
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
@@ -694,7 +694,7 @@ async def tag_green_data():
 
 
 @pytest.fixture
-async def rfile_schema() -> NodeSchema:
+async def rfile_schema() -> NodeSchemaAPI:
     data = {
         "name": "TransformJinja2",
         "namespace": "Core",
@@ -730,11 +730,11 @@ async def rfile_schema() -> NodeSchema:
             },
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
-async def ipaddress_schema() -> NodeSchema:
+async def ipaddress_schema() -> NodeSchemaAPI:
     data = {
         "name": "IPAddress",
         "namespace": "Infra",
@@ -754,11 +754,11 @@ async def ipaddress_schema() -> NodeSchema:
             }
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
-async def ipnetwork_schema() -> NodeSchema:
+async def ipnetwork_schema() -> NodeSchemaAPI:
     data = {
         "name": "IPNetwork",
         "namespace": "Infra",
@@ -778,11 +778,11 @@ async def ipnetwork_schema() -> NodeSchema:
             }
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
-async def ipam_ipprefix_schema() -> NodeSchema:
+async def ipam_ipprefix_schema() -> NodeSchemaAPI:
     data = {
         "name": "IPNetwork",
         "namespace": "Ipam",
@@ -791,11 +791,11 @@ async def ipam_ipprefix_schema() -> NodeSchema:
         "order_by": ["prefix_value"],
         "inherit_from": ["BuiltinIPAddress"],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
-async def simple_device_schema() -> NodeSchema:
+async def simple_device_schema() -> NodeSchemaAPI:
     data = {
         "name": "Device",
         "namespace": "Infra",
@@ -823,7 +823,7 @@ async def simple_device_schema() -> NodeSchema:
             },
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
@@ -897,7 +897,7 @@ async def ipam_ipprefix_data():
 
 
 @pytest.fixture
-async def ipaddress_pool_schema() -> NodeSchema:
+async def ipaddress_pool_schema() -> NodeSchemaAPI:
     data = {
         "name": "IPAddressPool",
         "namespace": "Core",
@@ -943,11 +943,11 @@ async def ipaddress_pool_schema() -> NodeSchema:
             },
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
-async def ipprefix_pool_schema() -> NodeSchema:
+async def ipprefix_pool_schema() -> NodeSchemaAPI:
     data = {
         "name": "IPPrefixPool",
         "namespace": "Core",
@@ -1002,11 +1002,11 @@ async def ipprefix_pool_schema() -> NodeSchema:
             },
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
-async def address_schema() -> NodeSchema:
+async def address_schema() -> NodeSchemaAPI:
     data = {
         "name": "Address",
         "namespace": "Infra",
@@ -1021,7 +1021,7 @@ async def address_schema() -> NodeSchema:
         ],
         "relationships": [],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchemaAPI(**data)
 
 
 @pytest.fixture
@@ -1065,7 +1065,7 @@ async def address_data():
 
 
 @pytest.fixture
-async def device_schema() -> NodeSchema:
+async def device_schema() -> NodeSchemaAPI:
     data = {
         "name": "Device",
         "namespace": "Infra",
@@ -1111,7 +1111,7 @@ async def device_schema() -> NodeSchema:
             {"name": "artifacts", "peer": "CoreArtifact", "optional": True, "cardinality": "many", "kind": "Generic"},
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture
@@ -1272,7 +1272,7 @@ async def device_data():
 
 
 @pytest.fixture
-async def artifact_definition_schema() -> NodeSchema:
+async def artifact_definition_schema() -> NodeSchemaAPI:
     data = {
         "name": "ArtifactDefinition",
         "namespace": "Core",
@@ -1285,7 +1285,7 @@ async def artifact_definition_schema() -> NodeSchema:
             {"name": "artifact_name", "kind": "Text"},
         ],
     }
-    return NodeSchema(**data)  # type: ignore
+    return NodeSchema(**data).convert_api()  # type: ignore
 
 
 @pytest.fixture

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -14,10 +14,10 @@ from infrahub_sdk.node import (
     RelatedNodeBase,
     RelationshipManagerBase,
 )
+from infrahub_sdk.schema import GenericSchema, NodeSchemaAPI
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
-    from infrahub_sdk.schema import GenericSchema
 
 # pylint: disable=no-member,too-many-lines
 # type: ignore[attr-defined]
@@ -133,7 +133,7 @@ async def test_node_hfid(client, schema_with_hfid, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_init_node_data_user(client, location_schema, client_type):
+async def test_init_node_data_user(client, location_schema: NodeSchemaAPI, client_type):
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -151,7 +151,7 @@ async def test_init_node_data_user(client, location_schema, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_init_node_data_user_with_relationships(client, location_schema, client_type):
+async def test_init_node_data_user_with_relationships(client, location_schema: NodeSchemaAPI, client_type):
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -177,7 +177,7 @@ async def test_init_node_data_user_with_relationships(client, location_schema, c
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_init_node_data_graphql(client, location_schema, location_data01, client_type):
+async def test_init_node_data_graphql(client, location_schema: NodeSchemaAPI, location_data01, client_type):
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
     else:
@@ -197,7 +197,7 @@ async def test_init_node_data_graphql(client, location_schema, location_data01, 
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_no_filters(clients, location_schema, client_type):
+async def test_query_data_no_filters(clients, location_schema: NodeSchemaAPI, client_type):
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         node = InfrahubNode(client=client, schema=location_schema)
@@ -297,7 +297,7 @@ async def test_query_data_no_filters(clients, location_schema, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_node(clients, location_schema, client_type):
+async def test_query_data_node(clients, location_schema: NodeSchemaAPI, client_type):
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         node = InfrahubNode(client=client, schema=location_schema)
@@ -748,7 +748,7 @@ async def test_query_data_generic_fragment(clients, mock_schema_query_02, client
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_include(client, location_schema, client_type):
+async def test_query_data_include(client, location_schema: NodeSchemaAPI, client_type):
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(include=["tags"])
@@ -870,7 +870,7 @@ async def test_query_data_include(client, location_schema, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_exclude(client, location_schema, client_type):
+async def test_query_data_exclude(client, location_schema: NodeSchemaAPI, client_type):
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(exclude=["description", "primary_tag"])
@@ -929,7 +929,7 @@ async def test_query_data_exclude(client, location_schema, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data(client, location_schema, client_type):
+async def test_create_input_data(client, location_schema: NodeSchemaAPI, client_type):
     data = {"name": {"value": "JFK1"}, "description": {"value": "JFK Airport"}, "type": {"value": "SITE"}}
 
     if client_type == "standard":

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -10,14 +10,16 @@ from infrahub_sdk import Config, InfrahubClient, InfrahubClientSync
 from infrahub_sdk.ctl.schema import display_schema_load_errors
 from infrahub_sdk.exceptions import SchemaNotFoundError, ValidationError
 from infrahub_sdk.schema import (
+    InfrahubSchema,
+    InfrahubSchemaSync,
+    NodeSchemaAPI,
+)
+from infrahub_sdk.schema.repository import (
     InfrahubCheckDefinitionConfig,
     InfrahubJinja2TransformConfig,
     InfrahubPythonTransformConfig,
     InfrahubRepositoryArtifactDefinitionConfig,
     InfrahubRepositoryConfig,
-    InfrahubSchema,
-    InfrahubSchemaSync,
-    NodeSchema,
 )
 from tests.unit.sdk.conftest import BothClients
 
@@ -59,7 +61,7 @@ async def test_fetch_schema(mock_schema_query_01, client_type):  # pylint: disab
         "CoreGraphQLQuery",
         "CoreRepository",
     ]
-    assert isinstance(nodes["BuiltinTag"], NodeSchema)
+    assert isinstance(nodes["BuiltinTag"], NodeSchemaAPI)
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
This PR is a first step toward cleaning up and restructuring the Pydantic models to manage the schema in the SDK

The main changes is the separation of models for what a user can provide and what we are getting from the SDK
Currently most fields are shared but overtime the goal is to generate the models automatically to have the proper type defined (Optional or not).

In the process, I've split the file schema.py into multiple files to separate the models we are using for the repository config from the models for the main schema.
