### PR TITLE
Rework `get_flat_value` to fix node relationships

### DIFF
--- a/changelog/6882.fixed.md
+++ b/changelog/6882.fixed.md
@@ -1,0 +1,1 @@
+Fix value lookup using a flat notation like `foo__bar__value` with relationships of cardinality one

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1053,7 +1053,7 @@ class InfrahubNode(InfrahubNodeBase):
 
         if rel.cardinality != RelationshipCardinality.ONE:
             raise ValueError(
-                f"Can only look up flat value for relationships of cardinality {RelationshipCardinality.ONE}"
+                f"Can only look up flat value for relationships of cardinality {RelationshipCardinality.ONE.value}"
             )
 
         related_node: RelatedNode = getattr(self, first)
@@ -1679,7 +1679,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
 
         if rel.cardinality != RelationshipCardinality.ONE:
             raise ValueError(
-                f"Can only look up flat value for relationships of cardinality {RelationshipCardinality.ONE}"
+                f"Can only look up flat value for relationships of cardinality {RelationshipCardinality.ONE.value}"
             )
 
         related_node: RelatedNodeSync = getattr(self, first)

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1029,7 +1029,7 @@ class InfrahubNode(InfrahubNodeBase):
         raise ResourceNotDefinedError(message=f"The node doesn't have a cardinality=one relationship for {name}")
 
     async def get_flat_value(self, key: str, separator: str = "__") -> Any:
-        """Query recursively an value defined in a flat notation (string), on a hierarchy of objects
+        """Query recursively a value defined in a flat notation (string), on a hierarchy of objects
 
         Examples:
             name__value
@@ -1053,7 +1053,7 @@ class InfrahubNode(InfrahubNodeBase):
 
         if rel.cardinality != RelationshipCardinality.ONE:
             raise ValueError(
-                f"Unable to lookup flat value for relationship of cardinality {RelationshipCardinality.MANY}"
+                f"Can only look up flat value for relationships of cardinality {RelationshipCardinality.ONE}"
             )
 
         related_node: RelatedNode = getattr(self, first)
@@ -1655,7 +1655,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         raise ResourceNotDefinedError(message=f"The node doesn't have a cardinality=one relationship for {name}")
 
     def get_flat_value(self, key: str, separator: str = "__") -> Any:
-        """Query recursively an value defined in a flat notation (string), on a hierarchy of objects
+        """Query recursively a value defined in a flat notation (string), on a hierarchy of objects
 
         Examples:
             name__value
@@ -1679,7 +1679,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
 
         if rel.cardinality != RelationshipCardinality.ONE:
             raise ValueError(
-                f"Unable to lookup flat value for relationship of cardinality {RelationshipCardinality.MANY}"
+                f"Can only look up flat value for relationships of cardinality {RelationshipCardinality.ONE}"
             )
 
         related_node: RelatedNodeSync = getattr(self, first)

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -8,7 +8,7 @@ from ..constants import InfrahubClientMode
 from ..exceptions import FeatureNotSupportedError, NodeNotFoundError, ResourceNotDefinedError, SchemaNotFoundError
 from ..graphql import Mutation, Query
 from ..schema import GenericSchemaAPI, RelationshipCardinality, RelationshipKind
