### PR TITLE
Trigger markdown lint on github action updates & fix rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,9 @@ jobs:
 
 
   markdown-lint:
-    if: needs.files-changed.outputs.documentation == 'true'
+    if: |
+      needs.files-changed.outputs.documentation == 'true' ||
+      needs.files-changed.outputs.github_workflows == 'true'
     needs: ["files-changed"]
     runs-on: "ubuntu-latest"
     timeout-minutes: 5

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,3 +11,5 @@ MD034: false # no-bare-urls
 MD041: false # allow 1st line to not be a top-level heading (required for Towncrier)
 MD045: false # no alt text around images
 MD047: false # single trailing newline
+MD059:       # Link descriptions that are prohibited
+  prohibited_texts: []


### PR DESCRIPTION
Fixes an issue with the CI where we upgraded markdown lint in #414, but the CI wasn't configured to run the markdown job during such an upgrade.

Now we see failures as there are violations based on the new rules from markdown lint. Which have to do with the text of anchor links.

The second update is to update the ruleset to ignore these new violations, we can go back later and re apply them again if desired.