### PR TITLE
ctl: Transform to not dump to JSON string if the return of the transform is text.

### DIFF
--- a/changelog/+ctl-transform-return-string.md
+++ b/changelog/+ctl-transform-return-string.md
@@ -1,0 +1,1 @@
+Allows the `infrahubctl transform` to return a regular string that does not get converted to a JSON string.

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -352,7 +352,11 @@ def transform(
     # Run Transform
     result = asyncio.run(transform.run(data=data))
 
-    json_string = ujson.dumps(result, indent=2, sort_keys=True)
+    if isinstance(result, str):
+        json_string = result
+    else:
+        json_string = ujson.dumps(result, indent=2, sort_keys=True)
+
     if out:
         write_to_file(Path(out), json_string)
     else:


### PR DESCRIPTION
If the transform returns a string, do not dump to a JSON string.