### PR TITLE
fix issue with batch execution of queries not considering filters

### DIFF
--- a/changelog/query-parallel.fixed.md
+++ b/changelog/query-parallel.fixed.md
@@ -1,0 +1,1 @@
+fixes issue where using `parallel` query execution could lead to excessive and unneeded GraphQL queries

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -786,7 +786,7 @@ class InfrahubClient(BaseClient):
             nodes = []
             related_nodes = []
             batch_process = await self.create_batch()
-            count = await self.count(kind=schema.kind)
+            count = await self.count(kind=schema.kind, **filters)
             total_pages = (count + pagination_size - 1) // pagination_size
 
             for page_number in range(1, total_pages + 1):
@@ -1930,7 +1930,7 @@ class InfrahubClientSync(BaseClient):
             related_nodes = []
             batch_process = self.create_batch()
 
-            count = self.count(kind=schema.kind)
+            count = self.count(kind=schema.kind, **filters)
             total_pages = (count + pagination_size - 1) // pagination_size
 
             for page_number in range(1, total_pages + 1):


### PR DESCRIPTION
Depends on #232 

There's an issue when using the `parallel` execution of queries.
In the current implementation we don't consider the filters that were passed into the query. 
This could lead to the client making excessive and unneeded GraphQL queries. 