### PR TITLE
Use correct case for Infrahub

### DIFF
--- a/infrahub_sdk/pytest_plugin/items/graphql_query.py
+++ b/infrahub_sdk/pytest_plugin/items/graphql_query.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 class InfrahubGraphQLQueryItem(InfrahubItem):
     def validate_resource_config(self) -> None:
-        # Resource name does not need to match against infrahub repo config
+        # Resource name does not need to match against Infrahub repository configuration
         return
 
     def execute_query(self) -> Any:

--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -24,7 +24,7 @@ ResourceClass = TypeVar("ResourceClass")
 
 
 class InfrahubRepositoryConfigElement(BaseModel):
-    """Class to regroup all elements of the infrahub configuration for a repository for typing purpose."""
+    """Class to regroup all elements of the Infrahub configuration for a repository for typing purpose."""
 
 
 class InfrahubRepositoryArtifactDefinitionConfig(InfrahubRepositoryConfigElement):

--- a/infrahub_sdk/testing/docker.py
+++ b/infrahub_sdk/testing/docker.py
@@ -13,7 +13,7 @@ INFRAHUB_VERSION = os.getenv("INFRAHUB_TESTING_IMAGE_VER")
 
 def skip_version(min_infrahub_version: str | None = None, max_infrahub_version: str | None = None) -> bool:
     """
-    Check if a test should be skipped depending on infrahub version.
+    Check if a test should be skipped depending on Infrahub version.
     """
     if INFRAHUB_VERSION is None:
         return True

--- a/tests/integration/test_infrahub_client.py
+++ b/tests/integration/test_infrahub_client.py
@@ -65,9 +65,9 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         assert isinstance(nodes[0], InfrahubNode)
         assert [node.name.value for node in nodes] == ["Bella", "Luna"]
 
-    # TODO enable these tests for infrahub version containing this commit
+    # TODO enable these tests for Infrahub version containing this commit
     #  https://github.com/opsmill/infrahub/commit/5a4d6860196b5bfb51fb8a124f33125f4a0b6753
-    #  when we support testing against multiple infrahub versions.
+    #  when we support testing against multiple Infrahub versions.
     # async def test_get_all_no_order(self, client: InfrahubClient, base_dataset):
     #     nodes = await client.all(kind=TESTING_CAT, order=Order(disable=True))
     #     assert len(nodes) == 2


### PR DESCRIPTION
This is mostly to get rid of annoying warnings in my editor..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Standardized capitalization to “Infrahub” across SDK docstrings and inline comments.
  - Clarified wording in a validation comment for repository configuration.
  - Updated wording in testing utilities docstrings for consistency.

- Tests
  - Adjusted comment capitalization in integration tests to match terminology standards.

- Style
  - Minor text-only edits; no behavioral or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->