### PR TITLE
Run CI tests against multiple versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # ------------------------------------------ Integration Tests  ------------------------------------------
-  integration-tests:
+  integration-tests-latest-infrahub:
     if: |
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
@@ -201,8 +201,87 @@ jobs:
           pip install invoke toml codecov
       - name: "Install Package"
         run: "poetry install --all-extras"
+      - name: "Set environment variables for python_testcontainers"
+        run: |
+          echo INFRAHUB_TESTING_IMAGE_VER=latest >> $GITHUB_ENV
       - name: "Integration Tests"
-        run: "poetry run pytest --cov infrahub_sdk tests/integration/"
+        run: |
+          poetry run pytest --cov infrahub_sdk tests/integration/
+      - name: "Upload coverage to Codecov"
+        run: |
+          codecov --flags integration-tests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  integration-tests-local-infrahub:
+    if: |
+      always() && !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      needs.files-changed.outputs.python == 'true' &&
+      (github.base_ref == 'stable' || github.base_ref == 'develop')
+    needs: ["files-changed", "yaml-lint", "python-lint"]
+    runs-on:
+      group: "huge-runners"
+    timeout-minutes: 30
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+
+      - name: "Extract target branch name"
+        id: extract_branch
+        run: echo "TARGET_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
+
+      - name: "Checkout infrahub repository"
+        uses: "actions/checkout@v4"
+        with:
+          repository: "opsmill/infrahub"
+          path: "infrahub-server"
+          ref: ${{ github.base_ref }}
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: "Setup git credentials prior dev.build"
+        run: |
+          cd infrahub-server
+          git config --global user.name 'Infrahub'
+          git config --global user.email 'infrahub@opsmill.com'
+          git config --global --add safe.directory '*'
+          git config --global credential.usehttppath true
+          git config --global credential.helper /usr/local/bin/infrahub-git-credential
+
+      - name: "Set environment variables prior dev.build"
+        run: |
+          echo "INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }}" >> $GITHUB_ENV
+          RUNNER_NAME=$(echo "${{ runner.name }}" | grep -o 'ghrunner[0-9]\+' | sed 's/ghrunner\([0-9]\+\)/ghrunner_\1/')
+          echo "PYTEST_DEBUG_TEMPROOT=/var/lib/github/${RUNNER_NAME}/_temp" >> $GITHUB_ENV
+          echo "INFRAHUB_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }}" >> $GITHUB_ENV
+          echo "INFRAHUB_TESTING_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }}" >> $GITHUB_ENV
+          echo "INFRAHUB_TESTING_DOCKER_IMAGE=opsmill/infrahub" >> $GITHUB_ENV
+
+      - name: "Build container"
+        run: |
+          cd infrahub-server
+          inv dev.build
+
+      - name: "Setup environment"
+        run: |
+          pipx install poetry==1.8.5
+          poetry config virtualenvs.create true --local
+          pip install invoke toml codecov
+
+      - name: "Install Package"
+        run: "poetry install --all-extras"
+
+      - name: "Integration Tests"
+        run: |
+          echo "Running tests for version: $INFRAHUB_TESTING_IMAGE_VER"
+          poetry run pytest --cov infrahub_sdk tests/integration/
+
       - name: "Upload coverage to Codecov"
         run: |
           codecov --flags integration-tests

--- a/infrahub_sdk/testing/docker.py
+++ b/infrahub_sdk/testing/docker.py
@@ -1,10 +1,40 @@
+from __future__ import annotations
+
+import os
+
 import pytest
 from infrahub_testcontainers.helpers import TestInfrahubDocker
+from packaging.version import InvalidVersion, Version
 
 from .. import Config, InfrahubClient, InfrahubClientSync
 
+INFRAHUB_VERSION = os.getenv("INFRAHUB_TESTING_IMAGE_VER", "latest")
+
+
+def skip_version(min_infrahub_version: str | None = None, max_infrahub_version: str | None = None) -> bool:
+    """
+    Check if a test should be skipped depending on infrahub version.
+    """
+    try:
+        version = Version(INFRAHUB_VERSION)
+    except InvalidVersion:
+        # We would typically end up here for development purpose while running a CI test against
+        # unreleased versions of infrahub, like `stable` or `develop` branch.
+        # For now, we consider this means we are testing against the most recent version of infrahub,
+        # so we skip if the test should not be ran against a maximum version.
+        return max_infrahub_version is None
+
+    if min_infrahub_version is not None and version < Version(min_infrahub_version):
+        return True
+
+    return max_infrahub_version is not None and version > Version(max_infrahub_version)
+
 
 class TestInfrahubDockerClient(TestInfrahubDocker):
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return INFRAHUB_VERSION
+
     @pytest.fixture(scope="class")
     def client(self, infrahub_port: int) -> InfrahubClient:
         return InfrahubClient(

--- a/tests/integration/test_infrahub_client.py
+++ b/tests/integration/test_infrahub_client.py
@@ -17,10 +17,6 @@ if TYPE_CHECKING:
 
 class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
     @pytest.fixture(scope="class")
-    def infrahub_version(self) -> str:
-        return "1.1.0"
-
-    @pytest.fixture(scope="class")
     async def base_dataset(
         self,
         client: InfrahubClient,

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -12,10 +12,6 @@ from infrahub_sdk.testing.schemas.car_person import TESTING_CAR, TESTING_MANUFAC
 
 class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
     @pytest.fixture(scope="class")
-    def infrahub_version(self) -> str:
-        return "1.1.0"
-
-    @pytest.fixture(scope="class")
     async def initial_schema(self, default_branch: str, client: InfrahubClient, schema_base: SchemaRoot) -> None:
         await client.schema.wait_until_converged(branch=default_branch)
 

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.repository import GitRepo
 from infrahub_sdk.utils import get_fixtures_dir
@@ -13,10 +11,6 @@ if TYPE_CHECKING:
 
 
 class TestInfrahubRepository(TestInfrahubDockerClient):
-    @pytest.fixture(scope="class")
-    def infrahub_version(self) -> str:
-        return "1.1.0"
-
     async def test_add_repository(self, client: InfrahubClient, remote_repos_dir):
         src_directory = get_fixtures_dir() / "integration/mock_repo"
         repo = GitRepo(name="mock_repo", src_directory=src_directory, dst_directory=remote_repos_dir)


### PR DESCRIPTION
This PR enables CI tests to run against both latest infrahub server version and local version of stable/develop branch. Version is set using `INFRAHUB_TESTING_IMAGE_VER` environment variable (that we already use within python_testcontainers, and related logic should be simplified when [this PR](https://github.com/opsmill/infrahub/pull/5550) is cleaned/finalized).

Ideally, we would also like to have an `---infrahub-version` cli argument for users convenience. Adding such a parameter requires to define `pytest_adoption` within a `conftest.py` file. However, having this `conftest.py` being loaded when a user runs a test requires either of the tests to be located in the same folder/subfolders of `conftest.py` - and it should not be the case. So, we need a more elaborated pytest plugin/hook mechanism that would deserve a dedicated PR.

Note that we may later want to run sdk tests at least against pinned major infrahub versions.