### PR TITLE
Support infrahub.yml or infrahub.yaml configuration files

### DIFF
--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -11,7 +11,6 @@ import typer
 from rich.console import Console
 from rich.logging import RichHandler
 
-from ..ctl import config
 from ..ctl.client import initialize_client
 from ..ctl.exceptions import QueryNotFoundError
 from ..ctl.repository import find_repository_config_file, get_repository_config

--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -14,7 +14,7 @@ from rich.logging import RichHandler
 from ..ctl import config
 from ..ctl.client import initialize_client
 from ..ctl.exceptions import QueryNotFoundError
-from ..ctl.repository import get_repository_config
+from ..ctl.repository import find_repository_config_file, get_repository_config
 from ..ctl.utils import catch_exception, execute_graphql_query
 from ..exceptions import ModuleImportError
 
@@ -59,7 +59,7 @@ def run(
     FORMAT = "%(message)s"
     logging.basicConfig(level=log_level, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
 
-    repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
+    repository_config = get_repository_config(find_repository_config_file())
 
     if list_available:
         list_checks(repository_config=repository_config)

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -20,7 +20,6 @@ from rich.table import Table
 
 from .. import __version__ as sdk_version
 from ..async_typer import AsyncTyper
-from ..ctl import config
 from ..ctl.branch import app as branch_app
 from ..ctl.check import run as run_check
 from ..ctl.client import initialize_client, initialize_client_sync

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -30,7 +30,7 @@ from ..ctl.menu import app as menu_app
 from ..ctl.object import app as object_app
 from ..ctl.render import list_jinja2_transforms, print_template_errors
 from ..ctl.repository import app as repository_app
-from ..ctl.repository import get_repository_config
+from ..ctl.repository import find_repository_config_file, get_repository_config
 from ..ctl.schema import app as schema_app
 from ..ctl.transform import list_transforms
 from ..ctl.utils import (
@@ -260,7 +260,7 @@ async def render(
     """Render a local Jinja2 Transform for debugging purpose."""
 
     variables_dict = parse_cli_vars(variables)
-    repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
+    repository_config = get_repository_config(find_repository_config_file())
 
     if list_available or not transform_name:
         list_jinja2_transforms(config=repository_config)
@@ -270,7 +270,7 @@ async def render(
     try:
         transform_config = repository_config.get_jinja2_transform(name=transform_name)
     except KeyError as exc:
-        console.print(f'[red]Unable to find "{transform_name}" in {config.INFRAHUB_REPO_CONFIG_FILE}')
+        console.print(f'[red]Unable to find "{transform_name}" in repository config file')
         list_jinja2_transforms(config=repository_config)
         raise typer.Exit(1) from exc
 
@@ -310,7 +310,7 @@ def transform(
     """Render a local transform (TransformPython) for debugging purpose."""
 
     variables_dict = parse_cli_vars(variables)
-    repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
+    repository_config = get_repository_config(find_repository_config_file())
 
     if list_available or not transform_name:
         list_transforms(config=repository_config)

--- a/infrahub_sdk/ctl/config.py
+++ b/infrahub_sdk/ctl/config.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 DEFAULT_CONFIG_FILE = "infrahubctl.toml"
 ENVVAR_CONFIG_FILE = "INFRAHUBCTL_CONFIG"
 INFRAHUB_REPO_CONFIG_FILE = ".infrahub.yml"
+INFRAHUB_REPO_CONFIG_FILE_ALT = ".infrahub.yaml"
 
 
 class Settings(BaseSettings):

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional
 import typer
 from rich.console import Console
 
-from ..ctl import config
 from ..ctl.client import initialize_client
 from ..ctl.repository import find_repository_config_file, get_repository_config
 from ..ctl.utils import execute_graphql_query, init_logging, parse_cli_vars

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -8,7 +8,7 @@ from rich.console import Console
 
 from ..ctl import config
 from ..ctl.client import initialize_client
-from ..ctl.repository import get_repository_config
+from ..ctl.repository import find_repository_config_file, get_repository_config
 from ..ctl.utils import execute_graphql_query, init_logging, parse_cli_vars
 from ..exceptions import ModuleImportError
 from ..node import InfrahubNode
@@ -26,7 +26,7 @@ async def run(
     variables: Optional[list[str]] = None,
 ) -> None:
     init_logging(debug=debug)
-    repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
+    repository_config = get_repository_config(find_repository_config_file())
 
     if list_available or not generator_name:
         list_generators(repository_config=repository_config)

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -24,11 +24,49 @@ app = AsyncTyper()
 console = Console()
 
 
+def find_repository_config_file(base_path: Path | None = None) -> Path:
+    """Find the repository config file, checking for both .yml and .yaml extensions.
+
+    Args:
+        base_path: Base directory to search in. If None, uses current directory.
+
+    Returns:
+        Path to the config file.
+
+    Raises:
+        FileNotFoundError: If neither .infrahub.yml nor .infrahub.yaml exists.
+    """
+    if base_path is None:
+        base_path = Path()
+
+    yml_path = base_path / ".infrahub.yml"
+    yaml_path = base_path / ".infrahub.yaml"
+
+    # Prefer .yml if both exist
+    if yml_path.exists():
+        return yml_path
+    if yaml_path.exists():
+        return yaml_path
+    # For backward compatibility, return .yml path for error messages
+    return yml_path
+
+
 def get_repository_config(repo_config_file: Path) -> InfrahubRepositoryConfig:
+    # If the file doesn't exist, try to find it with alternate extension
+    if not repo_config_file.exists():
+        if repo_config_file.name == ".infrahub.yml":
+            alt_path = repo_config_file.parent / ".infrahub.yaml"
+            if alt_path.exists():
+                repo_config_file = alt_path
+        elif repo_config_file.name == ".infrahub.yaml":
+            alt_path = repo_config_file.parent / ".infrahub.yml"
+            if alt_path.exists():
+                repo_config_file = alt_path
+
     try:
         config_file_data = load_repository_config_file(repo_config_file)
     except FileNotFoundError as exc:
-        console.print(f"[red]File not found {exc}")
+        console.print(f"[red]File not found {exc} (also checked for .infrahub.yml and .infrahub.yaml)")
         raise typer.Exit(1) from exc
     except FileNotValidError as exc:
         console.print(f"[red]{exc.message}")

--- a/infrahub_sdk/pytest_plugin/plugin.py
+++ b/infrahub_sdk/pytest_plugin/plugin.py
@@ -9,7 +9,7 @@ from pytest import exit as exit_test
 from .. import InfrahubClientSync
 from ..utils import is_valid_url
 from .loader import InfrahubYamlFile
-from .utils import load_repository_config
+from .utils import find_repository_config_file, load_repository_config
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -18,9 +18,9 @@ def pytest_addoption(parser: Parser) -> None:
         "--infrahub-repo-config",
         action="store",
         dest="infrahub_repo_config",
-        default=".infrahub.yml",
+        default=None,
         metavar="INFRAHUB_REPO_CONFIG_FILE",
-        help="Infrahub configuration file for the repository (default: %(default)s)",
+        help="Infrahub configuration file for the repository (.infrahub.yml or .infrahub.yaml)",
     )
     group.addoption(
         "--infrahub-address",
@@ -63,7 +63,10 @@ def pytest_addoption(parser: Parser) -> None:
 
 
 def pytest_sessionstart(session: Session) -> None:
-    session.infrahub_config_path = Path(session.config.option.infrahub_repo_config)  # type: ignore[attr-defined]
+    if session.config.option.infrahub_repo_config:
+        session.infrahub_config_path = Path(session.config.option.infrahub_repo_config)  # type: ignore[attr-defined]
+    else:
+        session.infrahub_config_path = find_repository_config_file()  # type: ignore[attr-defined]
 
     if session.infrahub_config_path.is_file():  # type: ignore[attr-defined]
         session.infrahub_repo_config = load_repository_config(repo_config_file=session.infrahub_config_path)  # type: ignore[attr-defined]

--- a/infrahub_sdk/pytest_plugin/utils.py
+++ b/infrahub_sdk/pytest_plugin/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import yaml

--- a/infrahub_sdk/pytest_plugin/utils.py
+++ b/infrahub_sdk/pytest_plugin/utils.py
@@ -6,7 +6,45 @@ from ..schema.repository import InfrahubRepositoryConfig
 from .exceptions import FileNotValidError
 
 
+def find_repository_config_file(base_path: Path | None = None) -> Path:
+    """Find the repository config file, checking for both .yml and .yaml extensions.
+
+    Args:
+        base_path: Base directory to search in. If None, uses current directory.
+
+    Returns:
+        Path to the config file.
+
+    Raises:
+        FileNotFoundError: If neither .infrahub.yml nor .infrahub.yaml exists.
+    """
+    if base_path is None:
+        base_path = Path()
+
+    yml_path = base_path / ".infrahub.yml"
+    yaml_path = base_path / ".infrahub.yaml"
+
+    # Prefer .yml if both exist
+    if yml_path.exists():
+        return yml_path
+    if yaml_path.exists():
+        return yaml_path
+    # For backward compatibility, return .yml path for error messages
+    return yml_path
+
+
 def load_repository_config(repo_config_file: Path) -> InfrahubRepositoryConfig:
+    # If the file doesn't exist, try to find it with alternate extension
+    if not repo_config_file.exists():
+        if repo_config_file.name == ".infrahub.yml":
+            alt_path = repo_config_file.parent / ".infrahub.yaml"
+            if alt_path.exists():
+                repo_config_file = alt_path
+        elif repo_config_file.name == ".infrahub.yaml":
+            alt_path = repo_config_file.parent / ".infrahub.yml"
+            if alt_path.exists():
+                repo_config_file = alt_path
+
     if not repo_config_file.is_file():
         raise FileNotFoundError(repo_config_file)
 


### PR DESCRIPTION
- Add find_repository_config_file() function to search for both .yml and .yaml extensions
- Update all modules to use dynamic config file discovery
- Prefer .yml over .yaml when both exist for backward compatibility
- Update pytest plugin to support both extensions
- Improve error messages to mention both possible file extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both `.infrahub.yml` and `.infrahub.yaml` repository configuration files, with automatic detection and preference for `.infrahub.yml` if both exist.
  * Introduced dynamic discovery of repository config file paths across commands and plugins.
  * Improved error messages to reflect checks for both config file extensions.

* **Bug Fixes**
  * Enhanced robustness in loading repository configuration by falling back to alternate file extensions if the initially specified config file is missing.

* **Chores**
  * Updated command-line options and help messages to clarify support for both `.yml` and `.yaml` config file extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->