### PR TITLE
Avoid providing a falsy fallback to `dict.get()`

### DIFF
--- a/infrahub_sdk/analyzer.py
+++ b/infrahub_sdk/analyzer.py
@@ -91,7 +91,7 @@ class GraphQLQueryAnalyzer:
                     else:
                         data["default_value"] = variable.default_value.value
 
-                if not data.get("default_value", None) and non_null:
+                if not data.get("default_value") and non_null:
                     data["required"] = True
 
                 response.append(GraphQLQueryVariable(**data))

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -1074,7 +1074,7 @@ class InfrahubNode(InfrahubNodeBase):
         timeout: int | None = None,
     ) -> Self:
         if not schema:
-            node_kind = data.get("__typename", None) or data.get("node", {}).get("__typename", None)
+            node_kind = data.get("__typename") or data.get("node", {}).get("__typename", None)
             if not node_kind:
                 raise ValueError("Unable to determine the type of the node, __typename not present in data")
             schema = await client.schema.get(kind=node_kind, branch=branch, timeout=timeout)
@@ -1594,7 +1594,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         timeout: int | None = None,
     ) -> Self:
         if not schema:
-            node_kind = data.get("__typename", None) or data.get("node", {}).get("__typename", None)
+            node_kind = data.get("__typename") or data.get("node", {}).get("__typename", None)
             if not node_kind:
                 raise ValueError("Unable to determine the type of the node, __typename not present in data")
             schema = client.schema.get(kind=node_kind, branch=branch, timeout=timeout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,7 +273,6 @@ ignore = [
     "RUF005",  # Consider `[*path, str(key)]` instead of concatenation
     "RUF015",  # Prefer `next(iter(input_data["variables"].keys()))` over single element slice
     "RUF029",  # Function is declared `async`, but doesn't `await` or use `async` features.
-    "RUF056",  # [*] Avoid providing a falsy fallback to `dict.get()` in boolean test positions. The default fallback `None` is already falsy.
     "S108",    # Probable insecure usage of temporary file or directory
     "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
     "S701",    # By default, jinja2 sets `autoescape` to `False`. Consider using `autoescape=True`
@@ -284,7 +283,6 @@ ignore = [
     "SIM114",  # Combine `if` branches using logical `or` operator
     "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM118",  # Use `key in dict` instead of `key in dict.keys)
-    "SIM910",  # Use `data.get(key)` instead of `data.get(key, None)`
     "TC003",   # Move standard library import `collections.abc.Iterable` into a type-checking block
     "UP031",   # Use format specifiers instead of percent format
 ]


### PR DESCRIPTION
Slight cleanup of ruff rules, mostly because I want it in place in the GraphQLQueryAnalyzer class.