-from ..utils import compare_lists, generate_short_id, get_flat_value
+from ..utils import compare_lists, generate_short_id
 from .attribute import Attribute
 from .constants import (
     ARTIFACT_DEFINITION_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE,
@@ -417,14 +417,6 @@ class InfrahubNodeBase:
             data["@filters"]["partial_match"] = True
 
         return data
-
-    def extract(self, params: dict[str, str]) -> dict[str, Any]:
-        """Extract some datapoints defined in a flat notation."""
-        result: dict[str, Any] = {}
-        for key, value in params.items():
-            result[key] = get_flat_value(self, key=value)
-
-        return result
 
     def __hash__(self) -> int:
         return hash(self.id)
@@ -1036,6 +1028,46 @@ class InfrahubNode(InfrahubNodeBase):
 
         raise ResourceNotDefinedError(message=f"The node doesn't have a cardinality=one relationship for {name}")
 
+    async def get_flat_value(self, key: str, separator: str = "__") -> Any:
+        """Query recursively an value defined in a flat notation (string), on a hierarchy of objects
+
+        Examples:
+            name__value
+            module.object.value
+        """
+        if separator not in key:
+            return getattr(self, key)
+
+        first, remaining = key.split(separator, maxsplit=1)
+
+        if first in self._schema.attribute_names:
+            attr = getattr(self, first)
+            for part in remaining.split(separator):
+                attr = getattr(attr, part)
+            return attr
+
+        try:
+            rel = self._schema.get_relationship(name=first)
+        except ValueError as exc:
+            raise ValueError(f"No attribute or relationship named '{first}' for '{self._schema.kind}'") from exc
+
+        if rel.cardinality != RelationshipCardinality.ONE:
+            raise ValueError(
+                f"Unable to lookup flat value for relationship of cardinality {RelationshipCardinality.MANY}"
+            )
+
+        related_node: RelatedNode = getattr(self, first)
+        await related_node.fetch()
+        return await related_node.peer.get_flat_value(key=remaining, separator=separator)
+
+    async def extract(self, params: dict[str, str]) -> dict[str, Any]:
+        """Extract some datapoints defined in a flat notation."""
+        result: dict[str, Any] = {}
+        for key, value in params.items():
+            result[key] = await self.get_flat_value(key=value)
+
+        return result
+
     def __dir__(self) -> Iterable[str]:
         base = list(super().__dir__())
         return sorted(
@@ -1621,6 +1653,46 @@ class InfrahubNodeSync(InfrahubNodeBase):
             return self._relationship_cardinality_one_data[name]
 
         raise ResourceNotDefinedError(message=f"The node doesn't have a cardinality=one relationship for {name}")
+
+    def get_flat_value(self, key: str, separator: str = "__") -> Any:
+        """Query recursively an value defined in a flat notation (string), on a hierarchy of objects
+
+        Examples:
+            name__value
+            module.object.value
+        """
+        if separator not in key:
+            return getattr(self, key)
+
+        first, remaining = key.split(separator, maxsplit=1)
+
+        if first in self._schema.attribute_names:
+            attr = getattr(self, first)
+            for part in remaining.split(separator):
+                attr = getattr(attr, part)
+            return attr
+
+        try:
+            rel = self._schema.get_relationship(name=first)
+        except ValueError as exc:
+            raise ValueError(f"No attribute or relationship named '{first}' for '{self._schema.kind}'") from exc
+
+        if rel.cardinality != RelationshipCardinality.ONE:
+            raise ValueError(
+                f"Unable to lookup flat value for relationship of cardinality {RelationshipCardinality.MANY}"
+            )
+
+        related_node: RelatedNodeSync = getattr(self, first)
+        related_node.fetch()
+        return related_node.peer.get_flat_value(key=remaining, separator=separator)
+
+    def extract(self, params: dict[str, str]) -> dict[str, Any]:
+        """Extract some datapoints defined in a flat notation."""
+        result: dict[str, Any] = {}
+        for key, value in params.items():
+            result[key] = self.get_flat_value(key=value)
+
+        return result
 
     def __dir__(self) -> Iterable[str]:
         base = list(super().__dir__())

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -204,8 +204,6 @@ class CoreNodeBase(Protocol):
 
     def get_raw_graphql_data(self) -> dict | None: ...
 
-    def extract(self, params: dict[str, str]) -> dict[str, Any]: ...
-
 
 @runtime_checkable
 class CoreNode(CoreNodeBase, Protocol):

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -190,23 +190,6 @@ def str_to_bool(value: str) -> bool:
         raise ValueError(f"{value} can not be converted into a boolean") from exc
 
 
-def get_flat_value(obj: Any, key: str, separator: str = "__") -> Any:
-    """Query recursively an value defined in a flat notation (string), on a hierarchy of objects
-
-    Examples:
-        name__value
-        module.object.value
-    """
-    if separator not in key:
-        return getattr(obj, key)
-
-    first_part, remaining_part = key.split(separator, maxsplit=1)
-    sub_obj = getattr(obj, first_part)
-    if not sub_obj:
-        return None
-    return get_flat_value(obj=sub_obj, key=remaining_part, separator=separator)
-
-
 def generate_request_filename(request: httpx.Request) -> str:
     """Return a filename for a request sent to the Infrahub API
 

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1947,23 +1947,52 @@ async def test_node_IPNetwork_deserialization(client, ipnetwork_schema, client_t
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_extract(client, location_schema, location_data01, client_type):
+async def test_get_flat_value(
+    httpx_mock: HTTPXMock, mock_schema_query_01, clients, location_schema, location_data01, client_type
+):
+    httpx_mock.add_response(
+        method="POST",
+        json={"data": {"BuiltinTag": {"count": 1, "edges": [location_data01["node"]["primary_tag"]]}}},
+        match_headers={"X-Infrahub-Tracker": "query-builtintag-page1"},
+        is_reusable=True,
+    )
+
     if client_type == "standard":
-        node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
+        tag = InfrahubNode(client=clients.standard, schema=location_schema, data=location_data01)
+        assert await tag.get_flat_value(key="name__value") == "DFW"
+        assert await tag.get_flat_value(key="primary_tag__display_label") == "red"
+        assert await tag.get_flat_value(key="primary_tag.display_label", separator=".") == "red"
+
+        with pytest.raises(ValueError, match="Unable to lookup flat value for relationship of cardinality"):
+            assert await tag.get_flat_value(key="tags__display_label") == "red"
     else:
-        node = InfrahubNodeSync(client=client, schema=location_schema, data=location_data01)
+        tag = InfrahubNodeSync(client=clients.sync, schema=location_schema, data=location_data01)
+        assert tag.get_flat_value(key="name__value") == "DFW"
+        assert tag.get_flat_value(key="primary_tag__display_label") == "red"
+        assert tag.get_flat_value(key="primary_tag.display_label", separator=".") == "red"
 
-    params = {
-        "identifier": "id",
-        "name": "name__value",
-        "description": "description__value",
-    }
+        with pytest.raises(ValueError, match="Unable to lookup flat value for relationship of cardinality"):
+            assert tag.get_flat_value(key="tags__display_label") == "red"
 
-    assert node.extract(params=params) == {
-        "description": None,
-        "identifier": "llllllll-llll-llll-llll-llllllllllll",
-        "name": "DFW",
-    }
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_extract(clients, location_schema, location_data01, client_type):
+    params = {"identifier": "id", "name": "name__value", "description": "description__value"}
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema, data=location_data01)
+        assert await node.extract(params=params) == {
+            "description": None,
+            "identifier": "llllllll-llll-llll-llll-llllllllllll",
+            "name": "DFW",
+        }
+
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema, data=location_data01)
+        assert node.extract(params=params) == {
+            "description": None,
+            "identifier": "llllllll-llll-llll-llll-llllllllllll",
+            "name": "DFW",
+        }
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1963,7 +1963,7 @@ async def test_get_flat_value(
         assert await tag.get_flat_value(key="primary_tag__display_label") == "red"
         assert await tag.get_flat_value(key="primary_tag.display_label", separator=".") == "red"
 
-        with pytest.raises(ValueError, match="Unable to lookup flat value for relationship of cardinality"):
+        with pytest.raises(ValueError, match="Can only look up flat value for relationships of cardinality one"):
             assert await tag.get_flat_value(key="tags__display_label") == "red"
     else:
         tag = InfrahubNodeSync(client=clients.sync, schema=location_schema, data=location_data01)
@@ -1971,7 +1971,7 @@ async def test_get_flat_value(
         assert tag.get_flat_value(key="primary_tag__display_label") == "red"
         assert tag.get_flat_value(key="primary_tag.display_label", separator=".") == "red"
 
-        with pytest.raises(ValueError, match="Unable to lookup flat value for relationship of cardinality"):
+        with pytest.raises(ValueError, match="Can only look up flat value for relationships of cardinality one"):
             assert tag.get_flat_value(key="tags__display_label") == "red"
 
 

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -6,7 +6,6 @@ import pytest
 from graphql import parse
 from whenever import Instant
 
-from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.utils import (
     base16decode,
     base16encode,
@@ -19,7 +18,6 @@ from infrahub_sdk.utils import (
     duplicates,
     extract_fields,
     generate_short_id,
-    get_flat_value,
     is_valid_url,
     is_valid_uuid,
     str_to_bool,
@@ -141,13 +139,6 @@ def test_base16():
     assert base16decode("139b5be157694069") == 1412823931503067241
     assert base16decode(base16encode(-9223372036721928027)) == -9223372036721928027
     assert base16decode(base16encode(1412823931503067241)) == 1412823931503067241
-
-
-def test_get_flat_value(client, tag_schema, tag_green_data):
-    tag = InfrahubNode(client=client, schema=tag_schema, data=tag_green_data)
-    assert get_flat_value(obj=tag, key="name__value") == "green"
-    assert get_flat_value(obj=tag, key="name__source__display_label") == "CRM"
-    assert get_flat_value(obj=tag, key="name.source.display_label", separator=".") == "CRM"
 
 
 def test_dict_hash():


### PR DESCRIPTION
This change moves the `get_flat_value` function to methods of the `InfrahubNode` and `InfrahubNodeSync` classes. This allows to handle traversing relationships of cardinality one using a flat notation in addition to attributes.

The `extract` method has also been moved as it needs to be `async` for regular nodes now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of value lookups using flat notation (e.g., `foo__bar__value`) for relationships with cardinality one, ensuring correct resolution of nested attributes.

* **New Features**
  * Introduced enhanced methods for retrieving and extracting nested values using flat key notation in both asynchronous and synchronous node interfaces.

* **Tests**
  * Updated and expanded tests to separately verify flat value retrieval and extraction, including error handling for invalid lookups.
  * Removed outdated tests related to the previous utility function for flat value extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->