### PR TITLE
`infrahubctl check` to find and filter the same as PC checks

### DIFF
--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -157,9 +157,7 @@ async def run_targeted_check(
         )
         check_summary.append(result)
     else:
-        targets = await client.get(
-            kind="CoreGroup", include=["members"], **{"name__value": check_module.definition.targets}
-        )
+        targets = await client.get(kind="CoreGroup", include=["members"], name__value=check_module.definition.targets)
         await targets.members.fetch()
         for member in targets.members.peers:
             check_parameter = {}

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -137,12 +137,10 @@ async def run_targeted_check(
     variables: dict[str, str],
     branch: str | None = None,
 ) -> bool:
-    filters = {}
     identifier = None
     identifier_attribute = None
     # TODO: Does this support multiple parameters and we need make identifiers a dict to iterate over on L166-168?
     for param_key, param_value in check_module.definition.parameters.items():
-        filters[param_value] = check_module.definition.targets
         identifier = param_key
         identifier_attribute = param_value.split("__")[0]
 
@@ -159,7 +157,9 @@ async def run_targeted_check(
         )
         check_summary.append(result)
     else:
-        targets = await client.get(kind="CoreGroup", include=["members"], **filters)
+        targets = await client.get(
+            kind="CoreGroup", include=["members"], **{"name__value": check_module.definition.targets}
+        )
         await targets.members.fetch()
         for member in targets.members.peers:
             check_parameter = {}

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -137,6 +137,7 @@ async def run_targeted_check(
     variables: dict[str, str],
     branch: str | None = None,
 ) -> bool:
+    filters = {"name__value": check_module.definition.targets}
     identifier = None
     identifier_attribute = None
     # TODO: Does this support multiple parameters and we need make identifiers a dict to iterate over on L166-168?
@@ -157,7 +158,7 @@ async def run_targeted_check(
         )
         check_summary.append(result)
     else:
-        targets = await client.get(kind="CoreGroup", include=["members"], name__value=check_module.definition.targets)
+        targets = await client.get(kind="CoreGroup", include=["members"], **filters)
         await targets.members.fetch()
         for member in targets.members.peers:
             check_parameter = {}

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -138,14 +138,13 @@ async def run_targeted_check(
     branch: str | None = None,
 ) -> bool:
     filters = {}
-    param_value = list(check_module.definition.parameters.values())
-    if param_value:
-        filters[param_value[0]] = check_module.definition.targets
-
-    param_key = list(check_module.definition.parameters.keys())
     identifier = None
-    if param_key:
-        identifier = param_key[0]
+    identifier_attribute = None
+    # TODO: Does this support multiple parameters and we need make identifiers a dict to iterate over on L166-168?
+    for param_key, param_value in check_module.definition.parameters.items():
+        filters[param_value] = check_module.definition.targets
+        identifier = param_key
+        identifier_attribute = param_value.split("__")[0]
 
     check_summary: list[bool] = []
     if variables:
@@ -164,8 +163,8 @@ async def run_targeted_check(
         await targets.members.fetch()
         for member in targets.members.peers:
             check_parameter = {}
-            if identifier:
-                attribute = getattr(member.peer, identifier)
+            if identifier and identifier_attribute:
+                attribute = getattr(member.peer, identifier_attribute)
                 check_parameter = {identifier: attribute.value}
             result = await run_check(
                 check_module=check_module,


### PR DESCRIPTION
Fixes #445 
- Iterate over `parameters` defined in a `check_definition` and set the parameters into the GraphQL query properly

1. This code is still somewhat rudimentary and I think we may want to iterate over parameters and change `identifier` to a dictionary with the to be properly passed into the GraphQL to support multiple parameters.