### PR TITLE
respect ordering of files when loading

### DIFF
--- a/infrahub_sdk/yaml.py
+++ b/infrahub_sdk/yaml.py
@@ -122,8 +122,6 @@ class YamlFile(LocalFile):
         yaml_files: list[Self] = []
         file_extensions = {".yaml", ".yml", ".json"}  # FIXME: .json is not a YAML file, should be removed
 
-        paths = sorted(paths, key=lambda p: p.name)  # Ensure order when processing paths
-
         for file_path in paths:
             if not file_path.exists():
                 # Check if the provided path exists, relevant for the first call coming from the user
@@ -135,6 +133,7 @@ class YamlFile(LocalFile):
             elif file_path.is_dir():
                 # Introduce recursion to handle sub-folders
                 sub_paths = [Path(sub_file_path) for sub_file_path in file_path.glob("*")]
+                sub_paths = sorted(sub_paths, key=lambda p: p.name)
                 yaml_files.extend(cls.load_from_disk(paths=sub_paths))
             # else: skip non-file, non-dir (e.g., symlink...)
 


### PR DESCRIPTION
always sorting the files alphabetically will cause a problem if a file `a_objects.yml` is dependent on `z_objects.yml`
this update is to only sort files alphabetically if they are in a directory, in which case I think we can assume that order does not matter.
I'm not exactly sure why we need to order files alphabetically at all actually, so maybe the added line is unecessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the order in which files are processed when loading from directories, ensuring subdirectory contents are sorted by filename while leaving the initial input order unchanged. This may affect the sequence in which files are loaded from disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->