### PR TITLE
align environment variables between the SDK and `infrahubctl`

### DIFF
--- a/changelog/+align-infrahubctl-env-vars.md
+++ b/changelog/+align-infrahubctl-env-vars.md
@@ -1,0 +1,1 @@
+Aligned the environment variables used by the `infrahubctl` with the environment variables used by the SDK

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -130,12 +130,12 @@ async def run(
     debug: bool = False,
     _: str = CONFIG_PARAM,
     branch: str = typer.Option("main", help="Branch on which to run the script."),
-    concurrent: int = typer.Option(
-        4,
+    concurrent: int | None = typer.Option(
+        None,
         help="Maximum number of requests to execute at the same time.",
-        envvar="INFRAHUBCTL_CONCURRENT_EXECUTION",
+        envvar="INFRAHUB_MAX_CONCURRENT_EXECUTION",
     ),
-    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
+    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUB_TIMEOUT"),
     variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),

--- a/infrahub_sdk/ctl/exporter.py
+++ b/infrahub_sdk/ctl/exporter.py
@@ -26,9 +26,9 @@ def dump(
     concurrent: int = typer.Option(
         4,
         help="Maximum number of requests to execute at the same time.",
-        envvar="INFRAHUBCTL_CONCURRENT_EXECUTION",
+        envvar="INFRAHUB_MAX_CONCURRENT_EXECUTION",
     ),
-    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
+    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUB_TIMEOUT"),
     exclude: list[str] = typer.Option(
         ["CoreAccount"],
         help="Prevent node kind(s) from being exported, CoreAccount is excluded by default",

--- a/infrahub_sdk/ctl/importer.py
+++ b/infrahub_sdk/ctl/importer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from asyncio import run as aiorun
 from pathlib import Path
 
@@ -24,12 +26,12 @@ def load(
     quiet: bool = typer.Option(False, help="No console output"),
     _: str = CONFIG_PARAM,
     branch: str = typer.Option("main", help="Branch from which to export"),
-    concurrent: int = typer.Option(
-        4,
+    concurrent: int | None = typer.Option(
+        None,
         help="Maximum number of requests to execute at the same time.",
-        envvar="INFRAHUBCTL_CONCURRENT_EXECUTION",
+        envvar="INFRAHUB_MAX_CONCURRENT_EXECUTION",
     ),
-    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
+    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUB_TIMEOUT"),
 ) -> None:
     """Import nodes and their relationships into the database."""
     console = Console()


### PR DESCRIPTION
`infrahuctl` was using other environment variables to achieve the same goal as other envrionment variables that we leverage in the SDK. This PR aligns the usage of them.

INFRAHUBCTL_TIMEOUT > INFRAHUB_TIMEOUT
INFRAHUBCTL_CONCURRENT_EXECUTION > INFRAHUBCTL_MAX_CONCURRENT_EXECUTION