### PR TITLE
Fix sentence case

### DIFF
--- a/docs/docs/python-sdk/introduction.mdx
+++ b/docs/docs/python-sdk/introduction.mdx
@@ -4,7 +4,7 @@ title: Python SDK
 
 The Infrahub Python SDK greatly simplifies how you can interact with Infrahub programmatically.
 
-## Blog Posts
+## Blog posts
 
 - [Querying Data in Infrahub via the Python SDK](https://www.opsmill.com/querying-data-in-infrahub-via-the-python-sdk/)
 


### PR DESCRIPTION
Get rid of warning from vale:

```bash
❯ vale docs/docs

 docs/docs/python-sdk/introduction.mdx
 7:4  warning  'Blog Posts' should use         Infrahub.sentence-case
               sentence case

✖ 0 errors, 1 warning and 0 suggestions in 45 files.
```