### PR TITLE
Fix URL to the documentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ At its heart, Infrahub is built on 3 fundamental pillars:
 
 The Infrahub Python SDK greatly simplifies how you can interact with Infrahub programmatically.
 
-More information can be found in the [Infrahub Python SDK Documentation](https://docs.infrahub.app/python-sdk/).
+More information can be found in the [Infrahub Python SDK Documentation](https://docs.infrahub.app/python-sdk/introduction).
 
 ## Installation
 


### PR DESCRIPTION
Someone reported that the url pointing at the doc is not working, we should use `https://docs.infrahub.app/python-sdk/introduction/` instead of `https://docs.infrahub.app/python-sdk/`
