### PR TITLE
Add ability to use convert_query_response with Python Transforms

### DIFF
--- a/changelog/281.added.md
+++ b/changelog/281.added.md
@@ -1,0 +1,1 @@
+Added ability to convert the query response to InfrahubNode objects when using Python Transforms in the same way you can with Generators.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -271,11 +271,6 @@ class BaseClient:
             input_data={"data": input_data},
         )
 
-    def _clone_config(self, branch: str | None = None) -> Config:
-        config = copy.deepcopy(self.config)
-        config.default_branch = branch or config.default_branch
-        return config
-
 
 class InfrahubClient(BaseClient):
     """GraphQL Client to interact with Infrahub."""
@@ -854,7 +849,7 @@ class InfrahubClient(BaseClient):
 
     def clone(self, branch: str | None = None) -> InfrahubClient:
         """Return a cloned version of the client using the same configuration"""
-        return InfrahubClient(config=self._clone_config(branch=branch))
+        return InfrahubClient(config=self.config.clone(branch=branch))
 
     async def execute_graphql(
         self,
@@ -1598,7 +1593,7 @@ class InfrahubClientSync(BaseClient):
 
     def clone(self, branch: str | None = None) -> InfrahubClientSync:
         """Return a cloned version of the client using the same configuration"""
-        return InfrahubClientSync(config=self._clone_config(branch=branch))
+        return InfrahubClientSync(config=self.config.clone(branch=branch))
 
     def execute_graphql(
         self,

--- a/infrahub_sdk/config.py
+++ b/infrahub_sdk/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 from pydantic import Field, field_validator, model_validator
@@ -158,3 +159,19 @@ class Config(ConfigBase):
         elif values.get("recorder") == RecorderType.JSON and "custom_recorder" not in values:
             values["custom_recorder"] = JSONRecorder()
         return values
+
+    def clone(self, branch: str | None = None) -> Config:
+        config: dict[str, Any] = {
+            "default_branch": branch or self.default_branch,
+            "recorder": self.recorder,
+            "custom_recorder": self.custom_recorder,
+            "requester": self.requester,
+            "sync_requester": self.sync_requester,
+            "log": self.log,
+        }
+        covered_keys = list(config.keys())
+        for field in Config.model_fields.keys():
+            if field not in covered_keys:
+                config[field] = deepcopy(getattr(self, field))
+
+        return Config(**config)

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -41,6 +41,7 @@ from ..ctl.utils import (
 )
 from ..ctl.validate import app as validate_app
 from ..exceptions import GraphQLError, ModuleImportError
+from ..node import InfrahubNode
 from ..protocols_generator.generator import CodeGenerator
 from ..schema import MainSchemaTypesAll, SchemaRoot
 from ..template import Jinja2Template
@@ -330,7 +331,12 @@ def transform(
         console.print(f"[red]{exc.message}")
         raise typer.Exit(1) from exc
 
-    transform = transform_class(client=client, branch=branch)
+    transform = transform_class(
+        client=client,
+        branch=branch,
+        infrahub_node=InfrahubNode,
+        convert_query_response=transform_config.convert_query_response,
+    )
     # Get data
     query_str = repository_config.get_query(name=transform.query).load_query()
     data = asyncio.run(

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -62,7 +62,7 @@ async def run(
         generator = generator_class(
             query=generator_config.query,
             client=client,
-            branch=branch,
+            branch=branch or "",
             params=variables_dict,
             convert_query_response=generator_config.convert_query_response,
             infrahub_node=InfrahubNode,
@@ -91,7 +91,7 @@ async def run(
             generator = generator_class(
                 query=generator_config.query,
                 client=client,
-                branch=branch,
+                branch=branch or "",
                 params=params,
                 convert_query_response=generator_config.convert_query_response,
                 infrahub_node=InfrahubNode,

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
 import logging
-import os
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from infrahub_sdk.repository import GitRepoManager
-
 from .exceptions import UninitializedError
+from .operation import InfrahubOperation
 
 if TYPE_CHECKING:
     from .client import InfrahubClient
     from .context import RequestContext
     from .node import InfrahubNode
-    from .store import NodeStore
 
 
-class InfrahubGenerator:
+class InfrahubGenerator(InfrahubOperation):
     """Infrahub Generator class"""
 
     def __init__(
@@ -24,7 +21,7 @@ class InfrahubGenerator:
         query: str,
         client: InfrahubClient,
         infrahub_node: type[InfrahubNode],
-        branch: str | None = None,
+        branch: str = "",
         root_directory: str = "",
         generator_instance: str = "",
         params: dict | None = None,
@@ -33,34 +30,20 @@ class InfrahubGenerator:
         request_context: RequestContext | None = None,
     ) -> None:
         self.query = query
-        self.branch = branch
-        self.git: GitRepoManager | None = None
+
+        super().__init__(
+            client=client,
+            infrahub_node=infrahub_node,
+            convert_query_response=convert_query_response,
+            branch=branch,
+            root_directory=root_directory,
+        )
+
         self.params = params or {}
-        self.root_directory = root_directory or os.getcwd()
         self.generator_instance = generator_instance
-        self._init_client = client.clone(branch=self.branch_name)
         self._client: InfrahubClient | None = None
-        self._nodes: list[InfrahubNode] = []
-        self._related_nodes: list[InfrahubNode] = []
-        self.infrahub_node = infrahub_node
-        self.convert_query_response = convert_query_response
         self.logger = logger if logger else logging.getLogger("infrahub.tasks")
         self.request_context = request_context
-
-    @property
-    def store(self) -> NodeStore:
-        """The store will be populated with nodes based on the query during the collection of data if activated"""
-        return self._init_client.store
-
-    @property
-    def nodes(self) -> list[InfrahubNode]:
-        """Returns nodes collected and parsed during the data collection process if this feature is enables"""
-        return self._nodes
-
-    @property
-    def related_nodes(self) -> list[InfrahubNode]:
-        """Returns nodes collected and parsed during the data collection process if this feature is enables"""
-        return self._related_nodes
 
     @property
     def subscribers(self) -> list[str] | None:
@@ -77,20 +60,6 @@ class InfrahubGenerator:
     @client.setter
     def client(self, value: InfrahubClient) -> None:
         self._client = value
-
-    @property
-    def branch_name(self) -> str:
-        """Return the name of the current git branch."""
-
-        if self.branch:
-            return self.branch
-
-        if not self.git:
-            self.git = GitRepoManager(self.root_directory)
-
-        self.branch = str(self.git.active_branch)
-
-        return self.branch
 
     async def collect_data(self) -> dict:
         """Query the result of the GraphQL Query defined in self.query and return the result"""
@@ -116,27 +85,6 @@ class InfrahubGenerator:
             identifier=identifier, params=self.params, delete_unused_nodes=True, group_type="CoreGeneratorGroup"
         ) as self.client:
             await self.generate(data=unpacked)
-
-    async def process_nodes(self, data: dict) -> None:
-        if not self.convert_query_response:
-            return
-
-        await self._init_client.schema.all(branch=self.branch_name)
-
-        for kind in data:
-            if kind in self._init_client.schema.cache[self.branch_name].nodes.keys():
-                for result in data[kind].get("edges", []):
-                    node = await self.infrahub_node.from_graphql(
-                        client=self._init_client, branch=self.branch_name, data=result
-                    )
-                    self._nodes.append(node)
-                    await node._process_relationships(
-                        node_data=result, branch=self.branch_name, related_nodes=self._related_nodes
-                    )
-
-        for node in self._nodes + self._related_nodes:
-            if node.id:
-                self._init_client.store.set(node=node)
 
     @abstractmethod
     async def generate(self, data: dict) -> None:

--- a/infrahub_sdk/operation.py
+++ b/infrahub_sdk/operation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from .repository import GitRepoManager
+
+if TYPE_CHECKING:
+    from . import InfrahubClient
+    from .node import InfrahubNode
+    from .store import NodeStore
+
+
+class InfrahubOperation:
+    def __init__(
+        self,
+        client: InfrahubClient,
+        infrahub_node: type[InfrahubNode],
+        convert_query_response: bool,
+        branch: str,
+        root_directory: str,
+    ):
+        self.branch = branch
+        self.convert_query_response = convert_query_response
+        self.root_directory = root_directory or os.getcwd()
+        self.infrahub_node = infrahub_node
+        self._nodes: list[InfrahubNode] = []
+        self._related_nodes: list[InfrahubNode] = []
+        self._init_client = client.clone(branch=self.branch_name)
+        self.git: GitRepoManager | None = None
+
+    @property
+    def branch_name(self) -> str:
+        """Return the name of the current git branch."""
+
+        if self.branch:
+            return self.branch
+
+        if not hasattr(self, "git") or not self.git:
+            self.git = GitRepoManager(self.root_directory)
+
+        self.branch = str(self.git.active_branch)
+
+        return self.branch
+
+    @property
+    def store(self) -> NodeStore:
+        """The store will be populated with nodes based on the query during the collection of data if activated"""
+        return self._init_client.store
+
+    @property
+    def nodes(self) -> list[InfrahubNode]:
+        """Returns nodes collected and parsed during the data collection process if this feature is enabled"""
+        return self._nodes
+
+    @property
+    def related_nodes(self) -> list[InfrahubNode]:
+        """Returns nodes collected and parsed during the data collection process if this feature is enabled"""
+        return self._related_nodes
+
+    async def process_nodes(self, data: dict) -> None:
+        if not self.convert_query_response:
+            return
+
+        await self._init_client.schema.all(branch=self.branch_name)
+
+        for kind in data:
+            if kind in self._init_client.schema.cache[self.branch_name].nodes.keys():
+                for result in data[kind].get("edges", []):
+                    node = await self.infrahub_node.from_graphql(
+                        client=self._init_client, branch=self.branch_name, data=result
+                    )
+                    self._nodes.append(node)
+                    await node._process_relationships(
+                        node_data=result, branch=self.branch_name, related_nodes=self._related_nodes
+                    )
+
+        for node in self._nodes + self._related_nodes:
+            if node.id:
+                self._init_client.store.set(node=node)

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -154,6 +154,10 @@ class CoreMenu(CoreNode):
     children: RelationshipManager
 
 
+class CoreObjectComponentTemplate(CoreNode):
+    template_name: String
+
+
 class CoreObjectTemplate(CoreNode):
     template_name: String
 
@@ -205,6 +209,7 @@ class CoreWebhook(CoreNode):
     name: String
     event_type: Enum
     branch_scope: Dropdown
+    node_kind: StringOptional
     description: StringOptional
     url: URL
     validate_certificates: BooleanOptional
@@ -479,6 +484,7 @@ class CoreTransformJinja2(CoreTransformation):
 class CoreTransformPython(CoreTransformation):
     file_path: String
     class_name: String
+    convert_query_response: BooleanOptional
 
 
 class CoreUserValidator(CoreValidator):
@@ -625,6 +631,10 @@ class CoreMenuSync(CoreNodeSync):
     children: RelationshipManagerSync
 
 
+class CoreObjectComponentTemplateSync(CoreNodeSync):
+    template_name: String
+
+
 class CoreObjectTemplateSync(CoreNodeSync):
     template_name: String
 
@@ -676,6 +686,7 @@ class CoreWebhookSync(CoreNodeSync):
     name: String
     event_type: Enum
     branch_scope: Dropdown
+    node_kind: StringOptional
     description: StringOptional
     url: URL
     validate_certificates: BooleanOptional
@@ -950,6 +961,7 @@ class CoreTransformJinja2Sync(CoreTransformationSync):
 class CoreTransformPythonSync(CoreTransformationSync):
     file_path: String
     class_name: String
+    convert_query_response: BooleanOptional
 
 
 class CoreUserValidatorSync(CoreValidatorSync):

--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -117,6 +117,10 @@ class InfrahubPythonTransformConfig(InfrahubRepositoryConfigElement):
     name: str = Field(..., description="The name of the Transform")
     file_path: Path = Field(..., description="The file within the repository with the transform code.")
     class_name: str = Field(default="Transform", description="The name of the transform class to run.")
+    convert_query_response: bool = Field(
+        default=False,
+        description="Decide if the transform should convert the result of the GraphQL query to SDK InfrahubNode objects.",
+    )
 
     def load_class(self, import_root: str | None = None, relative_path: str | None = None) -> type[InfrahubTransform]:
         module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)

--- a/infrahub_sdk/transforms.py
+++ b/infrahub_sdk/transforms.py
@@ -5,34 +5,38 @@ import os
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from infrahub_sdk.repository import GitRepoManager
-
-from .exceptions import UninitializedError
+from .operation import InfrahubOperation
 
 if TYPE_CHECKING:
     from . import InfrahubClient
+    from .node import InfrahubNode
 
 INFRAHUB_TRANSFORM_VARIABLE_TO_IMPORT = "INFRAHUB_TRANSFORMS"
 
 
-class InfrahubTransform:
+class InfrahubTransform(InfrahubOperation):
     name: str | None = None
     query: str
     timeout: int = 10
 
     def __init__(
         self,
+        client: InfrahubClient,
+        infrahub_node: type[InfrahubNode],
+        convert_query_response: bool = False,
         branch: str = "",
         root_directory: str = "",
         server_url: str = "",
-        client: InfrahubClient | None = None,
     ):
-        self.git: GitRepoManager
+        super().__init__(
+            client=client,
+            infrahub_node=infrahub_node,
+            convert_query_response=convert_query_response,
+            branch=branch,
+            root_directory=root_directory,
+        )
 
-        self.branch = branch
         self.server_url = server_url or os.environ.get("INFRAHUB_URL", "http://127.0.0.1:8000")
-        self.root_directory = root_directory or os.getcwd()
-
         self._client = client
 
         if not self.name:
@@ -43,24 +47,7 @@ class InfrahubTransform:
 
     @property
     def client(self) -> InfrahubClient:
-        if self._client:
-            return self._client
-
-        raise UninitializedError("The client has not been initialized")
-
-    @property
-    def branch_name(self) -> str:
-        """Return the name of the current git branch."""
-
-        if self.branch:
-            return self.branch
-
-        if not hasattr(self, "git") or not self.git:
-            self.git = GitRepoManager(self.root_directory)
-
-        self.branch = str(self.git.active_branch)
-
-        return self.branch
+        return self._init_client
 
     @abstractmethod
     def transform(self, data: dict) -> Any:
@@ -86,6 +73,7 @@ class InfrahubTransform:
             data = await self.collect_data()
 
         unpacked = data.get("data") or data
+        await self.process_nodes(data=unpacked)
 
         if asyncio.iscoroutinefunction(self.transform):
             return await self.transform(data=unpacked)

--- a/tests/fixtures/repos/ctl_integration/.infrahub.yml
+++ b/tests/fixtures/repos/ctl_integration/.infrahub.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/python-sdk/repository-config/develop.json
+---
+python_transforms:
+  - name: animal_person
+    class_name: AnimalPerson
+    file_path: "transforms/animal_person.py"
+    convert_query_response: false
+  - name: animal_person_converted
+    class_name: ConvertedAnimalPerson
+    file_path: "transforms/converted.py"
+    convert_query_response: true
+
+generator_definitions:
+  - name: animal_tags
+    file_path: "generators/tag_generator.py"
+    targets: pet_owners
+    query: animal_person
+    convert_query_response: false
+    parameters:
+      name: "name__value"
+  - name: animal_tags_convert
+    file_path: "generators/tag_generator_convert.py"
+    targets: pet_owners
+    query: animal_person
+    convert_query_response: true
+    parameters:
+      name: "name__value"
+
+
+queries:
+  - name: animal_person
+    file_path: queries/animal_person.gql

--- a/tests/fixtures/repos/ctl_integration/generators/tag_generator.py
+++ b/tests/fixtures/repos/ctl_integration/generators/tag_generator.py
@@ -1,0 +1,15 @@
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        response_person = data["TestingPerson"]["edges"][0]["node"]
+        name: str = response_person["name"]["value"]
+
+        for animal in data["TestingPerson"]["edges"][0]["node"]["animals"]["edges"]:
+            payload = {
+                "name": f"raw-{name.lower().replace(' ', '-')}-{animal['node']['name']['value'].lower()}",
+                "description": "Without converting query response",
+            }
+            obj = await self.client.create(kind="BuiltinTag", data=payload)
+            await obj.save(allow_upsert=True)

--- a/tests/fixtures/repos/ctl_integration/generators/tag_generator_convert.py
+++ b/tests/fixtures/repos/ctl_integration/generators/tag_generator_convert.py
@@ -1,0 +1,16 @@
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        response_person = data["TestingPerson"]["edges"][0]["node"]
+        name: str = response_person["name"]["value"]
+        person = self.store.get(key=name, kind="TestingPerson")
+
+        for animal in person.animals.peers:
+            payload = {
+                "name": f"converted-{name.lower().replace(' ', '-')}-{animal.peer.name.value.lower()}",
+                "description": "Using convert_query_response",
+            }
+            obj = await self.client.create(kind="BuiltinTag", data=payload)
+            await obj.save(allow_upsert=True)

--- a/tests/fixtures/repos/ctl_integration/queries/animal_person.gql
+++ b/tests/fixtures/repos/ctl_integration/queries/animal_person.gql
@@ -1,0 +1,27 @@
+query TestPersonQuery($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        __typename
+        id
+        name {
+          value
+        }
+        height {
+          value
+        }
+        animals {
+          edges {
+            node {
+              __typename
+              id
+              name {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/repos/ctl_integration/transforms/animal_person.py
+++ b/tests/fixtures/repos/ctl_integration/transforms/animal_person.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class AnimalPerson(InfrahubTransform):
+    query = "animal_person"
+
+    async def transform(self, data) -> dict[str, Any]:
+        response_person = data["TestingPerson"]["edges"][0]["node"]
+        name: str = response_person["name"]["value"]
+        animal_names = sorted(
+            animal["node"]["name"]["value"] for animal in data["TestingPerson"]["edges"][0]["node"]["animals"]["edges"]
+        )
+
+        return {"person": name, "pets": animal_names}

--- a/tests/fixtures/repos/ctl_integration/transforms/converted.py
+++ b/tests/fixtures/repos/ctl_integration/transforms/converted.py
@@ -1,0 +1,18 @@
+from operator import itemgetter
+from typing import Any
+
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class ConvertedAnimalPerson(InfrahubTransform):
+    query = "animal_person"
+
+    async def transform(self, data) -> dict[str, Any]:
+        response_person = data["TestingPerson"]["edges"][0]["node"]
+        name: str = response_person["name"]["value"]
+        person = self.store.get(key=name, kind="TestingPerson")
+
+        animals = [{"type": animal.peer.typename, "name": animal.peer.name.value} for animal in person.animals.peers]
+        animals.sort(key=itemgetter("name"))
+
+        return {"person": person.name.value, "herd_size": len(animals), "animals": animals}

--- a/tests/integration/test_infrahubctl.py
+++ b/tests/integration/test_infrahubctl.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from infrahub_sdk.ctl import config
+from infrahub_sdk.ctl.cli_commands import app, generator
+from infrahub_sdk.ctl.parameters import load_configuration
+from infrahub_sdk.repository import GitRepoManager
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+from infrahub_sdk.testing.schemas.animal import SchemaAnimal
+from tests.helpers.utils import change_directory, strip_color
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+FIXTURE_BASE_DIR = Path(Path(os.path.abspath(__file__)).parent / ".." / "fixtures")
+
+
+runner = CliRunner()
+
+
+class TestInfrahubCtl(TestInfrahubDockerClient, SchemaAnimal):
+    @pytest.fixture(scope="class")
+    async def base_dataset(
+        self,
+        client: InfrahubClient,
+        load_schema,
+        person_liam,
+        person_ethan,
+        person_sophia,
+        cat_luna,
+        cat_bella,
+        dog_daisy,
+        dog_rocky,
+        ctl_client_config,
+    ):
+        await client.branch.create(branch_name="branch01")
+
+    @pytest.fixture(scope="class")
+    def repository(self) -> Generator[str]:
+        temp_dir = tempfile.mkdtemp()
+
+        try:
+            fixture_path = Path(FIXTURE_BASE_DIR / "repos" / "ctl_integration")
+            shutil.copytree(fixture_path, temp_dir, dirs_exist_ok=True)
+            # Initialize fixture as git repository. This is necessary to run some infrahubctl commands.
+            GitRepoManager(temp_dir)
+
+            yield temp_dir
+
+        finally:
+            shutil.rmtree(temp_dir)
+
+    @pytest.fixture(scope="class")
+    def ctl_client_config(self, client: InfrahubClient) -> Generator:
+        load_configuration(value="infrahubctl.toml")
+        assert config.SETTINGS._settings
+        config.SETTINGS._settings.server_address = client.config.address
+        original_username = os.environ.get("INFRAHUB_USERNAME")
+        original_password = os.environ.get("INFRAHUB_PASSWORD")
+        if client.config.username and client.config.password:
+            os.environ["INFRAHUB_USERNAME"] = client.config.username
+            os.environ["INFRAHUB_PASSWORD"] = client.config.password
+        yield
+        if original_username:
+            os.environ["INFRAHUB_USERNAME"] = original_username
+        if original_password:
+            os.environ["INFRAHUB_PASSWORD"] = original_password
+
+    def test_infrahubctl_transform_cmd_animal_person(self, repository: str, base_dataset: None) -> None:
+        """Test infrahubctl transform without converting nodes."""
+
+        with change_directory(repository):
+            ethans_output = runner.invoke(app, ["transform", "animal_person", "name=Ethan Carter"])
+            structured_ethan_output = json.loads(strip_color(ethans_output.stdout))
+
+            liams_output = runner.invoke(app, ["transform", "animal_person", "name=Liam Walker"])
+            structured_liam_output = json.loads(strip_color(liams_output.stdout))
+
+            assert structured_ethan_output == {"person": "Ethan Carter", "pets": ["Bella", "Daisy", "Luna"]}
+            assert structured_liam_output == {"person": "Liam Walker", "pets": []}
+
+    def test_infrahubctl_transform_cmd_convert_animal_person(self, repository: str, base_dataset: None) -> None:
+        """Test infrahubctl transform when converting nodes."""
+
+        with change_directory(repository):
+            ethans_output = runner.invoke(app, ["transform", "animal_person_converted", "name=Ethan Carter"])
+            structured_ethan_output = json.loads(strip_color(ethans_output.stdout))
+
+            liams_output = runner.invoke(app, ["transform", "animal_person_converted", "name=Liam Walker"])
+            structured_liam_output = json.loads(strip_color(liams_output.stdout))
+
+            assert structured_ethan_output == {
+                "animals": [
+                    {"name": "Bella", "type": "TestingCat"},
+                    {"name": "Daisy", "type": "TestingDog"},
+                    {"name": "Luna", "type": "TestingCat"},
+                ],
+                "herd_size": 3,
+                "person": "Ethan Carter",
+            }
+            assert structured_liam_output == {
+                "animals": [],
+                "herd_size": 0,
+                "person": "Liam Walker",
+            }
+
+    async def test_infrahubctl_generator_cmd_animal_tags(
+        self, repository: str, base_dataset: None, client: InfrahubClient
+    ) -> None:
+        """Test infrahubctl generator without converting nodes."""
+
+        expected_generated_tags = ["raw-ethan-carter-bella", "raw-ethan-carter-daisy", "raw-ethan-carter-luna"]
+        initial_tags = await client.all(kind="BuiltinTag")
+
+        with change_directory(repository):
+            await generator(
+                generator_name="animal_tags", variables=["name=Ethan Carter"], list_available=False, path="."
+            )
+
+        final_tags = await client.all(kind="BuiltinTag")
+
+        initial_tag_names = [tag.name.value for tag in initial_tags]
+        final_tag_names = [tag.name.value for tag in final_tags]
+
+        for tag in expected_generated_tags:
+            assert tag not in initial_tag_names
+            assert tag in final_tag_names
+
+    async def test_infrahubctl_generator_cmd_animal_tags_convert_query(
+        self, repository: str, base_dataset: None, client: InfrahubClient
+    ) -> None:
+        """Test infrahubctl generator with conversion of nodes."""
+
+        expected_generated_tags = [
+            "converted-ethan-carter-bella",
+            "converted-ethan-carter-daisy",
+            "converted-ethan-carter-luna",
+        ]
+        initial_tags = await client.all(kind="BuiltinTag")
+
+        with change_directory(repository):
+            await generator(
+                generator_name="animal_tags_convert", variables=["name=Ethan Carter"], list_available=False, path="."
+            )
+
+        final_tags = await client.all(kind="BuiltinTag")
+
+        initial_tag_names = [tag.name.value for tag in initial_tags]
+        final_tag_names = [tag.name.value for tag in final_tags]
+
+        for tag in expected_generated_tags:
+            assert tag not in initial_tag_names
+            assert tag in final_tag_names


### PR DESCRIPTION
This PR introduced support for "convert_query_response" for Python Transforms.

Changes:
* The client method to clone the config has been moved to the config object itself and modified to not only rely on deepcopy. The reason for this comes from the tests within the Infrahub directory where we've overridden the client transport to a method that doesn't allow for pickling. As the transport itself shouldn't be of interest for the config we reuse some of the elements in the cloned config
* As some of the methods and logic is shared between Generators and Transforms a new "InfrahubOperation" class has been introduced and logic has been transfered and consolidated from both Generators and Transforms to this new base class.
* Some new protocols were added
* I added some new integration tests for both Transforms and Generators, previously these weren't tested within the SDK but and instead relied on tests within the Infrahub repository, but added to the SDK tests to have better coverage
* I ran into some issues with the tests for the "infrahubctl generator" typer app as it's an async app, after some troubleshooting I noticed that the `typer.testing.CliRunner` doesn't seem to support tests for async commands like this. Instead of spending more time on that I opted to call the `generator` function directly within the code for now. It would be good with a permanent solution for that but I didn't want to spend more time on it now.

Fixes #281

Backend PR: https://github.com/opsmill/infrahub/pull/6363