### PR TITLE
Pin version of Poetry in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: "Setup environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
           poetry config virtualenvs.prefer-active-python true
           pip install invoke toml codecov
       - name: "Install Package"
@@ -192,7 +192,7 @@ jobs:
           python-version: "3.12"
       - name: "Setup environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
           poetry config virtualenvs.prefer-active-python true
           pip install invoke toml codecov
       - name: "Install Package"


### PR DESCRIPTION
A new major release of Poetry has been published earlier today (2.0)
it looks like it includes some breaking changes that are breaking the CI pipeline for now

This PR fixes the issue by pinning the version of Poetry in CI to the latest know working release (1.8.5)