### PR TITLE
fix bug in Timestamp.add

### DIFF
--- a/infrahub_sdk/timestamp.py
+++ b/infrahub_sdk/timestamp.py
@@ -153,7 +153,7 @@ class Timestamp:
         nanoseconds: int = 0,
         disambiguate: Literal["compatible"] = "compatible",
     ) -> Timestamp:
-        return Timestamp(
+        return self.__class__(
             self._obj.add(
                 years=years,
                 months=months,

--- a/infrahub_sdk/timestamp.py
+++ b/infrahub_sdk/timestamp.py
@@ -183,7 +183,7 @@ class Timestamp:
         nanoseconds: int = 0,
         disambiguate: Literal["compatible"] = "compatible",
     ) -> Timestamp:
-        return Timestamp(
+        return self.__class__(
             self._obj.subtract(
                 years=years,
                 months=months,


### PR DESCRIPTION
instantiate the new timestamp as `self.__class__` instead of `Timestamp` so that we keep the correct class

for example, infrahub has its own `Timestamp` class that inherites from the sdk's `Timestamp` and calling `.add` on an infrahub `Timestamp` yields an sdk `Timestamp`