### PR TITLE
pass branch into count call

### DIFF
--- a/changelog/+branch-in-count.fixed.md
+++ b/changelog/+branch-in-count.fixed.md
@@ -1,0 +1,1 @@
+Update internal calls to `count` to include the branch parameter so that the query is performed on the correct branch

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -824,7 +824,7 @@ class InfrahubClient(BaseClient):
             nodes = []
             related_nodes = []
             batch_process = await self.create_batch()
-            count = await self.count(kind=schema.kind, partial_match=partial_match, **filters)
+            count = await self.count(kind=schema.kind, branch=branch, partial_match=partial_match, **filters)
             total_pages = (count + pagination_size - 1) // pagination_size
 
             for page_number in range(1, total_pages + 1):
@@ -1989,7 +1989,7 @@ class InfrahubClientSync(BaseClient):
             related_nodes = []
             batch_process = self.create_batch()
 
-            count = self.count(kind=schema.kind, partial_match=partial_match, **filters)
+            count = self.count(kind=schema.kind, branch=branch, partial_match=partial_match, **filters)
             total_pages = (count + pagination_size - 1) // pagination_size
 
             for page_number in range(1, total_pages + 1):


### PR DESCRIPTION
we were missing the `branch` argument here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of node counts during batch processing by ensuring branch context is respected in filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->