### PR TITLE
fix: improve cardinality many relationship fetch

### DIFF
--- a/infrahub_sdk/node/relationship.py
+++ b/infrahub_sdk/node/relationship.py
@@ -4,8 +4,10 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from ..exceptions import (
+    Error,
     UninitializedError,
 )
+from ..types import Order
 from .constants import PROPERTIES_FLAG, PROPERTIES_OBJECT
 from .related_node import RelatedNode, RelatedNodeSync
 
@@ -156,8 +158,19 @@ class RelationshipManager(RelationshipManagerBase):
             self.peers = rm.peers
             self.initialized = True
 
+        ids_per_kind_map = {}
         for peer in self.peers:
-            await peer.fetch()  # type: ignore[misc]
+            if not peer.id or not peer.typename:
+                raise Error("Unable to fetch the peer, id and/or typename are not defined")
+            if peer.typename not in ids_per_kind_map:
+                ids_per_kind_map[peer.typename] = [peer.id]
+            else:
+                ids_per_kind_map[peer.typename].append(peer.id)
+
+        for kind, ids in ids_per_kind_map.items():
+            await self.client.filters(
+                kind=kind, ids=ids, populate_store=True, branch=self.branch, parallel=True, order=Order(disable=True)
+            )
 
     def add(self, data: str | RelatedNode | dict) -> None:
         """Add a new peer to this relationship."""
@@ -261,8 +274,19 @@ class RelationshipManagerSync(RelationshipManagerBase):
             self.peers = rm.peers
             self.initialized = True
 
+        ids_per_kind_map = {}
         for peer in self.peers:
-            peer.fetch()
+            if not peer.id or not peer.typename:
+                raise Error("Unable to fetch the peer, id and/or typename are not defined")
+            if peer.typename not in ids_per_kind_map:
+                ids_per_kind_map[peer.typename] = [peer.id]
+            else:
+                ids_per_kind_map[peer.typename].append(peer.id)
+
+        for kind, ids in ids_per_kind_map.items():
+            self.client.filters(
+                kind=kind, ids=ids, populate_store=True, branch=self.branch, parallel=True, order=Order(disable=True)
+            )
 
     def add(self, data: str | RelatedNodeSync | dict) -> None:
         """Add a new peer to this relationship."""

--- a/infrahub_sdk/node/relationship.py
+++ b/infrahub_sdk/node/relationship.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -158,7 +159,7 @@ class RelationshipManager(RelationshipManagerBase):
             self.peers = rm.peers
             self.initialized = True
 
-        ids_per_kind_map = {}
+        ids_per_kind_map = defaultdict(list)
         for peer in self.peers:
             if not peer.id or not peer.typename:
                 raise Error("Unable to fetch the peer, id and/or typename are not defined")
@@ -167,10 +168,20 @@ class RelationshipManager(RelationshipManagerBase):
             else:
                 ids_per_kind_map[peer.typename].append(peer.id)
 
+        batch = await self.client.create_batch()
         for kind, ids in ids_per_kind_map.items():
-            await self.client.filters(
-                kind=kind, ids=ids, populate_store=True, branch=self.branch, parallel=True, order=Order(disable=True)
+            batch.add(
+                task=self.client.filters,
+                kind=kind,
+                ids=ids,
+                populate_store=True,
+                branch=self.branch,
+                parallel=True,
+                order=Order(disable=True),
             )
+
+        async for _ in batch.execute():
+            pass
 
     def add(self, data: str | RelatedNode | dict) -> None:
         """Add a new peer to this relationship."""
@@ -274,7 +285,7 @@ class RelationshipManagerSync(RelationshipManagerBase):
             self.peers = rm.peers
             self.initialized = True
 
-        ids_per_kind_map = {}
+        ids_per_kind_map = defaultdict(list)
         for peer in self.peers:
             if not peer.id or not peer.typename:
                 raise Error("Unable to fetch the peer, id and/or typename are not defined")
@@ -283,10 +294,20 @@ class RelationshipManagerSync(RelationshipManagerBase):
             else:
                 ids_per_kind_map[peer.typename].append(peer.id)
 
+        batch = self.client.create_batch()
         for kind, ids in ids_per_kind_map.items():
-            self.client.filters(
-                kind=kind, ids=ids, populate_store=True, branch=self.branch, parallel=True, order=Order(disable=True)
+            batch.add(
+                task=self.client.filters,
+                kind=kind,
+                ids=ids,
+                populate_store=True,
+                branch=self.branch,
+                parallel=True,
+                order=Order(disable=True),
             )
+
+        for _ in batch.execute():
+            pass
 
     def add(self, data: str | RelatedNodeSync | dict) -> None:
         """Add a new peer to this relationship."""

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1886,6 +1886,19 @@ async def test_node_fetch_relationship(
         "data": {
             "BuiltinTag": {
                 "count": 1,
+            }
+        }
+    }
+
+    httpx_mock.add_response(
+        method="POST",
+        json=response2,
+    )
+
+    response3 = {
+        "data": {
+            "BuiltinTag": {
+                "count": 1,
                 "edges": [
                     tag_blue_data,
                 ],
@@ -1895,7 +1908,7 @@ async def test_node_fetch_relationship(
 
     httpx_mock.add_response(
         method="POST",
-        json=response2,
+        json=response3,
         match_headers={"X-Infrahub-Tracker": "query-builtintag-page1"},
     )
 


### PR DESCRIPTION
Fixes #475 

Using plain `filters()` call with a list of ids to fetch is better than sequentially fetching each id.

Using `parallel=False` we get:

```
real    0m17.552s
user    0m2.329s
sys     0m0.061s
```

With `parallel=True` we get:

```
real    0m9.379s
user    0m4.515s
sys     0m0.077s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced data fetching efficiency for relationships by batching requests, resulting in faster loading times when retrieving related items.
* **Bug Fixes**
  * Improved test reliability by refining mocked responses to better simulate data fetching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->