### PR TITLE
fix: build for python 3.13

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2207,5 +2207,5 @@ tests = ["Jinja2", "pytest", "pyyaml", "rich"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9, <=3.13"
-content-hash = "bbd7280cdf6fab3001d339f4b12d01b0883008905d1a0c3f9010eafdaec5b15f"
+python-versions = "^3.9, <3.14"
+content-hash = "eecc46f7563f6f1057281f72c3877abd859d96c63493b221d10d3910e25b3b34"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9, <=3.13"
+python = "^3.9, <3.14"
 pydantic = ">=2.0.0,!=2.0.1,!=2.1.0,<3.0.0"
 pydantic-settings = ">=2.0"
 graphql-core = ">=3.1,<3.3"


### PR DESCRIPTION
#256  was supposed to reintroduce 3.13 support, but according to CI logs:

![image](https://github.com/user-attachments/assets/ca8708ec-9b58-459f-b2ba-5f2bf7f48d83)


Edit: need to investigate why `poetry install` is 20x slower with 3.13...
