### PR TITLE
Update InfrahubNode artifact_fetch and artifact_generate methods to use artiface name instead of the defintion name

### DIFF
--- a/changelog/+artifact_methods.changed.md
+++ b/changelog/+artifact_methods.changed.md
@@ -1,0 +1,1 @@
+Changes InfrahubNode `artifact_fetch` and `artifact_generate` methods to use the name of the artifact instead of the name of the artifact definition

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -1125,7 +1125,7 @@ class InfrahubNode(InfrahubNodeBase):
     async def artifact_fetch(self, name: str) -> str | dict[str, Any]:
         self._validate_artifact_support(ARTIFACT_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE)
 
-        artifact = await self._client.get(kind="CoreArtifact", definition__name__value=name, object__ids=[self.id])
+        artifact = await self._client.get(kind="CoreArtifact", name__value=name, object__ids=[self.id])
         content = await self._client.object_store.get(identifier=artifact.storage_id.value)  # type: ignore[attr-defined]
         return content
 

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -1118,7 +1118,7 @@ class InfrahubNode(InfrahubNodeBase):
     async def artifact_generate(self, name: str) -> None:
         self._validate_artifact_support(ARTIFACT_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE)
 
-        artifact = await self._client.get(kind="CoreArtifact", definition__name__value=name, object__ids=[self.id])
+        artifact = await self._client.get(kind="CoreArtifact", name__value=name, object__ids=[self.id])
         await artifact.definition.fetch()  # type: ignore[attr-defined]
         await artifact.definition.peer.generate([artifact.id])  # type: ignore[attr-defined]
 


### PR DESCRIPTION
Now that artifacts are properly getting their name from the `artifact_name` attribute of the artifact definition (https://github.com/opsmill/infrahub/issues/5484), we need to update the InfrahubNode `artifact_fetch` and `artifact_generate` method to use the name of the artifact instead.