### PR TITLE
Fix import_root in case a Path object was submitted

### DIFF
--- a/changelog/+513f19bc.fixed.md
+++ b/changelog/+513f19bc.fixed.md
@@ -1,0 +1,1 @@
+Convert import_root to a string if it was submitted as a Path object to ensure that anything added to sys.path is a string

--- a/infrahub_sdk/_importer.py
+++ b/infrahub_sdk/_importer.py
@@ -22,6 +22,10 @@ def import_module(
     if import_root and relative_path:
         file_on_disk = Path(import_root, relative_path, module_path.name)
 
+    # This is a temporary workaround for to account for issues if "import_root" is a Path instead of a str
+    # Later we should rework this so that import_root and relative_path are all Path objects. Here we must
+    # ensure that anything we add to sys.path is a string and not a Path or PosixPath object.
+    import_root = str(import_root)
     if import_root not in sys.path:
         sys.path.append(import_root)
 


### PR DESCRIPTION
This PR fixes an issue that can occur if a Path object is passed to the importer instead of an `str`, mypy failed to see these issues.

To illustrate the problem that might occur we can create a local file:

```python
❯ cat /tmp/test_module.py
print("successfully imported")
```

Then in a separate location we run:

```python
import sys
from pathlib import Path

import importlib

path = Path("/tmp")

sys.path.append(path)

importlib.import_module("test_module")
```

It fails with:

```python
>>> importlib.import_module("test_module")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>

  File "/nix/store/w2sjj4z4bxbh67yw38pqzx290bw3pra8-python3-3.12.5/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'test_module'
>>>
```

If we instead use:

```python
import sys
import importlib

path = "/tmp"

sys.path.append(path)

importlib.import_module("test_module")
```

The operation is successful:

```python
>>> importlib.import_module("test_module")
successfully imported
<module 'test_module' from '/tmp/test_module.py'>
```

Later we should rewrite these functions to instead expect `Path` objects but ensure that we add them as strings to sys.path.