### PR TITLE
Prepare version 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [1.13.4](https://github.com/opsmill/infrahub-sdk-python/tree/v1.13.4) - 2025-07-22
+
+### Fixed
+
+- Fix processing of relationshhip during nodes retrieval using the Sync Client, when prefecthing related_nodes. ([#461](https://github.com/opsmill/infrahub-sdk-python/issues/461))
+- Fix schema loading to ignore non-YAML files in folders. ([#462](https://github.com/opsmill/infrahub-sdk-python/issues/462))
+- Fix ignored node variable in filters(). ([#469](https://github.com/opsmill/infrahub-sdk-python/issues/469))
+- Fix use of parallel with filters for Infrahub Client Sync.
+- Avoid sending empty list to infrahub if no valids schemas are found.
+
 ## [1.13.3](https://github.com/opsmill/infrahub-sdk-python/tree/v1.13.3) - 2025-06-30
 
 ### Fixed

--- a/changelog/461.fixed.md
+++ b/changelog/461.fixed.md
@@ -1,1 +1,0 @@
-Fixes processing of relationshhip during nodes retrieval using the Sync Client, when prefecthing related_nodes.

--- a/changelog/462.fixed.md
+++ b/changelog/462.fixed.md
@@ -1,1 +1,0 @@
-Fixes schema loading to ignore non-YAML files in folders.

--- a/changelog/469.fixed.md
+++ b/changelog/469.fixed.md
@@ -1,1 +1,0 @@
-Fixes ignored node variable in filters().

--- a/changelog/fixed.md
+++ b/changelog/fixed.md
@@ -1,2 +1,0 @@
-Fixes using of parallel with filters for Infrahub Client Sync.
-Avoid sending empty list of schemas to infrahub if no valids schemas are found.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-sdk"
-version = "1.13.3"
+version = "1.13.4"
 description = "Python Client to interact with Infrahub"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected relationship processing during node retrieval with the Sync Client when prefetching related nodes.
  * Schema loading now properly ignores non-YAML files in folders.
  * Fixed an issue with the ignored node variable in filters.
  * Improved handling of parallel execution with filters for the Infrahub Client Sync.
  * Prevented sending empty schema lists to Infrahub when no valid schemas are found.

* **Chores**
  * Updated version to 1.13.4.
  * Updated changelog with latest release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->