### PR TITLE
Add protocols for Infrahub 1.4

### DIFF
--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -233,6 +233,10 @@ class CoreWebhook(CoreNode):
     validate_certificates: BooleanOptional
 
 
+class CoreWeightedPoolResource(CoreNode):
+    allocation_weight: IntegerOptional
+
+
 class LineageOwner(CoreNode):
     pass
 
@@ -321,6 +325,7 @@ class CoreCheckDefinition(CoreTaskTarget):
 
 
 class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
+    shared_key: StringOptional
     transformation: RelatedNode
 
 
@@ -405,12 +410,12 @@ class CoreGraphQLQueryGroup(CoreGroup):
 
 
 class CoreGroupAction(CoreAction):
-    add_members: Boolean
+    member_action: Dropdown
     group: RelatedNode
 
 
 class CoreGroupTriggerRule(CoreTriggerRule):
-    members_added: Boolean
+    member_update: Dropdown
     group: RelatedNode
 
 
@@ -442,7 +447,7 @@ class CoreNodeTriggerAttributeMatch(CoreNodeTriggerMatch):
 
 class CoreNodeTriggerRelationshipMatch(CoreNodeTriggerMatch):
     relationship_name: String
-    added: Boolean
+    modification_type: Dropdown
     peer: StringOptional
 
 
@@ -457,6 +462,7 @@ class CoreNumberPool(CoreResourcePool, LineageSource):
     node_attribute: String
     start_range: Integer
     end_range: Integer
+    pool_type: Enum
 
 
 class CoreObjectPermission(CoreBasePermission):
@@ -481,7 +487,10 @@ class CoreProposedChange(CoreTaskTarget):
     source_branch: String
     destination_branch: String
     state: Enum
+    is_draft: Boolean
+    total_comments: IntegerOptional
     approved_by: RelationshipManager
+    rejected_by: RelationshipManager
     reviewers: RelationshipManager
     created_by: RelatedNode
     comments: RelationshipManager
@@ -553,6 +562,14 @@ class InternalAccountToken(CoreNode):
     token: String
     expiration: DateTimeOptional
     account: RelatedNode
+
+
+class InternalIPPrefixAvailable(BuiltinIPPrefix):
+    pass
+
+
+class InternalIPRangeAvailable(BuiltinIPAddress):
+    last_address: IPHost
 
 
 class InternalRefreshToken(CoreNode):
@@ -766,6 +783,10 @@ class CoreWebhookSync(CoreNodeSync):
     validate_certificates: BooleanOptional
 
 
+class CoreWeightedPoolResourceSync(CoreNodeSync):
+    allocation_weight: IntegerOptional
+
+
 class LineageOwnerSync(CoreNodeSync):
     pass
 
@@ -854,6 +875,7 @@ class CoreCheckDefinitionSync(CoreTaskTargetSync):
 
 
 class CoreCustomWebhookSync(CoreWebhookSync, CoreTaskTargetSync):
+    shared_key: StringOptional
     transformation: RelatedNodeSync
 
 
@@ -938,12 +960,12 @@ class CoreGraphQLQueryGroupSync(CoreGroupSync):
 
 
 class CoreGroupActionSync(CoreActionSync):
-    add_members: Boolean
+    member_action: Dropdown
     group: RelatedNodeSync
 
 
 class CoreGroupTriggerRuleSync(CoreTriggerRuleSync):
-    members_added: Boolean
+    member_update: Dropdown
     group: RelatedNodeSync
 
 
@@ -975,7 +997,7 @@ class CoreNodeTriggerAttributeMatchSync(CoreNodeTriggerMatchSync):
 
 class CoreNodeTriggerRelationshipMatchSync(CoreNodeTriggerMatchSync):
     relationship_name: String
-    added: Boolean
+    modification_type: Dropdown
     peer: StringOptional
 
 
@@ -990,6 +1012,7 @@ class CoreNumberPoolSync(CoreResourcePoolSync, LineageSourceSync):
     node_attribute: String
     start_range: Integer
     end_range: Integer
+    pool_type: Enum
 
 
 class CoreObjectPermissionSync(CoreBasePermissionSync):
@@ -1014,7 +1037,10 @@ class CoreProposedChangeSync(CoreTaskTargetSync):
     source_branch: String
     destination_branch: String
     state: Enum
+    is_draft: Boolean
+    total_comments: IntegerOptional
     approved_by: RelationshipManagerSync
+    rejected_by: RelationshipManagerSync
     reviewers: RelationshipManagerSync
     created_by: RelatedNodeSync
     comments: RelationshipManagerSync
@@ -1086,6 +1112,14 @@ class InternalAccountTokenSync(CoreNodeSync):
     token: String
     expiration: DateTimeOptional
     account: RelatedNodeSync
+
+
+class InternalIPPrefixAvailableSync(BuiltinIPPrefixSync):
+    pass
+
+
+class InternalIPRangeAvailableSync(BuiltinIPAddressSync):
+    last_address: IPHost
 
 
 class InternalRefreshTokenSync(CoreNodeSync):


### PR DESCRIPTION
Replaces #485 targeting `infrahub-develop` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new resource types for weighted pools and internal IP availability.
  * Added new attributes to support draft status, comment counts, and rejection tracking in proposed changes.
  * Added new enum and dropdown options for more granular control in group actions, trigger rules, and number pools.

* **Enhancements**
  * Extended webhooks with an optional shared key attribute.
  * Improved flexibility by replacing several boolean flags with dropdowns for action and modification types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->