### PR TITLE
set the default branch correctly on the client store in a generator

### DIFF
--- a/changelog/+store_default_branch_generator.fixed.md
+++ b/changelog/+store_default_branch_generator.fixed.md
@@ -1,0 +1,1 @@
+fixes an issue where the default branch of the client store was not properly set in a generator

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -40,6 +40,7 @@ class InfrahubGenerator:
         self.generator_instance = generator_instance
         self._init_client = client.clone()
         self._init_client.config.default_branch = self._init_client.default_branch = self.branch_name
+        self._init_client.store._default_branch = self.branch_name
         self._client: InfrahubClient | None = None
         self._nodes: list[InfrahubNode] = []
         self._related_nodes: list[InfrahubNode] = []


### PR DESCRIPTION
When a generator runs on a task worker, the client that gets passed when we instantiate a generator, does not have the default branch set to the current active branch.

This leads to a situation where the default branch on the store never gets properly set. Due to this objects that get stored end-up in the correct NodeStoreBranch, but when we retrieve them we always try to fetch them from the `main` NodeStoreBranch.