### PR TITLE
Add setting typename, display_label, and kind if it exists when calling _init_relationships

### DIFF
--- a/changelog/455.fixed.md
+++ b/changelog/455.fixed.md
@@ -1,0 +1,1 @@
+Update InfrahubNode creation to include __typename, display_label, and kind from a RelatedNode

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -507,13 +507,17 @@ class InfrahubNode(InfrahubNodeBase):
 
             if rel_schema.cardinality == "one":
                 if isinstance(rel_data, RelatedNode):
-                    peer_id_data: dict[str, Any] = {}
-                    if rel_data.id:
-                        peer_id_data["id"] = rel_data.id
-                    if rel_data.hfid:
-                        peer_id_data["hfid"] = rel_data.hfid
-                    if rel_data.typename:
-                        peer_id_data["__typename"] = rel_data.typename
+                    peer_id_data: dict[str, Any] = {
+                        key: value
+                        for key, value in (
+                            ("id", rel_data.id),
+                            ("hfid", rel_data.hfid),
+                            ("__typename", rel_data.typename),
+                            ("kind", rel_data.kind),
+                            ("display_label", rel_data.display_label),
+                        )
+                        if value is not None
+                    }
                     if peer_id_data:
                         rel_data = peer_id_data
                     else:
@@ -1092,13 +1096,17 @@ class InfrahubNodeSync(InfrahubNodeBase):
 
             if rel_schema.cardinality == "one":
                 if isinstance(rel_data, RelatedNodeSync):
-                    peer_id_data: dict[str, Any] = {}
-                    if rel_data.id:
-                        peer_id_data["id"] = rel_data.id
-                    if rel_data.hfid:
-                        peer_id_data["hfid"] = rel_data.hfid
-                    if rel_data.typename:
-                        peer_id_data["__typename"] = rel_data.typename
+                    peer_id_data: dict[str, Any] = {
+                        key: value
+                        for key, value in (
+                            ("id", rel_data.id),
+                            ("hfid", rel_data.hfid),
+                            ("__typename", rel_data.typename),
+                            ("kind", rel_data.kind),
+                            ("display_label", rel_data.display_label),
+                        )
+                        if value is not None
+                    }
                     if peer_id_data:
                         rel_data = peer_id_data
                     else:

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -512,6 +512,8 @@ class InfrahubNode(InfrahubNodeBase):
                         peer_id_data["id"] = rel_data.id
                     if rel_data.hfid:
                         peer_id_data["hfid"] = rel_data.hfid
+                    if rel_data.typename:
+                        peer_id_data["__typename"] = rel_data.typename
                     if peer_id_data:
                         rel_data = peer_id_data
                     else:
@@ -1095,6 +1097,8 @@ class InfrahubNodeSync(InfrahubNodeBase):
                         peer_id_data["id"] = rel_data.id
                     if rel_data.hfid:
                         peer_id_data["hfid"] = rel_data.hfid
+                    if rel_data.typename:
+                        peer_id_data["__typename"] = rel_data.typename
                     if peer_id_data:
                         rel_data = peer_id_data
                     else:

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -39,6 +39,7 @@ class RelatedNodeBase:
         self._hfid: list[str] | None = None
         self._display_label: str | None = None
         self._typename: str | None = None
+        self._kind: str | None = None
 
         if isinstance(data, (CoreNodeBase)):
             self._peer = data
@@ -117,6 +118,12 @@ class RelatedNodeBase:
         if self._peer:
             return self._peer.typename
         return self._typename
+
+    @property
+    def kind(self) -> str | None:
+        if self._peer:
+            return self._peer.get_kind()
+        return self._kind
 
     def _generate_input_data(self, allocate_from_pool: bool = False) -> dict[str, Any]:
         data: dict[str, Any] = {}

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -83,7 +83,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         assert node_after.name.value == node.name.value
         assert node_after.manufacturer.peer.id == manufacturer_mercedes.id
         assert node_after.owner.peer.id == person_joe.id
-        assert node_after.owner.peer.__typename == "TestingPerson"
+        assert node_after.owner.peer.typename == "TestingPerson"
 
     async def test_node_update_with_original_data(
         self,

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -83,6 +83,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         assert node_after.name.value == node.name.value
         assert node_after.manufacturer.peer.id == manufacturer_mercedes.id
         assert node_after.owner.peer.id == person_joe.id
+        assert node_after.owner.peer.__typename == "TestingPerson"
 
     async def test_node_update_with_original_data(
         self,

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -196,7 +196,13 @@ async def test_init_node_data_user_with_relationships(client, location_schema: N
 
 
 @pytest.mark.parametrize("client_type", client_types)
-@pytest.mark.parametrize("rel_data", [{"id": "pppppppp"}, {"hfid": ["pppp", "pppp"]}])
+@pytest.mark.parametrize(
+    "rel_data",
+    [
+        {"id": "pppppppp", "__typename": "BuiltinTag"},
+        {"hfid": ["pppp", "pppp"], "display_label": "mmmm", "kind": "BuiltinTag"},
+    ],
+)
 async def test_init_node_data_user_with_relationships_using_related_node(
     client, location_schema: NodeSchemaAPI, client_type, rel_data
 ):
@@ -231,6 +237,9 @@ async def test_init_node_data_user_with_relationships_using_related_node(
     assert isinstance(node.primary_tag, RelatedNodeBase)
     assert node.primary_tag.id == rel_data.get("id")
     assert node.primary_tag.hfid == rel_data.get("hfid")
+    assert node.primary_tag.typename == rel_data.get("__typename")
+    assert node.primary_tag.kind == rel_data.get("kind")
+    assert node.primary_tag.display_label == rel_data.get("display_label")
 
     keys = dir(node)
     assert "name" in keys


### PR DESCRIPTION
Fixes #455 

- We set the `__typename` when relationships are already a RelatedNode as we were omitting it previously so it could not do the lookup of the object in the store.
- also sets `kind` and `display_label` for the peer if it exists on the input `RelatedNode`