### PR TITLE
 Remove default value "main" for branch parameter from all Infrahub CTL commands

### DIFF
--- a/changelog/264.fixed.md
+++ b/changelog/264.fixed.md
@@ -1,0 +1,1 @@
+Remove default value "main" for branch parameter from all Infrahub CTL commands.

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -129,7 +129,7 @@ async def run(
     method: str = "run",
     debug: bool = False,
     _: str = CONFIG_PARAM,
-    branch: str = typer.Option("main", help="Branch on which to run the script."),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch on which to run the script."),
     concurrent: int | None = typer.Option(
         None,
         help="Maximum number of requests to execute at the same time.",

--- a/infrahub_sdk/ctl/exporter.py
+++ b/infrahub_sdk/ctl/exporter.py
@@ -22,7 +22,7 @@ def dump(
     directory: Path = typer.Option(directory_name_with_timestamp, help="Directory path to store export"),
     quiet: bool = typer.Option(False, help="No console output"),
     _: str = CONFIG_PARAM,
-    branch: str = typer.Option("main", help="Branch from which to export"),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch from which to export"),
     concurrent: int = typer.Option(
         4,
         help="Maximum number of requests to execute at the same time.",

--- a/infrahub_sdk/ctl/importer.py
+++ b/infrahub_sdk/ctl/importer.py
@@ -25,7 +25,7 @@ def load(
     ),
     quiet: bool = typer.Option(False, help="No console output"),
     _: str = CONFIG_PARAM,
-    branch: str = typer.Option("main", help="Branch from which to export"),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch from which to export"),
     concurrent: int | None = typer.Option(
         None,
         help="Maximum number of requests to execute at the same time.",

--- a/infrahub_sdk/ctl/menu.py
+++ b/infrahub_sdk/ctl/menu.py
@@ -27,7 +27,7 @@ def callback() -> None:
 async def load(
     menus: list[Path],
     debug: bool = False,
-    branch: str = typer.Option("main", help="Branch on which to load the menu."),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch on which to load the menu."),
     _: str = CONFIG_PARAM,
 ) -> None:
     """Load one or multiple menu files into Infrahub."""

--- a/infrahub_sdk/ctl/object.py
+++ b/infrahub_sdk/ctl/object.py
@@ -27,7 +27,7 @@ def callback() -> None:
 async def load(
     paths: list[Path],
     debug: bool = False,
-    branch: str = typer.Option("main", help="Branch on which to load the objects."),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch on which to load the objects."),
     _: str = CONFIG_PARAM,
 ) -> None:
     """Load one or multiple objects files into Infrahub."""

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -69,7 +69,7 @@ async def add(
     name: str,
     location: str,
     description: str = "",
-    username: str = "",
+    username: str | None = None,
     password: str = "",
     ref: str = "",
     read_only: bool = False,

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -74,7 +74,7 @@ async def add(
     ref: str = "",
     read_only: bool = False,
     debug: bool = False,
-    branch: str = typer.Option("main", help="Branch on which to add the repository."),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch on which to add the repository."),
     _: str = CONFIG_PARAM,
 ) -> None:
     """Add a new repository."""

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -69,12 +69,11 @@ async def add(
     name: str,
     location: str,
     description: str = "",
-    username: str | None = None,
+    username: str = "",
     password: str = "",
     ref: str = "",
     read_only: bool = False,
     debug: bool = False,
-    branch: str = typer.Option(None, help="Branch on which to add the repository."),
     _: str = CONFIG_PARAM,
 ) -> None:
     """Add a new repository."""
@@ -111,18 +110,17 @@ async def add(
         query={"ok": None},
     )
 
-    await client.execute_graphql(query=query.render(), branch_name=branch, tracker="mutation-repository-create")
+    await client.execute_graphql(query=query.render(), tracker="mutation-repository-create")
 
 
 @app.command()
 async def list(
-    branch: str | None = None,
     debug: bool = False,
     _: str = CONFIG_PARAM,
 ) -> None:
     init_logging(debug=debug)
 
-    client = initialize_client(branch=branch)
+    client = initialize_client()
 
     repo_status_query = {
         "CoreGenericRepository": {
@@ -142,7 +140,7 @@ async def list(
     }
 
     query = Query(name="GetRepositoryStatus", query=repo_status_query)
-    resp = await client.execute_graphql(query=query.render(), branch_name=branch, tracker="query-repository-list")
+    resp = await client.execute_graphql(query=query.render(), tracker="query-repository-list")
 
     table = Table(title="List of all Repositories")
 

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -115,7 +115,7 @@ async def add(
 
 @app.command()
 async def list(
-    branch: str = typer.Option(None, help="Branch on which to check the schema."),
+    branch: str = typer.Option(None, help="Branch on which to list repositories."),
     debug: bool = False,
     _: str = CONFIG_PARAM,
 ) -> None:

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -115,6 +115,7 @@ async def add(
 
 @app.command()
 async def list(
+    branch: str = typer.Option(None, help="Branch on which to check the schema."),
     debug: bool = False,
     _: str = CONFIG_PARAM,
 ) -> None:
@@ -140,7 +141,7 @@ async def list(
     }
 
     query = Query(name="GetRepositoryStatus", query=repo_status_query)
-    resp = await client.execute_graphql(query=query.render(), tracker="query-repository-list")
+    resp = await client.execute_graphql(query=query.render(), branch_name=branch, tracker="query-repository-list")
 
     table = Table(title="List of all Repositories")
 

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -108,7 +108,7 @@ def get_node(schemas_data: list[dict], schema_index: int, node_index: int) -> di
 async def load(
     schemas: list[Path],
     debug: bool = False,
-    branch: str = typer.Option("main", help="Branch on which to load the schema."),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch on which to load the schema."),
     wait: int = typer.Option(0, help="Time in seconds to wait until the schema has converged across all workers"),
     _: str = CONFIG_PARAM,
 ) -> None:
@@ -159,7 +159,7 @@ async def load(
 async def check(
     schemas: list[Path],
     debug: bool = False,
-    branch: str = typer.Option("main", help="Branch on which to check the schema."),  # TODO: Replace main by None
+    branch: str = typer.Option(None, help="Branch on which to check the schema."),
     _: str = CONFIG_PARAM,
 ) -> None:
     """Check if schema files are valid and what would be the impact of loading them with Infrahub."""

--- a/tests/unit/ctl/test_repository_app.py
+++ b/tests/unit/ctl/test_repository_app.py
@@ -284,8 +284,6 @@ mutation {
                 "This is a test description",
                 "--ref",
                 "my-custom-branch",
-                "--branch",
-                "develop",
             ],
         )
         assert output.exit_code == 0
@@ -329,6 +327,6 @@ mutation {
         )
 
     def test_repo_list(self, mock_repositories_list) -> None:
-        result = runner.invoke(app, ["repository", "list", "--branch", "main"])
+        result = runner.invoke(app, ["repository", "list"])
         assert result.exit_code == 0
         assert strip_color(result.stdout) == read_fixture("output.txt", "integration/test_infrahubctl/repository_list")

--- a/tests/unit/ctl/test_repository_app.py
+++ b/tests/unit/ctl/test_repository_app.py
@@ -74,7 +74,6 @@ mutation {
     }
 }
 """,
-            branch_name="main",
             tracker="mutation-repository-create",
         )
 
@@ -135,7 +134,6 @@ mutation {
     }
 }
 """,
-            branch_name="main",
             tracker="mutation-repository-create",
         )
 
@@ -198,7 +196,6 @@ mutation {
     }
 }
 """,
-            branch_name="main",
             tracker="mutation-repository-create",
         )
 
@@ -260,7 +257,6 @@ mutation {
     }
 }
 """,
-            branch_name="main",
             tracker="mutation-repository-create",
         )
 
@@ -329,7 +325,6 @@ mutation {
     }
 }
 """,
-            branch_name="develop",
             tracker="mutation-repository-create",
         )
 


### PR DESCRIPTION
Before (env variable is ignored):

```console
➜ export | grep INFRAHUB
INFRAHUB_ADDRESS=http://localhost:8000
INFRAHUB_API_TOKEN=06438eb2-8019-4776-878c-0941b1f1d1ec
➜ infrahubctl schema check schema.yml
 schema 'schema.yml' is Valid!
diff:
    added:
        RandomGeneric:
            added: {}
            changed: {}
            removed: {}
        RandomStuff:
            added: {}
            changed: {}
            removed: {}
    changed: {}
    removed: {}

➜ export INFRAHUB_DEFAULT_BRANCH="doesntexist"
➜ infrahubctl schema check schema.yml
 schema 'schema.yml' is Valid!
diff:
    added:
        RandomGeneric:
            added: {}
            changed: {}
            removed: {}
        RandomStuff:
            added: {}
            changed: {}
            removed: {}
    changed: {}
    removed: {}
```

After (Take into account the env variable + If there is no default branch set then fallback on default branch set in SDK):

```console
➜ export | grep INFRAHUB
INFRAHUB_ADDRESS=http://localhost:8000
INFRAHUB_API_TOKEN=06438eb2-8019-4776-878c-0941b1f1d1ec
➜ infrahubctl schema check schema.yml
 schema 'schema.yml' is Valid!
diff:
    added:
        RandomGeneric:
            added: {}
            changed: {}
            removed: {}
        RandomStuff:
            added: {}
            changed: {}
            removed: {}
    changed: {}
    removed: {}

➜ export INFRAHUB_DEFAULT_BRANCH="doesntexist"
➜ infrahubctl schema check schema.yml
HTTP communication failure: Client error '400 Bad Request' for url 'http://localhost:8000/api/schema/check?branch=doesntexist'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400 on POST to http://localhost:8000/api/schema/check?branch=doesntexist
```

resolves: #264 