### PR TITLE
Update process_nodes to use new format of schema cache

### DIFF
--- a/changelog/+4507ed25.fixed.md
+++ b/changelog/+4507ed25.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where the process_nodes method in the generators used the old format of the schema hash, so node population didn't work

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -125,7 +125,7 @@ class InfrahubGenerator:
         await self._init_client.schema.all(branch=self.branch_name)
 
         for kind in data:
-            if kind in self._init_client.schema.cache[self.branch_name]:
+            if kind in self._init_client.schema.cache[self.branch_name].nodes.keys():
                 for result in data[kind].get("edges", []):
                     node = await self.infrahub_node.from_graphql(
                         client=self._init_client, branch=self.branch_name, data=result


### PR DESCRIPTION
This PR fixes a bug uncovered by https://github.com/opsmill/infrahub/pull/6112

A test pipeline to validate against the Infrahub repo can be found here:
https://github.com/opsmill/infrahub/pull/6115