### PR TITLE
re-allow using RelatedNode as input to cardinality=one rel

### DIFF
--- a/changelog/452.fixed.md
+++ b/changelog/452.fixed.md
@@ -1,0 +1,1 @@
+Re-enable specifying a cardinality-one relationship using a RelatedNode when creating an InfrahubNode

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -506,9 +506,12 @@ class InfrahubNode(InfrahubNodeBase):
             rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
 
             if rel_schema.cardinality == "one":
-                self._relationship_cardinality_one_data[rel_schema.name] = RelatedNode(
-                    name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
-                )
+                if isinstance(rel_data, RelatedNode):
+                    self._relationship_cardinality_one_data[rel_schema.name] = rel_data
+                else:
+                    self._relationship_cardinality_one_data[rel_schema.name] = RelatedNode(
+                        name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
+                    )
             else:
                 self._relationship_cardinality_many_data[rel_schema.name] = RelationshipManager(
                     name=rel_schema.name,
@@ -1079,10 +1082,12 @@ class InfrahubNodeSync(InfrahubNodeBase):
             rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
 
             if rel_schema.cardinality == "one":
-                self._relationship_cardinality_one_data[rel_schema.name] = RelatedNodeSync(
-                    name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
-                )
-
+                if isinstance(rel_data, RelatedNodeSync):
+                    self._relationship_cardinality_one_data[rel_schema.name] = rel_data
+                else:
+                    self._relationship_cardinality_one_data[rel_schema.name] = RelatedNodeSync(
+                        name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
+                    )
             else:
                 self._relationship_cardinality_many_data[rel_schema.name] = RelationshipManagerSync(
                     name=rel_schema.name,

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -501,17 +501,23 @@ class InfrahubNode(InfrahubNodeBase):
 
         return cls(client=client, schema=schema, branch=branch, data=cls._strip_alias(data))
 
-    def _init_relationships(self, data: dict | None = None) -> None:
+    def _init_relationships(self, data: dict | RelatedNode | None = None) -> None:
         for rel_schema in self._schema.relationships:
             rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
 
             if rel_schema.cardinality == "one":
                 if isinstance(rel_data, RelatedNode):
-                    self._relationship_cardinality_one_data[rel_schema.name] = rel_data
-                else:
-                    self._relationship_cardinality_one_data[rel_schema.name] = RelatedNode(
-                        name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
-                    )
+                    peer_id_data: dict[str, Any] | None = {}
+                    if rel_data.id:
+                        peer_id_data["id"] = rel_data.id
+                    if rel_data.hfid:
+                        peer_id_data["hfid"] = rel_data.hfid
+                    if not peer_id_data:
+                        peer_id_data = None
+                    rel_data = peer_id_data
+                self._relationship_cardinality_one_data[rel_schema.name] = RelatedNode(
+                    name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
+                )
             else:
                 self._relationship_cardinality_many_data[rel_schema.name] = RelationshipManager(
                     name=rel_schema.name,

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1090,11 +1090,18 @@ class InfrahubNodeSync(InfrahubNodeBase):
 
             if rel_schema.cardinality == "one":
                 if isinstance(rel_data, RelatedNodeSync):
-                    self._relationship_cardinality_one_data[rel_schema.name] = rel_data
-                else:
-                    self._relationship_cardinality_one_data[rel_schema.name] = RelatedNodeSync(
-                        name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
-                    )
+                    peer_id_data: dict[str, Any] = {}
+                    if rel_data.id:
+                        peer_id_data["id"] = rel_data.id
+                    if rel_data.hfid:
+                        peer_id_data["hfid"] = rel_data.hfid
+                    if peer_id_data:
+                        rel_data = peer_id_data
+                    else:
+                        rel_data = None
+                self._relationship_cardinality_one_data[rel_schema.name] = RelatedNodeSync(
+                    name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
+                )
             else:
                 self._relationship_cardinality_many_data[rel_schema.name] = RelationshipManagerSync(
                     name=rel_schema.name,

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -507,14 +507,15 @@ class InfrahubNode(InfrahubNodeBase):
 
             if rel_schema.cardinality == "one":
                 if isinstance(rel_data, RelatedNode):
-                    peer_id_data: dict[str, Any] | None = {}
+                    peer_id_data: dict[str, Any] = {}
                     if rel_data.id:
                         peer_id_data["id"] = rel_data.id
                     if rel_data.hfid:
                         peer_id_data["hfid"] = rel_data.hfid
-                    if not peer_id_data:
-                        peer_id_data = None
-                    rel_data = peer_id_data
+                    if peer_id_data:
+                        rel_data = peer_id_data
+                    else:
+                        rel_data = None
                 self._relationship_cardinality_one_data[rel_schema.name] = RelatedNode(
                     name=rel_schema.name, branch=self._branch, client=self._client, schema=rel_schema, data=rel_data
                 )

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -74,7 +74,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
     ):
         related_node = car_golf.owner
         node = await client.create(
-            kind=TESTING_CAR, name="Tiguan", color="Black", manufacturer=manufacturer_mercedes.id, owner=related_node
+            kind=TESTING_CAR, name="CoolerTiguan", color="Black", manufacturer=manufacturer_mercedes, owner=related_node
         )
         await node.save()
         assert node.id is not None

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -63,6 +63,27 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         assert node_after.name.value == node.name.value
         assert node_after.manufacturer.peer.id == manufacturer_mercedes.id
 
+    async def test_node_create_with_relationships_using_related_node(
+        self,
+        default_branch: str,
+        client: InfrahubClient,
+        initial_schema: None,
+        manufacturer_mercedes,
+        car_golf,
+        person_joe,
+    ):
+        related_node = car_golf.owner
+        node = await client.create(
+            kind=TESTING_CAR, name="Tiguan", color="Black", manufacturer=manufacturer_mercedes.id, owner=related_node
+        )
+        await node.save()
+        assert node.id is not None
+
+        node_after = await client.get(kind=TESTING_CAR, id=node.id, prefetch_relationships=True)
+        assert node_after.name.value == node.name.value
+        assert node_after.manufacturer.peer.id == manufacturer_mercedes.id
+        assert node_after.owner.peer.id == person_joe.id
+
     async def test_node_update_with_original_data(
         self,
         default_branch: str,

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -74,9 +74,9 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
     ):
         related_node = car_golf.owner
         node = await client.create(
-            kind=TESTING_CAR, name="CoolerTiguan", color="Black", manufacturer=manufacturer_mercedes, owner=related_node
+            kind=TESTING_CAR, name="Tiguan", color="Black", manufacturer=manufacturer_mercedes, owner=related_node
         )
-        await node.save()
+        await node.save(allow_upsert=True)
         assert node.id is not None
 
         node_after = await client.get(kind=TESTING_CAR, id=node.id, prefetch_relationships=True)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -15,6 +15,7 @@ from infrahub_sdk.node import (
     parse_human_friendly_id,
 )
 from infrahub_sdk.node.constants import SAFE_VALUE
+from infrahub_sdk.node.related_node import RelatedNode, RelatedNodeSync
 from infrahub_sdk.schema import GenericSchema, NodeSchemaAPI
 
 if TYPE_CHECKING:
@@ -169,6 +170,50 @@ async def test_init_node_data_user_with_relationships(client, location_schema: N
         "description": {"value": "JFK Airport"},
         "type": {"value": "SITE"},
         "primary_tag": "pppppppp",
+        "tags": [{"id": "aaaaaa"}, {"id": "bbbb"}],
+    }
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data=data)
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
+
+    assert node.name.value == "JFK1"
+    assert node.name.is_protected is None
+    assert node.description.value == "JFK Airport"
+    assert node.type.value == "SITE"
+
+    assert isinstance(node.tags, RelationshipManagerBase)
+    assert len(node.tags.peers) == 2
+    assert isinstance(node.tags.peers[0], RelatedNodeBase)
+    assert isinstance(node.primary_tag, RelatedNodeBase)
+    assert node.primary_tag.id == "pppppppp"
+
+    keys = dir(node)
+    assert "name" in keys
+    assert "type" in keys
+    assert "tags" in keys
+    assert "get_kind" in keys
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_init_node_data_user_with_relationships_using_related_node(
+    client, location_schema: NodeSchemaAPI, client_type
+):
+    rel_schema = location_schema.get_relationship(name="primary_tag")
+    if client_type == "standard":
+        primary_tag = RelatedNode(
+            name="primary_tag", branch="main", client=client, schema=rel_schema, data={"id": "pppppppp"}
+        )
+    else:
+        primary_tag = RelatedNodeSync(
+            name="primary_tag", branch="main", client=client, schema=rel_schema, data={"id": "pppppppp"}
+        )
+
+    data = {
+        "name": {"value": "JFK1"},
+        "description": {"value": "JFK Airport"},
+        "type": {"value": "SITE"},
+        "primary_tag": primary_tag,
         "tags": [{"id": "aaaaaa"}, {"id": "bbbb"}],
     }
     if client_type == "standard":

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -196,17 +196,16 @@ async def test_init_node_data_user_with_relationships(client, location_schema: N
 
 
 @pytest.mark.parametrize("client_type", client_types)
+@pytest.mark.parametrize("rel_data", [{"id": "pppppppp"}, {"hfid": ["pppp", "pppp"]}])
 async def test_init_node_data_user_with_relationships_using_related_node(
-    client, location_schema: NodeSchemaAPI, client_type
+    client, location_schema: NodeSchemaAPI, client_type, rel_data
 ):
     rel_schema = location_schema.get_relationship(name="primary_tag")
     if client_type == "standard":
-        primary_tag = RelatedNode(
-            name="primary_tag", branch="main", client=client, schema=rel_schema, data={"id": "pppppppp"}
-        )
+        primary_tag = RelatedNode(name="primary_tag", branch="main", client=client, schema=rel_schema, data=rel_data)
     else:
         primary_tag = RelatedNodeSync(
-            name="primary_tag", branch="main", client=client, schema=rel_schema, data={"id": "pppppppp"}
+            name="primary_tag", branch="main", client=client, schema=rel_schema, data=rel_data
         )
 
     data = {
@@ -230,7 +229,8 @@ async def test_init_node_data_user_with_relationships_using_related_node(
     assert len(node.tags.peers) == 2
     assert isinstance(node.tags.peers[0], RelatedNodeBase)
     assert isinstance(node.primary_tag, RelatedNodeBase)
-    assert node.primary_tag.id == "pppppppp"
+    assert node.primary_tag.id == rel_data.get("id")
+    assert node.primary_tag.hfid == rel_data.get("hfid")
 
     keys = dir(node)
     assert "name" in keys


### PR DESCRIPTION
fixes #452 

we accidentally included a breaking change in version `1.13.1`. we stopped allowing passing a `RelatedNode` as an input when creating a new `InfrahubNode`. This PR makes that possible again