### PR TITLE
Improve error message when a schema is not JSON valid.

### DIFF
--- a/changelog/+jsondecode.changed.md
+++ b/changelog/+jsondecode.changed.md
@@ -1,0 +1,1 @@
+Improve error message when a schema received from the server is not JSON valid. The new exception will be of type `infrahub_sdk.exceptions.JsonDecodeError` instead of `json.decoder.JSONDecodeError`

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import MutableMapping
 from enum import Enum
 from time import sleep
@@ -13,6 +14,7 @@ from typing_extensions import TypeAlias
 
 from ..exceptions import (
     InvalidResponseError,
+    JsonDecodeError,
     SchemaNotFoundError,
     ValidationError,
 )
@@ -420,7 +422,14 @@ class InfrahubSchema(InfrahubSchemaBase):
         response = await self.client._get(url=url, timeout=timeout)
         response.raise_for_status()
 
-        data: MutableMapping[str, Any] = response.json()
+        try:
+            data: MutableMapping[str, Any] = response.json()
+        except json.decoder.JSONDecodeError as exc:
+            raise JsonDecodeError(
+                message=f"Invalid Schema response received from the server at {response.url}: {response.text} [{response.status_code}] ",
+                content=response.text,
+                url=response.url,
+            ) from exc
 
         nodes: MutableMapping[str, MainSchemaTypesAPI] = {}
         for node_schema in data.get("nodes", []):


### PR DESCRIPTION
This PR aim to improve the error message reported by the SDK when the schema received from the server is not JSON valid. 

Currently a `json.decoder.JSONDecodeError` exception will be raised but it doesn't contain enough information

```python
2025-03-21T13:56:10.519447Z [error    ] Failed to execute generator: Expecting value: line 1 column 1 (char 0) [prefect.flow_runs] routing_key=check.generator.run
[...]
  File "/opt/infrahub/git/182ed5b8-d9c2-e54a-3ee3-106550e9b385/commits/f42cdfbfa634e470425650887aa4acf70cbc9ec2/infrahub_edge/models.py", line 2639, in get_and_save_infrahub_node
    node = await client.get(kind=kind, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/community/python_sdk/infrahub_sdk/client.py", line 467, in get
    schema = await self.schema.get(kind=kind, branch=branch)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/community/python_sdk/infrahub_sdk/schema/__init__.py", line 190, in get
    self.cache[branch] = await self.fetch(branch=branch, timeout=timeout)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/community/python_sdk/infrahub_sdk/schema/__init__.py", line 405, in fetch
    data: MutableMapping[str, Any] = response.json()
                                     ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/httpx/_models.py", line 766, in json
    return jsonlib.loads(self.content, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 338, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/decoder.py", line 356, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
``` 