### PR TITLE
add repository dispatch workflow triggering updates in other repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,10 @@ jobs:
     secrets: inherit
     with:
       version: ${{ github.ref_name }}
+
+  repository-dispatch:
+    needs: check_release
+    uses: ./.github/workflows/repository-dispatch.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.check_release.outputs.version }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -1,0 +1,53 @@
+---
+# yamllint disable rule:truthy rule:line-length
+name: Trigger Infrahub SDK update in other repositories
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs-on:
+        description: "The OS to run the job on"
+        required: false
+        default: "ubuntu-22.04"
+        type: string
+      version:
+        type: string
+        required: false
+        description: The string to extract semver from.
+        default: ''
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "The OS to run the job on"
+        required: false
+        default: "ubuntu-22.04"
+        type: string
+      version:
+        type: string
+        required: false
+        description: The string to extract semver from.
+        default: ''
+
+jobs:
+  repository-dispatch:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        # Either a literal path, or the name of a secret...
+        repo:
+          - "opsmill/infrahub-demo-dc-fabric"
+          - "INFRAHUB_CUSTOMER1_REPOSITORY"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
+          # if matrix.repo contains a slash, use it literally; otherwise look up the secret named by matrix.repo
+          repository: ${{ contains(matrix.repo, '/') && matrix.repo || secrets[matrix.repo] }}
+          event-type: trigger-infrahub-sdk-python-update
+          client-payload: |
+            {"version":"${{ inputs.version }}"}


### PR DESCRIPTION
Trigger SDK updates in other repositories, primarily to trigger integration tests in demo and customer repositories.