### PR TITLE
add trailing microsecond 0s to serialized timestamps

### DIFF
--- a/infrahub_sdk/timestamp.py
+++ b/infrahub_sdk/timestamp.py
@@ -88,9 +88,11 @@ class Timestamp:
         return f"Timestamp: {self.to_string()}"
 
     def to_string(self, with_z: bool = True) -> str:
-        if with_z:
-            return self._obj.instant().format_common_iso()
-        return self.to_datetime().isoformat()
+        time_str = self.to_datetime().isoformat(timespec="microseconds")
+        if with_z and time_str.endswith("+00:00"):
+            time_str = time_str[:-6]
+            time_str += "Z"
+        return time_str
 
     def to_timestamp(self) -> int:
         return self._obj.timestamp()

--- a/tests/unit/sdk/test_timestamp.py
+++ b/tests/unit/sdk/test_timestamp.py
@@ -12,11 +12,11 @@ UTC = timezone.utc  # Required for older versions of Python
 def test_init_empty():
     t1 = Timestamp()
     assert isinstance(t1, Timestamp)
-    assert t1.to_string() == t1._obj.instant().format_common_iso()
+    assert t1.to_datetime() == t1._obj.py_datetime()
 
     t2 = Timestamp(None)
     assert isinstance(t2, Timestamp)
-    assert t2.to_string() == t2._obj.instant().format_common_iso()
+    assert t2.to_datetime() == t2._obj.py_datetime()
 
 
 def test_init_timestamp():
@@ -24,7 +24,7 @@ def test_init_timestamp():
     t2 = Timestamp(t1)
     assert t1.to_string() == t2.to_string()
     assert isinstance(t2, Timestamp)
-    assert t2.to_string() == t2._obj.instant().format_common_iso()
+    assert t2.to_datetime() == t2._obj.py_datetime()
 
 
 def test_parse_string():

--- a/tests/unit/sdk/test_timestamp.py
+++ b/tests/unit/sdk/test_timestamp.py
@@ -65,7 +65,7 @@ def test_parse_string():
 )
 def test_to_datetime(input_str, expected_datetime):
     assert isinstance(Timestamp(input_str).to_datetime(), datetime)
-    assert str(Timestamp(input_str).to_datetime()) == str(expected_datetime)
+    assert Timestamp(input_str).to_datetime() == expected_datetime
 
 
 @pytest.mark.parametrize(
@@ -73,7 +73,7 @@ def test_to_datetime(input_str, expected_datetime):
     [
         pytest.param(
             "2022-01-01T10:01:01.123000Z",
-            "2022-01-01T10:01:01.123Z",
+            "2022-01-01T10:01:01.123000Z",
             "2022-01-01T10:01:01.123000+00:00",
             id="milliseconds",
         ),
@@ -94,13 +94,13 @@ def test_to_string_default(input_str, expected_str, expected_str_no_z):
 def test_add():
     t1 = Timestamp("2022-01-01T10:01:01.123Z")
     t2 = t1.add(hours=1)
-    assert t2.to_string() == "2022-01-01T11:01:01.123Z"
+    assert t2.to_string() == "2022-01-01T11:01:01.123000Z"
 
 
 def test_subtract():
     t1 = Timestamp("2022-01-01T10:05:01.123Z")
     t2 = t1.subtract(hours=1)
-    assert t2.to_string() == "2022-01-01T09:05:01.123Z"
+    assert t2.to_string() == "2022-01-01T09:05:01.123000Z"
 
 
 def test_compare():
@@ -117,6 +117,15 @@ def test_compare():
     assert t11 <= t12
     assert t11 >= t12
     assert t11 == t12
+
+
+def test_serialize():
+    time_no_z = "2022-01-01T11:00:00.000000+00:00"
+    time = "2022-01-01T11:00:00.000000Z"
+    timestamp = Timestamp(time)
+
+    assert timestamp.to_string(with_z=False) == time_no_z
+    assert timestamp.to_string() == time
 
 
 @pytest.mark.parametrize("invalid_str", ["blurple", "1122334455667788", "2023-45-99"])


### PR DESCRIPTION
IFC-1374

the new Timestamp using `whenever` strips trailing zeros from serialized instances. This can cause our database-level datetime comparison logic to break b/c we use string comparison on timestamp fields and a later timestamp with no trailing 0s can appear as earlier incorrectly

small cypher example
╒════════════════════════════════════════════════════════╕
│"2025-03-12T16:33:54.7Z" > "2025-03-12T16:33:54.710000Z"│
╞════════════════════════════════════════════════════════╡
│true                                                    │
└────────────────────────────────────────────────────────┘