### PR TITLE
Fix issue with menu load due to missing direction

### DIFF
--- a/changelog/+3bf1c5c.fixed.md
+++ b/changelog/+3bf1c5c.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue with with `infrahubctl menu load` that would fail while loading the menu

--- a/infrahub_sdk/schema.py
+++ b/infrahub_sdk/schema.py
@@ -282,6 +282,12 @@ class RelationshipCardinality(str, Enum):
     MANY = "many"
 
 
+class RelationshipDirection(str, Enum):
+    BIDIR = "bidirectional"
+    OUTBOUND = "outbound"
+    INBOUND = "inbound"
+
+
 class BranchSupportType(str, Enum):
     AWARE = "aware"
     AGNOSTIC = "agnostic"
@@ -339,6 +345,7 @@ class RelationshipSchema(BaseModel):
     state: SchemaState = SchemaState.PRESENT
     name: str
     peer: str
+    direction: RelationshipDirection = RelationshipDirection.BIDIR
     kind: RelationshipKind = RelationshipKind.GENERIC
     label: Optional[str] = None
     description: Optional[str] = None
@@ -412,6 +419,21 @@ class BaseNodeSchema(BaseModel):
             return None
 
         raise ValueError(f"Unable to find the relationship {id}")
+
+    def get_matching_relationship(
+        self, id: str, direction: RelationshipDirection = RelationshipDirection.BIDIR
+    ) -> RelationshipSchema:
+        valid_direction = RelationshipDirection.BIDIR
+        if direction == RelationshipDirection.INBOUND:
+            valid_direction = RelationshipDirection.OUTBOUND
+        elif direction == RelationshipDirection.OUTBOUND:
+            valid_direction = RelationshipDirection.INBOUND
+
+        for item in self.relationships:
+            if item.identifier == id and item.direction == valid_direction:
+                return item
+
+        raise ValueError(f"Unable to find the relationship {id} / ({valid_direction.value})")
 
     @property
     def attribute_names(self) -> list[str]:

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -78,7 +78,7 @@ class InfrahubObjectFileData(BaseModel):
             if rel_schema.identifier is None:
                 raise ValueError("identifier must be defined")
 
-            peer_rel = peer_schema.get_relationship_by_identifier(id=rel_schema.identifier)
+            peer_rel = peer_schema.get_matching_relationship(id=rel_schema.identifier, direction=rel_schema.direction)
 
             rel_data = data[rel]["data"]
             context = {}


### PR DESCRIPTION
This PR fixes an issue with `infrahubctl menu load` that would fail with the following error
```
25h[11:27:12] INFO     Node: Organization__MainMenu                    object.py:67
Error: Unexpected format for children found a <class 'str'>, 
18129073-738c-dc82-3348-c5193c8b5d82
Traceback (most recent call last):
```
The issue was related to the relationships `parent` & `children`  on `CoreMenu` having the same `identifier`, when we are trying to create nested objects we are searching for the matching relationship on the other node and in some cases the search would return the wrong relationship.
