### PR TITLE
Update artifact_generate|fetch to search for artifact by name__value rather than the definition__name__value.

### DIFF
--- a/changelog/+artifact_methods.changed.md
+++ b/changelog/+artifact_methods.changed.md
@@ -1,1 +1,1 @@
-Changes InfrahubNode `artifact_fetch` and `artifact_generate` methods to use the name of the artifact instead of the name of the artifact definition
+Changes InfrahubNode/InfrahubNodeSync `artifact_fetch` and `artifact_generate` methods to use the name of the artifact instead of the name of the artifact definition

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -1635,13 +1635,13 @@ class InfrahubNodeSync(InfrahubNodeBase):
 
     def artifact_generate(self, name: str) -> None:
         self._validate_artifact_support(ARTIFACT_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE)
-        artifact = self._client.get(kind="CoreArtifact", definition__name__value=name, object__ids=[self.id])
+        artifact = self._client.get(kind="CoreArtifact", name__value=name, object__ids=[self.id])
         artifact.definition.fetch()  # type: ignore[attr-defined]
         artifact.definition.peer.generate([artifact.id])  # type: ignore[attr-defined]
 
     def artifact_fetch(self, name: str) -> str | dict[str, Any]:
         self._validate_artifact_support(ARTIFACT_FETCH_FEATURE_NOT_SUPPORTED_MESSAGE)
-        artifact = self._client.get(kind="CoreArtifact", definition__name__value=name, object__ids=[self.id])
+        artifact = self._client.get(kind="CoreArtifact", name__value=name, object__ids=[self.id])
         content = self._client.object_store.get(identifier=artifact.storage_id.value)  # type: ignore[attr-defined]
         return content
 


### PR DESCRIPTION
Related to https://github.com/opsmill/infrahub-sdk-python/pull/266 for the `InfrahubNodeSync` methods.