### PR TITLE
bugfix: Process nodes in generators CTL when no variables are passed in

### DIFF
--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -64,7 +64,6 @@ async def run(
             infrahub_node=InfrahubNode,
         )
         await generator._init_client.schema.all(branch=generator.branch_name)
-        await generator.process_nodes(data=data)
         await generator.run(identifier=generator_config.name, data=data)
 
     else:
@@ -101,7 +100,6 @@ async def run(
                 repository_config=repository_config,
             )
             await generator._init_client.schema.all(branch=generator.branch_name)
-            await generator.process_nodes(data=data)
             await generator.run(identifier=generator_config.name, data=data)
 
 

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -101,6 +101,7 @@ async def run(
                 repository_config=repository_config,
             )
             await generator._init_client.schema.all(branch=generator.branch_name)
+            await generator.process_nodes(data=data)
             await generator.run(identifier=generator_config.name, data=data)
 
 

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -97,9 +97,7 @@ class InfrahubGenerator:
             update_group=True,
             subscribers=self.subscribers,
         )
-        unpacked = data.get("data") or data
-        await self.process_nodes(data=unpacked)
-        return data
+        return data.get("data") or data
 
     async def run(self, identifier: str, data: Optional[dict] = None) -> None:
         """Execute the generator after collecting the data from the GraphQL query."""
@@ -107,6 +105,7 @@ class InfrahubGenerator:
         if not data:
             data = await self.collect_data()
         unpacked = data.get("data") or data
+        await self.process_nodes(data=unpacked)
 
         async with self._init_client.start_tracking(
             identifier=identifier, params=self.params, delete_unused_nodes=True, group_type="CoreGeneratorGroup"


### PR DESCRIPTION
Add processing of nodes when no variables are passed into CLI so the nodes get added into the store.

This added `generator.process_nodes` call that the `generator.collect_data` method typically handles, but since we're collecting data outside, `.process_nodes` was never called within `infrahubctl`.