### PR TITLE
Add support for Offset DateTime to Timestamp

### DIFF
--- a/infrahub_sdk/timestamp.py
+++ b/infrahub_sdk/timestamp.py
@@ -5,7 +5,7 @@ import warnings
 from datetime import datetime, timezone
 from typing import Literal
 
-from whenever import Date, Instant, LocalDateTime, Time, ZonedDateTime
+from whenever import Date, Instant, LocalDateTime, OffsetDateTime, Time, ZonedDateTime
 
 from .exceptions import TimestampFormatError
 
@@ -57,6 +57,12 @@ class Timestamp:
         try:
             local_date_time = LocalDateTime.parse_common_iso(value)
             return local_date_time.assume_utc().to_tz("UTC")
+        except ValueError:
+            pass
+
+        try:
+            offset_date_time = OffsetDateTime.parse_common_iso(value)
+            return offset_date_time.to_tz("UTC")
         except ValueError:
             pass
 

--- a/tests/unit/sdk/test_timestamp.py
+++ b/tests/unit/sdk/test_timestamp.py
@@ -37,7 +37,7 @@ def test_parse_string():
     assert Timestamp._parse_string("10s")
     assert Timestamp._parse_string("2025-01-02")
     assert Timestamp._parse_string("2024-06-04T03:13:03.386270")
-
+    assert Timestamp._parse_string("2025-03-05T18:01:52+01:00")
     with pytest.raises(TimestampFormatError):
         Timestamp._parse_string("notvalid")
 


### PR DESCRIPTION
The DateTime format `"2025-03-05T18:01:52+01:00"` was previously supported with Pendulum but it's no longer working after #256 
