### PR TITLE
Fixes the import path for the Attribute class

### DIFF
--- a/changelog/fixes.attribute_import_path.md
+++ b/changelog/fixes.attribute_import_path.md
@@ -1,0 +1,1 @@
+Fixes the import path of the Attribute class

--- a/infrahub_sdk/node/__init__.py
+++ b/infrahub_sdk/node/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .attribute import Attribute
 from .constants import (
     ARTIFACT_DEFINITION_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE,
     ARTIFACT_FETCH_FEATURE_NOT_SUPPORTED_MESSAGE,
@@ -25,6 +26,7 @@ __all__ = [
     "PROPERTIES_FLAG",
     "PROPERTIES_OBJECT",
     "SAFE_VALUE",
+    "Attribute",
     "InfrahubNode",
     "InfrahubNodeBase",
     "InfrahubNodeSync",


### PR DESCRIPTION
In #409 we have split up the `node.py` file into multiple files.
This created an issue with the import path of the Attribute class.