### PR TITLE
Add `infrahub.tasks` as built-in logger to `InfrahubGenerator` class

### DIFF
--- a/changelog/+add-logger-to-generator-class.md
+++ b/changelog/+add-logger-to-generator-class.md
@@ -1,0 +1,1 @@
+Added logger to `InfrahubGenerator` class to allow users use built-in logging (`self.logger`) to show logging within Infrahub CI pipeline.

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -21,7 +20,7 @@ if TYPE_CHECKING:
 async def run(
     generator_name: str,
     path: str,  # noqa: ARG001
-    debug: bool,  # noqa: ARG001
+    debug: bool,
     list_available: bool,
     branch: str | None = None,
     variables: list[str] | None = None,

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,7 +10,7 @@ from rich.console import Console
 from ..ctl import config
 from ..ctl.client import initialize_client
 from ..ctl.repository import get_repository_config
-from ..ctl.utils import execute_graphql_query, parse_cli_vars
+from ..ctl.utils import execute_graphql_query, init_logging, parse_cli_vars
 from ..exceptions import ModuleImportError
 from ..node import InfrahubNode
 
@@ -25,6 +26,7 @@ async def run(
     branch: str | None = None,
     variables: list[str] | None = None,
 ) -> None:
+    init_logging(debug=debug)
     repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
 
     if list_available or not generator_name:
@@ -34,7 +36,6 @@ async def run(
     generator_config = repository_config.get_generator_definition(name=generator_name)
 
     console = Console()
-
     relative_path = str(generator_config.file_path.parent) if generator_config.file_path.parent != Path() else None
 
     try:

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from abc import abstractmethod
 from typing import TYPE_CHECKING
@@ -27,6 +28,7 @@ class InfrahubGenerator:
         generator_instance: str = "",
         params: dict | None = None,
         convert_query_response: bool = False,
+        logger: logging.Logger | None = None,
     ) -> None:
         self.query = query
         self.branch = branch
@@ -41,6 +43,7 @@ class InfrahubGenerator:
         self._related_nodes: list[InfrahubNode] = []
         self.infrahub_node = infrahub_node
         self.convert_query_response = convert_query_response
+        self.logger = logger if logger else logging.getLogger("infrahub.tasks")
 
     @property
     def store(self) -> NodeStore:


### PR DESCRIPTION
There have been a few requests to implement logging within generators within the CI pipeline output.

This adds an option to pass in your own logger or default to `infrahub.tasks`.

I also added `init_logging` in the generator CTL command so we can take advantage of the logging on the console as well.

Please let me know if there is a more optimal way, but this might be a good thing to include in a few of the classes that run within the CI pipeline.