### PR TITLE
fixed broken link

### DIFF
--- a/docs/docs/python-sdk/guides/resource-manager.mdx
+++ b/docs/docs/python-sdk/guides/resource-manager.mdx
@@ -180,7 +180,7 @@ We will use `allocate_next_ip_address` to allocated an IP address out of the `Co
 
 We provided a data argument to method. This data argument is used to pass attributes and relationships that we want to set on the allocated resource. In this case we are setting to the description of the allocated IP Address.
 
-You can allocate resources in an idempotent way by passing an identifier argument to the allocation method. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [generators](https://github.com/opsmill/infrahub-docs/blob/main/docs/docs/topics/generator.mdx).
+You can allocate resources in an idempotent way by passing an identifier argument to the allocation method. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [generators](https://docs.infrahub.app/topics/generator).
 
 In this example we are executing the `allocate_next_ip_address` method 2 times, using the same identifier.
 

--- a/docs/docs/python-sdk/guides/resource-manager.mdx
+++ b/docs/docs/python-sdk/guides/resource-manager.mdx
@@ -180,7 +180,7 @@ We will use `allocate_next_ip_address` to allocated an IP address out of the `Co
 
 We provided a data argument to method. This data argument is used to pass attributes and relationships that we want to set on the allocated resource. In this case we are setting to the description of the allocated IP Address.
 
-You can allocate resources in an idempotent way by passing an identifier argument to the allocation method. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [generators](https://github.com/opsmill/infrahub-docs/blob/main/docs/docs/topics/generator).
+You can allocate resources in an idempotent way by passing an identifier argument to the allocation method. This identifier links the resource pool with the allocated resource allowing us to create idempotent allocation behavior. This is crucial when you want to allocate resources in an idempotent way using [generators](https://github.com/opsmill/infrahub-docs/blob/main/docs/docs/topics/generator.mdx).
 
 In this example we are executing the `allocate_next_ip_address` method 2 times, using the same identifier.
 


### PR DESCRIPTION
The 'generators' link is missing the extension, so clicking the link from the doc results in a broken page. Quick fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated a hyperlink in the Resource Manager guide to point to the generators topic on the docs site, improving navigation and link accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->