### PR TITLE
Fix sync parallel filters

### DIFF
--- a/changelog/fixed.md
+++ b/changelog/fixed.md
@@ -1,0 +1,1 @@
+Fixes using of parallel with filters for Infrahub Client Sync

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -830,7 +830,7 @@ class InfrahubClient(BaseClient):
 
             for page_number in range(1, total_pages + 1):
                 page_offset = (page_number - 1) * pagination_size
-                batch_process.add(task=process_page, page_offset=page_offset, page_number=page_number)
+                batch_process.add(task=process_page, node=node, page_offset=page_offset, page_number=page_number)
 
             async for _, response in batch_process.execute():
                 nodes.extend(response[1]["nodes"])
@@ -1996,7 +1996,7 @@ class InfrahubClientSync(BaseClient):
 
             for page_number in range(1, total_pages + 1):
                 page_offset = (page_number - 1) * pagination_size
-                batch_process.add(task=process_page, page_offset=page_offset, page_number=page_number)
+                batch_process.add(task=process_page, node=node, page_offset=page_offset, page_number=page_number)
 
             for _, response in batch_process.execute():
                 nodes.extend(response[1]["nodes"])

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -830,7 +830,7 @@ class InfrahubClient(BaseClient):
 
             for page_number in range(1, total_pages + 1):
                 page_offset = (page_number - 1) * pagination_size
-                batch_process.add(task=process_page, node=node, page_offset=page_offset, page_number=page_number)
+                batch_process.add(task=process_page, page_offset=page_offset, page_number=page_number)
 
             async for _, response in batch_process.execute():
                 nodes.extend(response[1]["nodes"])
@@ -1946,9 +1946,10 @@ class InfrahubClientSync(BaseClient):
         """
         branch = branch or self.default_branch
         schema = self.schema.get(kind=kind, branch=branch)
-        node = InfrahubNodeSync(client=self, schema=schema, branch=branch)
         if at:
             at = Timestamp(at)
+
+        node = InfrahubNodeSync(client=self, schema=schema, branch=branch)
         filters = kwargs
         pagination_size = self.pagination_size
 
@@ -1995,7 +1996,7 @@ class InfrahubClientSync(BaseClient):
 
             for page_number in range(1, total_pages + 1):
                 page_offset = (page_number - 1) * pagination_size
-                batch_process.add(task=process_page, node=node, page_offset=page_offset, page_number=page_number)
+                batch_process.add(task=process_page, page_offset=page_offset, page_number=page_number)
 
             for _, response in batch_process.execute():
                 nodes.extend(response[1]["nodes"])
@@ -2012,7 +2013,7 @@ class InfrahubClientSync(BaseClient):
 
             while has_remaining_items:
                 page_offset = (page_number - 1) * pagination_size
-                response, process_result = process_page(page_offset, page_number)
+                response, process_result = process_page(page_offset=page_offset, page_number=page_number)
 
                 nodes.extend(process_result["nodes"])
                 related_nodes.extend(process_result["related_nodes"])

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -402,10 +402,10 @@ class InfrahubNodeBase:
         if order:
             data["@filters"]["order"] = order
 
-        if offset:
+        if offset is not None:
             data["@filters"]["offset"] = offset
 
-        if limit:
+        if limit is not None:
             data["@filters"]["limit"] = limit
 
         if include and exclude:


### PR DESCRIPTION
When using the InfrahubClientSync.filters() with `parallel=True`, the pagination was unstable, with some delta returned now and then.

When dumping the queries, every time this issue happens, it seems like we are doing 2 times the 2nd page and not the first one. Forcing offset=0 fixes it.

I am not sure why this issue was not present with the Async Client, considering both of them are using the same `generate_query_data_init()` ...