### PR TITLE
Add hfid support for cardinality many relationships

### DIFF
--- a/changelog/+hfid_support_cardinality_many_relationships.changed.md
+++ b/changelog/+hfid_support_cardinality_many_relationships.changed.md
@@ -1,0 +1,1 @@
+Set the HFID on related nodes for cardinality many relationships and add hfid support to the RelationshipManager add, extend and remove methods

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -569,7 +569,9 @@ class RelationshipManager(RelationshipManagerBase):
             raise UninitializedError("Must call fetch() on RelationshipManager before editing members")
         new_node = RelatedNode(schema=self.schema, client=self.client, branch=self.branch, data=data)
 
-        if new_node.id and new_node.id not in self.peer_ids:
+        if (new_node.id and new_node.id not in self.peer_ids) or (
+            new_node.hfid and new_node.hfid not in self.peer_hfids
+        ):
             self.peers.append(new_node)
             self._has_update = True
 
@@ -587,6 +589,14 @@ class RelationshipManager(RelationshipManagerBase):
             idx = self.peer_ids.index(node_to_remove.id)
             if self.peers[idx].id != node_to_remove.id:
                 raise IndexError(f"Unexpected situation, the node with the index {idx} should be {node_to_remove.id}")
+
+            self.peers.pop(idx)
+            self._has_update = True
+
+        elif node_to_remove.hfid and node_to_remove.hfid in self.peer_hfids:
+            idx = self.peer_hfids.index(node_to_remove.hfid)
+            if self.peers[idx].hfid != node_to_remove.hfid:
+                raise IndexError(f"Unexpected situation, the node with the index {idx} should be {node_to_remove.hfid}")
 
             self.peers.pop(idx)
             self._has_update = True
@@ -664,7 +674,9 @@ class RelationshipManagerSync(RelationshipManagerBase):
             raise UninitializedError("Must call fetch() on RelationshipManager before editing members")
         new_node = RelatedNodeSync(schema=self.schema, client=self.client, branch=self.branch, data=data)
 
-        if new_node.id and new_node.id not in self.peer_ids:
+        if (new_node.id and new_node.id not in self.peer_ids) or (
+            new_node.hfid and new_node.hfid not in self.peer_hfids
+        ):
             self.peers.append(new_node)
             self._has_update = True
 
@@ -682,6 +694,13 @@ class RelationshipManagerSync(RelationshipManagerBase):
             idx = self.peer_ids.index(node_to_remove.id)
             if self.peers[idx].id != node_to_remove.id:
                 raise IndexError(f"Unexpected situation, the node with the index {idx} should be {node_to_remove.id}")
+            self.peers.pop(idx)
+            self._has_update = True
+
+        elif node_to_remove.hfid and node_to_remove.hfid in self.peer_hfids:
+            idx = self.peer_hfids.index(node_to_remove.hfid)
+            if self.peers[idx].hfid != node_to_remove.hfid:
+                raise IndexError(f"Unexpected situation, the node with the index {idx} should be {node_to_remove.hfid}")
 
             self.peers.pop(idx)
             self._has_update = True

--- a/infrahub_sdk/node.py
+++ b/infrahub_sdk/node.py
@@ -479,7 +479,7 @@ class RelationshipManagerBase:
         """
         data: dict[str, Any] = {
             "count": None,
-            "edges": {"node": {"id": None, "display_label": None, "__typename": None}},
+            "edges": {"node": {"id": None, "hfid": None, "display_label": None, "__typename": None}},
         }
 
         properties: dict[str, Any] = {}

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1105,6 +1105,7 @@ async def test_query_data_include_property(client, location_schema: NodeSchemaAP
                             },
                             "node": {
                                 "id": None,
+                                "hfid": None,
                                 "display_label": None,
                                 "__typename": None,
                             },
@@ -1157,6 +1158,7 @@ async def test_query_data_include(client, location_schema: NodeSchemaAPI, client
                         "edges": {
                             "node": {
                                 "id": None,
+                                "hfid": None,
                                 "display_label": None,
                                 "__typename": None,
                             },


### PR DESCRIPTION
- get and set the hfid for related nodes of cardinality many relationships
- add hfid support to RelationshipManager's add/extend/remove methods