### PR TITLE
utils.py: update file not found exception message

### DIFF
--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -45,7 +45,7 @@ def get_repository_config(repo_config_file: Path) -> InfrahubRepositoryConfig:
 
 
 def load_repository_config_file(repo_config_file: Path) -> dict:
-    yaml_data = read_file(file_name=repo_config_file)
+    yaml_data = read_file(file_path=repo_config_file)
 
     try:
         data = yaml.safe_load(yaml_data)

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -353,7 +353,9 @@ def write_to_file(path: Path, value: Any) -> bool:
 
 def read_file(file_path: Path) -> str:
     if not file_path.is_file():
-        raise FileNotValidError(name=str(file_path.name), message=f"{file_path.name}: not found at {file_path.cwd()}")
+        raise FileNotValidError(
+            name=str(file_path.name), message=f"{file_path.name}: not found at {file_path.parent}"
+        )
     try:
         with Path.open(file_path, encoding="utf-8") as fobj:
             return fobj.read()

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -353,9 +353,7 @@ def write_to_file(path: Path, value: Any) -> bool:
 
 def read_file(file_path: Path) -> str:
     if not file_path.is_file():
-        raise FileNotValidError(
-            name=str(file_path.name), message=f"{file_path.name}: not found at {file_path.parent}"
-        )
+        raise FileNotValidError(name=str(file_path.name), message=f"{file_path.name}: not found at {file_path.parent}")
     try:
         with Path.open(file_path, encoding="utf-8") as fobj:
             return fobj.read()

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -358,7 +358,9 @@ def read_file(file_path: Path) -> str:
         with Path.open(file_path, encoding="utf-8") as fobj:
             return fobj.read()
     except UnicodeDecodeError as exc:
-        raise FileNotValidError(name=str(file_path.name), message=f"Unable to read {file_path.name} with utf-8 encoding") from exc
+        raise FileNotValidError(
+            name=str(file_path.name), message=f"Unable to read {file_path.name} with utf-8 encoding"
+        ) from exc
 
 
 def get_user_permissions(data: list[dict]) -> dict:

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -353,7 +353,7 @@ def write_to_file(path: Path, value: Any) -> bool:
 
 def read_file(file_name: Path) -> str:
     if not file_name.is_file():
-        raise FileNotValidError(name=str(file_name), message=f"{file_name} is not a valid file")
+        raise FileNotValidError(name=str(file_name), message=f"{file_name}: not found at {Path.cwd()}")
     try:
         with Path.open(file_name, encoding="utf-8") as fobj:
             return fobj.read()

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -351,14 +351,14 @@ def write_to_file(path: Path, value: Any) -> bool:
     return written is not None
 
 
-def read_file(file_name: Path) -> str:
-    if not file_name.is_file():
-        raise FileNotValidError(name=str(file_name), message=f"{file_name}: not found at {Path.cwd()}")
+def read_file(file_path: Path) -> str:
+    if not file_path.is_file():
+        raise FileNotValidError(name=str(file_path.name), message=f"{file_path.name}: not found at {file_path.cwd()}")
     try:
-        with Path.open(file_name, encoding="utf-8") as fobj:
+        with Path.open(file_path, encoding="utf-8") as fobj:
             return fobj.read()
     except UnicodeDecodeError as exc:
-        raise FileNotValidError(name=str(file_name), message=f"Unable to read {file_name} with utf-8 encoding") from exc
+        raise FileNotValidError(name=str(file_path.name), message=f"Unable to read {file_path.name} with utf-8 encoding") from exc
 
 
 def get_user_permissions(data: list[dict]) -> dict:

--- a/tests/unit/sdk/test_yaml.py
+++ b/tests/unit/sdk/test_yaml.py
@@ -8,7 +8,7 @@ here = Path(__file__).parent.resolve()
 def test_read_missing_file() -> None:
     file_name = "i_do_not_exist.yml"
     dir = here / "test_data"
-    full_path = dir / filename
+    full_path = dir / file_name
     yaml_file = YamlFile(location=full_path)
     yaml_file.load_content()
     assert not yaml_file.valid

--- a/tests/unit/sdk/test_yaml.py
+++ b/tests/unit/sdk/test_yaml.py
@@ -6,11 +6,13 @@ here = Path(__file__).parent.resolve()
 
 
 def test_read_missing_file() -> None:
-    file = here / "test_data/i_do_not_exist.yml"
-    yaml_file = YamlFile(location=file)
+    file_name = "i_do_not_exist.yml"
+    dir = here / "test_data"
+    full_path = dir / filename
+    yaml_file = YamlFile(location=full_path)
     yaml_file.load_content()
     assert not yaml_file.valid
-    assert yaml_file.error_message == f"{file} is not a valid file"
+    assert yaml_file.error_message == f"{file_name}: not found at {dir}"
 
 
 def test_read_incorrect_encoding() -> None:

--- a/tests/unit/sdk/test_yaml.py
+++ b/tests/unit/sdk/test_yaml.py
@@ -16,11 +16,12 @@ def test_read_missing_file() -> None:
 
 
 def test_read_incorrect_encoding() -> None:
-    file = here / "test_data/schema_encoding_error.yml"
-    yaml_file = YamlFile(location=file)
+    file_name = "schema_encoding_error.yml"
+    full_path = here / "test_data" / file_name
+    yaml_file = YamlFile(location=full_path)
     yaml_file.load_content()
     assert not yaml_file.valid
-    assert yaml_file.error_message == f"Unable to read {file} with utf-8 encoding"
+    assert yaml_file.error_message == f"Unable to read {file_name} with utf-8 encoding"
 
 
 def test_read_multiple_files() -> None:


### PR DESCRIPTION
Previous message implies the file is found but the contents are not valid. Especially when referring to a YAML file.

This adds a clearer message and specifies where the code has looked for the file.

**Example:**

```
> ❯ infrahubctl generator --list 
.infrahub.yml: not found at /that/file/isnt/here
```