### PR TITLE
pyproject.toml: Removed [project] section for now.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[project]
-name = "infrahub-sdk"
-version = "1.5.0"
-requires-python = ">=3.9"
-
 [tool.poetry]
 name = "infrahub-sdk"
 version = "1.7.0"


### PR DESCRIPTION
If you `pip install git+https://github.com/opsmill/infrahub-sdk-python.git@stable`, it'll show the version as **1.5.0**.

I assume this change was to get us PEP 621 compliant and we can add it back and keep the versions up to date, but removing it just to keep managing versions simple.

```
❯ pip install git+https://github.com/opsmill/infrahub-sdk-python.git@develop
Collecting git+https://github.com/opsmill/infrahub-sdk-python.git@develop
  Cloning https://github.com/opsmill/infrahub-sdk-python.git (to revision develop) to /private/var/folders/5t/pqcr9rn115vcdyfw4t7tqgt40000gq/T/pip-req-build-27an6h07
  Running command git clone --filter=blob:none --quiet https://github.com/opsmill/infrahub-sdk-python.git /private/var/folders/5t/pqcr9rn115vcdyfw4t7tqgt40000gq/T/pip-req-build-27an6h07
  Running command git checkout -b develop --track origin/develop
  Switched to a new branch 'develop'
  branch 'develop' set up to track 'origin/develop'.
  Resolved https://github.com/opsmill/infrahub-sdk-python.git to commit d002b8544e4b8025e12b0ec66307cb656904aa15
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: dulwich<0.22.0,>=0.21.4 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (0.21.7)
Requirement already satisfied: eval-type-backport<0.3.0,>=0.2.2 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (0.2.2)
Requirement already satisfied: graphql-core<3.3,>=3.1 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (3.2.4)
Requirement already satisfied: httpx>=0.20 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (0.27.2)
Requirement already satisfied: pendulum>=2 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (3.0.0)
Requirement already satisfied: pydantic!=2.0.1,!=2.1.0,<3.0.0,>=2.0.0 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (2.9.1)
Requirement already satisfied: pydantic-settings>=2.0 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (2.5.2)
Requirement already satisfied: ujson<6,>=5 in ./.venv/lib/python3.9/site-packages (from infrahub-sdk==1.5.0) (5.10.0)
Requirement already satisfied: urllib3>=1.25 in ./.venv/lib/python3.9/site-packages (from dulwich<0.22.0,>=0.21.4->infrahub-sdk==1.5.0) (2.2.3)
Requirement already satisfied: anyio in ./.venv/lib/python3.9/site-packages (from httpx>=0.20->infrahub-sdk==1.5.0) (4.4.0)
Requirement already satisfied: certifi in ./.venv/lib/python3.9/site-packages (from httpx>=0.20->infrahub-sdk==1.5.0) (2024.8.30)
Requirement already satisfied: httpcore==1.* in ./.venv/lib/python3.9/site-packages (from httpx>=0.20->infrahub-sdk==1.5.0) (1.0.5)
Requirement already satisfied: idna in ./.venv/lib/python3.9/site-packages (from httpx>=0.20->infrahub-sdk==1.5.0) (3.9)
Requirement already satisfied: sniffio in ./.venv/lib/python3.9/site-packages (from httpx>=0.20->infrahub-sdk==1.5.0) (1.3.1)
Requirement already satisfied: h11<0.15,>=0.13 in ./.venv/lib/python3.9/site-packages (from httpcore==1.*->httpx>=0.20->infrahub-sdk==1.5.0) (0.14.0)
Requirement already satisfied: python-dateutil>=2.6 in ./.venv/lib/python3.9/site-packages (from pendulum>=2->infrahub-sdk==1.5.0) (2.9.0.post0)
Requirement already satisfied: tzdata>=2020.1 in ./.venv/lib/python3.9/site-packages (from pendulum>=2->infrahub-sdk==1.5.0) (2024.1)
Requirement already satisfied: time-machine>=2.6.0 in ./.venv/lib/python3.9/site-packages (from pendulum>=2->infrahub-sdk==1.5.0) (2.16.0)
Requirement already satisfied: annotated-types>=0.6.0 in ./.venv/lib/python3.9/site-packages (from pydantic!=2.0.1,!=2.1.0,<3.0.0,>=2.0.0->infrahub-sdk==1.5.0) (0.7.0)
Requirement already satisfied: pydantic-core==2.23.3 in ./.venv/lib/python3.9/site-packages (from pydantic!=2.0.1,!=2.1.0,<3.0.0,>=2.0.0->infrahub-sdk==1.5.0) (2.23.3)
Requirement already satisfied: typing-extensions>=4.6.1 in ./.venv/lib/python3.9/site-packages (from pydantic!=2.0.1,!=2.1.0,<3.0.0,>=2.0.0->infrahub-sdk==1.5.0) (4.12.2)
Requirement already satisfied: python-dotenv>=0.21.0 in ./.venv/lib/python3.9/site-packages (from pydantic-settings>=2.0->infrahub-sdk==1.5.0) (1.0.1)
Requirement already satisfied: six>=1.5 in ./.venv/lib/python3.9/site-packages (from python-dateutil>=2.6->pendulum>=2->infrahub-sdk==1.5.0) (1.16.0)
Requirement already satisfied: exceptiongroup>=1.0.2 in ./.venv/lib/python3.9/site-packages (from anyio->httpx>=0.20->infrahub-sdk==1.5.0) (1.2.2)
Building wheels for collected packages: infrahub-sdk
  Building wheel for infrahub-sdk (pyproject.toml) ... done
  Created wheel for infrahub-sdk: filename=infrahub_sdk-1.5.0-py3-none-any.whl size=140194 sha256=4254d703100141092890f5ec2170d03e26df465ff401468b1996f152f41a9e98
  Stored in directory: /private/var/folders/5t/pqcr9rn115vcdyfw4t7tqgt40000gq/T/pip-ephem-wheel-cache-o4ufv01x/wheels/b8/80/f0/b9b893bfa91ec5790a0e35b1595e593002b6dfd46537b81e51
Successfully built infrahub-sdk
Installing collected packages: infrahub-sdk
  Attempting uninstall: infrahub-sdk
    Found existing installation: infrahub-sdk 1.7.0
    Uninstalling infrahub-sdk-1.7.0:
      Successfully uninstalled infrahub-sdk-1.7.0
Successfully installed infrahub-sdk-1.5.0

[notice] A new release of pip is available: 24.3.1 -> 25.0
[notice] To update, run: pip install --upgrade pip
```