### PR TITLE
Auto fix return type None for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def event_loop():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def execute_before_any_test():
+def execute_before_any_test() -> None:
     config.SETTINGS.load_and_exit()
     config.SETTINGS.active.server_address = "http://mock"
 

--- a/tests/integration/test_infrahub_client.py
+++ b/tests/integration/test_infrahub_client.py
@@ -29,7 +29,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         cat_bella,
         dog_daisy,
         dog_rocky,
-    ):
+    ) -> None:
         await client.branch.create(branch_name="branch01")
 
     @pytest.fixture
@@ -39,7 +39,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         yield
         client.pagination_size = original_pagination_size
 
-    async def test_query_branches(self, client: InfrahubClient, base_dataset):
+    async def test_query_branches(self, client: InfrahubClient, base_dataset) -> None:
         branches = await client.branch.all()
         main = await client.branch.get(branch_name="main")
 
@@ -50,7 +50,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         assert "main" in branches
         assert "branch01" in branches
 
-    async def test_branch_delete(self, client: InfrahubClient, base_dataset):
+    async def test_branch_delete(self, client: InfrahubClient, base_dataset) -> None:
         async_branch = "async-delete-branch"
         await client.branch.create(branch_name=async_branch)
         pre_delete = await client.branch.all()
@@ -59,7 +59,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         assert async_branch in pre_delete.keys()
         assert async_branch not in post_delete.keys()
 
-    async def test_get_all(self, client: InfrahubClient, base_dataset):
+    async def test_get_all(self, client: InfrahubClient, base_dataset) -> None:
         nodes = await client.all(kind=TESTING_CAT)
         assert len(nodes) == 2
         assert isinstance(nodes[0], InfrahubNode)
@@ -80,7 +80,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
     #     assert isinstance(nodes[0], InfrahubNode)
     #     assert {node.name.value for node in nodes} == {"Bella", "Luna"}
 
-    async def test_get_one(self, client: InfrahubClient, base_dataset, cat_luna, person_sophia):
+    async def test_get_one(self, client: InfrahubClient, base_dataset, cat_luna, person_sophia) -> None:
         node1 = await client.get(kind=TESTING_CAT, id=cat_luna.id)
         assert isinstance(node1, InfrahubNode)
         assert node1.name.value == "Luna"
@@ -89,7 +89,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         assert isinstance(node2, InfrahubNode)
         assert node2.name.value == "Sophia Walker"
 
-    async def test_filters_partial_match(self, client: InfrahubClient, base_dataset):
+    async def test_filters_partial_match(self, client: InfrahubClient, base_dataset) -> None:
         nodes = await client.filters(kind=TESTING_PERSON, name__value="Walker")
         assert not nodes
 
@@ -98,17 +98,17 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         assert isinstance(nodes[0], InfrahubNode)
         assert sorted([node.name.value for node in nodes]) == ["Liam Walker", "Sophia Walker"]
 
-    async def test_get_generic(self, client: InfrahubClient, base_dataset):
+    async def test_get_generic(self, client: InfrahubClient, base_dataset) -> None:
         nodes = await client.all(kind=TESTING_ANIMAL)
         assert len(nodes) == 4
 
-    async def test_get_generic_fragment(self, client: InfrahubClient, base_dataset):
+    async def test_get_generic_fragment(self, client: InfrahubClient, base_dataset) -> None:
         nodes = await client.all(kind=TESTING_ANIMAL, fragment=True)
         assert len(nodes)
         assert nodes[0].typename in [TESTING_DOG, TESTING_CAT]
         assert nodes[0].breed.value is not None
 
-    async def test_get_related_nodes(self, client: InfrahubClient, base_dataset, person_ethan):
+    async def test_get_related_nodes(self, client: InfrahubClient, base_dataset, person_ethan) -> None:
         ethan = await client.get(kind=TESTING_PERSON, id=person_ethan.id)
         assert ethan
 
@@ -116,7 +116,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         await ethan.animals.fetch()
         assert len(ethan.animals.peers) == 3
 
-    async def test_profile(self, client: InfrahubClient, base_dataset, person_liam):
+    async def test_profile(self, client: InfrahubClient, base_dataset, person_liam) -> None:
         profile_schema_kind = f"Profile{TESTING_DOG}"
         profile_schema = await client.schema.get(kind=profile_schema_kind)
         assert isinstance(profile_schema, ProfileSchemaAPI)
@@ -137,30 +137,30 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         obj1 = await client.get(kind=TESTING_DOG, id=obj.id)
         assert obj1.color.value == "#111111"
 
-    async def test_create_branch(self, client: InfrahubClient, base_dataset):
+    async def test_create_branch(self, client: InfrahubClient, base_dataset) -> None:
         branch = await client.branch.create(branch_name="new-branch-1")
         assert isinstance(branch, BranchData)
         assert branch.id is not None
 
-    async def test_create_branch_async(self, client: InfrahubClient, base_dataset):
+    async def test_create_branch_async(self, client: InfrahubClient, base_dataset) -> None:
         task_id = await client.branch.create(branch_name="new-branch-2", wait_until_completion=False)
         assert isinstance(task_id, str)
 
-    async def test_count(self, client: InfrahubClient, base_dataset):
+    async def test_count(self, client: InfrahubClient, base_dataset) -> None:
         count = await client.count(kind=TESTING_PERSON)
         assert count == 3
 
-    async def test_count_with_filter(self, client: InfrahubClient, base_dataset):
+    async def test_count_with_filter(self, client: InfrahubClient, base_dataset) -> None:
         count = await client.count(kind=TESTING_PERSON, name__values=["Liam Walker", "Ethan Carter"])
         assert count == 2
 
-    async def test_query_unexisting_branch(self, client: InfrahubClient):
+    async def test_query_unexisting_branch(self, client: InfrahubClient) -> None:
         with pytest.raises(URLNotFoundError, match=r"/graphql/unexisting` not found."):
             await client.execute_graphql(query="unused", branch_name="unexisting")
 
     async def test_create_generic_rel_with_hfid(
         self, client: InfrahubClient, base_dataset, cat_luna, person_sophia, schema_animal, schema_cat
-    ):
+    ) -> None:
         # See https://github.com/opsmill/infrahub-sdk-python/issues/277
         assert schema_animal.human_friendly_id != schema_cat.human_friendly_id, (
             "Inherited node schema should have a different hfid than generic one for this test to be relevant"
@@ -170,7 +170,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         person_sophia = await client.get(kind=TESTING_PERSON, id=person_sophia.id, prefetch_relationships=True)
         assert person_sophia.favorite_animal.id == cat_luna.id
 
-    async def test_task_query(self, client: InfrahubClient, base_dataset, set_pagination_size3):
+    async def test_task_query(self, client: InfrahubClient, base_dataset, set_pagination_size3) -> None:
         nbr_tasks = await client.task.count()
         assert nbr_tasks
 

--- a/tests/integration/test_infrahubctl.py
+++ b/tests/integration/test_infrahubctl.py
@@ -42,7 +42,7 @@ class TestInfrahubCtl(TestInfrahubDockerClient, SchemaAnimal):
         dog_daisy,
         dog_rocky,
         ctl_client_config,
-    ):
+    ) -> None:
         await client.branch.create(branch_name="branch01")
 
     @pytest.fixture(scope="class")

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -20,7 +20,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
 
     async def test_node_create(
         self, client: InfrahubClient, initial_schema: None, schema_manufacturer_base: NodeSchema
-    ):
+    ) -> None:
         schema_manufacturer = NodeSchemaAPI(**schema_manufacturer_base.model_dump(exclude_unset=True))
         data = {
             "name": "Fiat",
@@ -34,7 +34,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         self,
         client: InfrahubClient,
         initial_schema: None,
-    ):
+    ) -> None:
         obj = await client.create(kind=TESTING_MANUFACTURER, name="Dacia")
         await obj.save()
 
@@ -52,7 +52,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         initial_schema: None,
         manufacturer_mercedes,
         person_joe,
-    ):
+    ) -> None:
         node = await client.create(
             kind=TESTING_CAR, name="Tiguan", color="Black", manufacturer=manufacturer_mercedes.id, owner=person_joe.id
         )
@@ -71,7 +71,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         manufacturer_mercedes,
         car_golf,
         person_joe,
-    ):
+    ) -> None:
         related_node = car_golf.owner
         node = await client.create(
             kind=TESTING_CAR, name="Tiguan", color="Black", manufacturer=manufacturer_mercedes, owner=related_node
@@ -90,7 +90,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         default_branch: str,
         client: InfrahubClient,
         initial_schema: None,
-    ):
+    ) -> None:
         person_marina = await client.create(kind="TestingPerson", name="marina", age=20)
         await person_marina.save()
 
@@ -183,7 +183,7 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         tag_blue,
         tag_red,
         tag_green,
-    ):
+    ) -> None:
         car_golf.color.value = "White"
         await car_golf.tags.fetch()
         car_golf.tags.add(tag_blue.id)

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class TestInfrahubRepository(TestInfrahubDockerClient):
-    async def test_add_repository(self, client: InfrahubClient, remote_repos_dir):
+    async def test_add_repository(self, client: InfrahubClient, remote_repos_dir) -> None:
         src_directory = get_fixtures_dir() / "integration/mock_repo"
         repo = GitRepo(name="mock_repo", src_directory=src_directory, dst_directory=remote_repos_dir)
         commit = repo._repo.git[repo._repo.git.head()]

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -15,7 +15,7 @@ from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 #
 #
 class TestInfrahubSchema(TestInfrahubDockerClient):
-    async def test_query_schema_for_branch_not_found(self, client: InfrahubClient):
+    async def test_query_schema_for_branch_not_found(self, client: InfrahubClient) -> None:
         with pytest.raises(BranchNotFoundError) as exc:
             await client.all(kind="BuiltinTag", branch="I-do-not-exist")
 

--- a/tests/integration/test_spec_object.py
+++ b/tests/integration/test_spec_object.py
@@ -24,7 +24,7 @@ def load_menu_file(name: str) -> MenuFile:
     return files[0]
 
 
-def test_load_nested_folders_order():
+def test_load_nested_folders_order() -> None:
     files = YamlFile.load_from_disk(paths=[get_fixtures_dir() / "nested_spec_objects"])
     assert len(files) == 6
     assert Path(files[0].location).name == "3_file.yml"
@@ -53,10 +53,10 @@ class TestSpecObject(TestInfrahubDockerClient, SchemaAnimal):
         )
         assert resp.errors == {}
 
-    async def test_create_branch(self, client: InfrahubClient, initial_schema: None, branch_name: str):
+    async def test_create_branch(self, client: InfrahubClient, initial_schema: None, branch_name: str) -> None:
         await client.branch.create(branch_name=branch_name, sync_with_git=False)
 
-    async def test_load_tags(self, client: InfrahubClient, branch_name: str, initial_schema: None):
+    async def test_load_tags(self, client: InfrahubClient, branch_name: str, initial_schema: None) -> None:
         obj_file = load_object_file("animal_tags01.yml")
         await obj_file.validate_format(client=client, branch=branch_name)
 
@@ -67,7 +67,7 @@ class TestSpecObject(TestInfrahubDockerClient, SchemaAnimal):
 
         assert len(await client.all(kind=obj_file.spec.kind, branch=branch_name)) == 3
 
-    async def test_update_tags(self, client: InfrahubClient, branch_name: str, initial_schema: None):
+    async def test_update_tags(self, client: InfrahubClient, branch_name: str, initial_schema: None) -> None:
         obj_file = load_object_file("animal_tags02.yml")
         await obj_file.validate_format(client=client, branch=branch_name)
 
@@ -81,7 +81,7 @@ class TestSpecObject(TestInfrahubDockerClient, SchemaAnimal):
         assert len(tags_by_name) == 4
         assert tags_by_name["Veterinarian"].description.value == "Licensed animal healthcare professional"
 
-    async def test_load_persons(self, client: InfrahubClient, branch_name: str, initial_schema: None):
+    async def test_load_persons(self, client: InfrahubClient, branch_name: str, initial_schema: None) -> None:
         obj_file = load_object_file("animal_person01.yml")
         await obj_file.validate_format(client=client, branch=branch_name)
 
@@ -92,7 +92,7 @@ class TestSpecObject(TestInfrahubDockerClient, SchemaAnimal):
 
         assert len(await client.all(kind=obj_file.spec.kind, branch=branch_name)) == 3
 
-    async def test_load_dogs(self, client: InfrahubClient, branch_name: str, initial_schema: None):
+    async def test_load_dogs(self, client: InfrahubClient, branch_name: str, initial_schema: None) -> None:
         obj_file = load_object_file("animal_dog01.yml")
         await obj_file.validate_format(client=client, branch=branch_name)
 
@@ -103,7 +103,7 @@ class TestSpecObject(TestInfrahubDockerClient, SchemaAnimal):
 
         assert len(await client.all(kind=obj_file.spec.kind, branch=branch_name)) == 4
 
-    async def test_load_persons02(self, client: InfrahubClient, branch_name: str, initial_schema: None):
+    async def test_load_persons02(self, client: InfrahubClient, branch_name: str, initial_schema: None) -> None:
         obj_file = load_object_file("animal_person02.yml")
         await obj_file.validate_format(client=client, branch=branch_name)
 
@@ -135,7 +135,7 @@ class TestSpecObject(TestInfrahubDockerClient, SchemaAnimal):
         animals_emily = [animal.display_label for animal in person_by_name["Emily Parker"].animals.peers]
         assert sorted(animals_emily) == sorted(["Max Golden Retriever", "Whiskers Siamese #FFD700"])
 
-    async def test_load_menu(self, client: InfrahubClient, branch_name: str, initial_schema: None):
+    async def test_load_menu(self, client: InfrahubClient, branch_name: str, initial_schema: None) -> None:
         menu_file = load_menu_file("animal_menu01.yml")
         await menu_file.validate_format(client=client, branch=branch_name)
 

--- a/tests/unit/ctl/test_branch_app.py
+++ b/tests/unit/ctl/test_branch_app.py
@@ -6,13 +6,13 @@ from infrahub_sdk.ctl.branch import app
 runner = CliRunner()
 
 
-def test_branch_list(mock_branches_list_query):
+def test_branch_list(mock_branches_list_query) -> None:
     result = runner.invoke(app=app, args=["list"])
     assert result.exit_code == 0
     assert "cr1234" in result.stdout
 
 
-def test_branch_create_no_auth(httpx_mock: HTTPXMock, authentication_error_payload):
+def test_branch_create_no_auth(httpx_mock: HTTPXMock, authentication_error_payload) -> None:
     httpx_mock.add_response(
         status_code=401,
         method="POST",
@@ -24,7 +24,7 @@ def test_branch_create_no_auth(httpx_mock: HTTPXMock, authentication_error_paylo
     assert "Authentication is required" in result.stdout
 
 
-def test_branch_create_wrong_name(mock_branch_create_error):
+def test_branch_create_wrong_name(mock_branch_create_error) -> None:
     result = runner.invoke(app=app, args=["create", "branch2"])
 
     assert result.exit_code == 1

--- a/tests/unit/ctl/test_cli.py
+++ b/tests/unit/ctl/test_cli.py
@@ -8,44 +8,44 @@ runner = CliRunner()
 pytestmark = pytest.mark.httpx_mock(can_send_already_matched_responses=True)
 
 
-def test_main_app():
+def test_main_app() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout
 
 
-def test_validate_all_commands_have_names():
+def test_validate_all_commands_have_names() -> None:
     assert app.registered_commands
     for command in app.registered_commands:
         assert command.name
 
 
-def test_validate_all_groups_have_names():
+def test_validate_all_groups_have_names() -> None:
     assert app.registered_groups
     for group in app.registered_groups:
         assert group.name
 
 
-def test_version_command():
+def test_version_command() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert "Python SDK: v" in result.stdout
 
 
-def test_info_command_success(mock_query_infrahub_version, mock_query_infrahub_user):
+def test_info_command_success(mock_query_infrahub_version, mock_query_infrahub_user) -> None:
     result = runner.invoke(app, ["info"])
     assert result.exit_code == 0
     for expected in ["Connection Status", "Python Version", "SDK Version", "Infrahub Version"]:
         assert expected in result.stdout, f"'{expected}' not found in info command output"
 
 
-def test_info_command_failure():
+def test_info_command_failure() -> None:
     result = runner.invoke(app, ["info"])
     assert result.exit_code == 0
     assert "Connection Error" in result.stdout
 
 
-def test_info_detail_command_success(mock_query_infrahub_version, mock_query_infrahub_user):
+def test_info_detail_command_success(mock_query_infrahub_version, mock_query_infrahub_user) -> None:
     result = runner.invoke(app, ["info", "--detail"])
     assert result.exit_code == 0
     for expected in [
@@ -58,7 +58,7 @@ def test_info_detail_command_success(mock_query_infrahub_version, mock_query_inf
         assert expected in result.stdout, f"'{expected}' not found in detailed info command output"
 
 
-def test_info_detail_command_failure():
+def test_info_detail_command_failure() -> None:
     result = runner.invoke(app, ["info", "--detail"])
     assert result.exit_code == 0
     assert "Error Reason" in result.stdout

--- a/tests/unit/ctl/test_schema_app.py
+++ b/tests/unit/ctl/test_schema_app.py
@@ -9,7 +9,7 @@ from tests.helpers.cli import remove_ansi_color
 runner = CliRunner()
 
 
-def test_schema_load_empty(httpx_mock: HTTPXMock):
+def test_schema_load_empty(httpx_mock: HTTPXMock) -> None:
     fixture_file = get_fixtures_dir() / "models" / "empty.json"
     result = runner.invoke(app=app, args=["load", str(fixture_file)])
 
@@ -17,7 +17,7 @@ def test_schema_load_empty(httpx_mock: HTTPXMock):
     assert "Invalid YAML/JSON file" in result.stdout
 
 
-def test_schema_load_one_valid(httpx_mock: HTTPXMock):
+def test_schema_load_one_valid(httpx_mock: HTTPXMock) -> None:
     fixture_file = get_fixtures_dir() / "models" / "valid_model_01.json"
 
     httpx_mock.add_response(
@@ -48,7 +48,7 @@ def test_schema_load_one_valid(httpx_mock: HTTPXMock):
     assert content_json == {"schemas": [fixture_file_content]}
 
 
-def test_schema_load_multiple(httpx_mock: HTTPXMock):
+def test_schema_load_multiple(httpx_mock: HTTPXMock) -> None:
     fixture_file1 = get_fixtures_dir() / "models" / "valid_schemas" / "contract.yml"
     fixture_file2 = get_fixtures_dir() / "models" / "valid_schemas" / "rack.yml"
 
@@ -81,7 +81,7 @@ def test_schema_load_multiple(httpx_mock: HTTPXMock):
     assert content_json == {"schemas": [fixture_file1_content, fixture_file2_content]}
 
 
-def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock):
+def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock) -> None:
     fixture_file = get_fixtures_dir() / "models" / "non_valid_namespace.json"
 
     httpx_mock.add_response(

--- a/tests/unit/ctl/test_validate_app.py
+++ b/tests/unit/ctl/test_validate_app.py
@@ -8,7 +8,7 @@ from tests.helpers.cli import remove_ansi_color
 runner = CliRunner()
 
 
-def test_validate_schema_valid():
+def test_validate_schema_valid() -> None:
     fixture_file = get_fixtures_dir() / "models" / "valid_model_01.json"
 
     result = runner.invoke(app=app, args=["schema", str(fixture_file)])
@@ -16,7 +16,7 @@ def test_validate_schema_valid():
     assert "Schema is valid" in result.stdout
 
 
-def test_validate_schema_empty():
+def test_validate_schema_empty() -> None:
     fixture_file = get_fixtures_dir() / "models" / "empty.json"
 
     result = runner.invoke(app=app, args=["schema", str(fixture_file)])
@@ -24,7 +24,7 @@ def test_validate_schema_empty():
     assert "Invalid YAML/JSON file" in remove_ansi_color(result.stdout)
 
 
-def test_validate_schema_non_valid():
+def test_validate_schema_non_valid() -> None:
     fixture_file = get_fixtures_dir() / "models" / "non_valid_model_01.json"
 
     result = runner.invoke(app=app, args=["schema", str(fixture_file)])
@@ -33,7 +33,7 @@ def test_validate_schema_non_valid():
 
 
 @pytest.mark.xfail(reason="FIXME: Currently not catching the proper exception")
-def test_validate_schema_json_non_valid():
+def test_validate_schema_json_non_valid() -> None:
     fixture_file = get_fixtures_dir() / "models" / "non_valid_json_01.json"
 
     result = runner.invoke(app=app, args=["schema", str(fixture_file)])

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -1,16 +1,16 @@
-def test_help_message(pytester):
+def test_help_message(pytester) -> None:
     """Make sure that the plugin is loaded by capturing an option it adds in the help message."""
     result = pytester.runpytest("--help")
     result.stdout.fnmatch_lines(["*Infrahub configuration file for the repository*"])
 
 
-def test_without_config(pytester):
+def test_without_config(pytester) -> None:
     """Make sure 0 tests run when test file is not found."""
     result = pytester.runpytest()
     result.assert_outcomes()
 
 
-def test_emptyconfig(pytester):
+def test_emptyconfig(pytester) -> None:
     """Make sure that the plugin load the test file properly."""
     pytester.makefile(
         ".yml",
@@ -25,7 +25,7 @@ def test_emptyconfig(pytester):
     result.assert_outcomes()
 
 
-def test_jinja2_transform_config_missing_directory(pytester):
+def test_jinja2_transform_config_missing_directory(pytester) -> None:
     """Make sure tests raise errors if directories are not found."""
     pytester.makefile(
         ".yml",
@@ -63,7 +63,7 @@ def test_jinja2_transform_config_missing_directory(pytester):
     result.assert_outcomes(errors=1)
 
 
-def test_jinja2_transform_config_missing_input(pytester):
+def test_jinja2_transform_config_missing_input(pytester) -> None:
     """Make sure tests raise errors if no inputs are provided."""
     pytester.makefile(
         ".yml",
@@ -104,7 +104,7 @@ def test_jinja2_transform_config_missing_input(pytester):
     result.assert_outcomes(errors=1)
 
 
-def test_jinja2_transform_no_expected_output(pytester):
+def test_jinja2_transform_no_expected_output(pytester) -> None:
     """Make sure tests succeed if no expect outputs are provided."""
     pytester.makefile(
         ".yml",
@@ -161,7 +161,7 @@ def test_jinja2_transform_no_expected_output(pytester):
     result.assert_outcomes(passed=1)
 
 
-def test_jinja2_transform_unexpected_output(pytester):
+def test_jinja2_transform_unexpected_output(pytester) -> None:
     """Make sure tests fail if the expected and computed outputs don't match."""
     pytester.makefile(
         ".yml",
@@ -233,7 +233,7 @@ def test_jinja2_transform_unexpected_output(pytester):
     result.assert_outcomes(failed=1)
 
 
-def test_python_transform(pytester):
+def test_python_transform(pytester) -> None:
     pytester.makefile(
         ".yml",
         test_python_transform="""

--- a/tests/unit/sdk/checks/test_checks.py
+++ b/tests/unit/sdk/checks/test_checks.py
@@ -6,7 +6,7 @@ from infrahub_sdk.checks import InfrahubCheck
 pytestmark = pytest.mark.httpx_mock(can_send_already_matched_responses=True)
 
 
-async def test_class_init():
+async def test_class_init() -> None:
     class IFCheckNoQuery(InfrahubCheck):
         pass
 
@@ -34,7 +34,7 @@ async def test_class_init():
     assert check.root_directory == "/tmp"
 
 
-async def test_async_init(client):
+async def test_async_init(client) -> None:
     class IFCheck(InfrahubCheck):
         query = "my_query"
 
@@ -42,7 +42,7 @@ async def test_async_init(client):
     assert isinstance(check.client, InfrahubClient)
 
 
-async def test_validate_sync_async(mock_gql_query_my_query):
+async def test_validate_sync_async(mock_gql_query_my_query) -> None:
     class IFCheckAsync(InfrahubCheck):
         query = "my_query"
 

--- a/tests/unit/sdk/spec/test_object.py
+++ b/tests/unit/sdk/spec/test_object.py
@@ -43,7 +43,7 @@ def location_bad_syntax02(root_location: dict) -> dict:
     return location
 
 
-async def test_validate_object(client: InfrahubClient, mock_schema_query_01: HTTPXMock, location_mexico_01):
+async def test_validate_object(client: InfrahubClient, mock_schema_query_01: HTTPXMock, location_mexico_01) -> None:
     obj = ObjectFile(location="some/path", content=location_mexico_01)
     await obj.validate_format(client=client)
 
@@ -52,7 +52,7 @@ async def test_validate_object(client: InfrahubClient, mock_schema_query_01: HTT
 
 async def test_validate_object_bad_syntax01(
     client: InfrahubClient, mock_schema_query_01: HTTPXMock, location_bad_syntax01
-):
+) -> None:
     obj = ObjectFile(location="some/path", content=location_bad_syntax01)
     with pytest.raises(ValidationError) as exc:
         await obj.validate_format(client=client)
@@ -62,7 +62,7 @@ async def test_validate_object_bad_syntax01(
 
 async def test_validate_object_bad_syntax02(
     client: InfrahubClient, mock_schema_query_01: HTTPXMock, location_bad_syntax02
-):
+) -> None:
     obj = ObjectFile(location="some/path", content=location_bad_syntax02)
     with pytest.raises(ValidationError) as exc:
         await obj.validate_format(client=client)
@@ -116,7 +116,7 @@ async def test_get_relationship_info_tags(
     data: dict | list,
     is_valid: bool,
     format: RelationshipDataFormat,
-):
+) -> None:
     location_schema = await client.schema.get(kind="BuiltinLocation")
 
     rel_info = await get_relationship_info(client, location_schema, "tags", data)

--- a/tests/unit/sdk/test_artifact.py
+++ b/tests/unit/sdk/test_artifact.py
@@ -7,7 +7,9 @@ client_types = ["standard", "sync"]
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_artifact_generate_raise_featurenotsupported(client, client_type, location_schema, location_data01):
+async def test_node_artifact_generate_raise_featurenotsupported(
+    client, client_type, location_schema, location_data01
+) -> None:
     # node does not inherit from CoreArtifactTarget
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
@@ -20,7 +22,9 @@ async def test_node_artifact_generate_raise_featurenotsupported(client, client_t
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_artifact_fetch_raise_featurenotsupported(client, client_type, location_schema, location_data01):
+async def test_node_artifact_fetch_raise_featurenotsupported(
+    client, client_type, location_schema, location_data01
+) -> None:
     # node does not inherit from CoreArtifactTarget
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
@@ -33,7 +37,7 @@ async def test_node_artifact_fetch_raise_featurenotsupported(client, client_type
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_generate_raise_featurenotsupported(client, client_type, location_schema, location_data01):
+async def test_node_generate_raise_featurenotsupported(client, client_type, location_schema, location_data01) -> None:
     # node not of kind CoreArtifactDefinition
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
@@ -52,7 +56,7 @@ async def test_node_artifact_definition_generate(
     mock_rest_api_artifact_definition_generate,
     artifact_definition_schema,
     artifact_definition_data,
-):
+) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=artifact_definition_schema, data=artifact_definition_data)
         await node.generate()
@@ -62,7 +66,9 @@ async def test_node_artifact_definition_generate(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_artifact_fetch(clients, client_type, mock_rest_api_artifact_fetch, device_schema, device_data):
+async def test_node_artifact_fetch(
+    clients, client_type, mock_rest_api_artifact_fetch, device_schema, device_data
+) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=device_schema, data=device_data)
         artifact_content = await node.artifact_fetch("startup-config")
@@ -81,7 +87,7 @@ ip name-server 1.1.1.1
 @pytest.mark.parametrize("client_type", client_types)
 async def test_node_artifact_generate(
     clients, client_type, mock_rest_api_artifact_generate, device_schema, device_data
-):
+) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=device_schema, data=device_data)
         await node.artifact_generate("startup-config")

--- a/tests/unit/sdk/test_batch.py
+++ b/tests/unit/sdk/test_batch.py
@@ -15,7 +15,7 @@ client_types = ["standard", "sync"]
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_batch_execution(clients: BothClients, client_type: str):
+async def test_batch_execution(clients: BothClients, client_type: str) -> None:
     r: list[int] = []
     tasks_number = 10
 
@@ -54,7 +54,7 @@ async def test_batch_return_exception(
     mock_schema_query_01,
     clients: BothClients,
     client_type: str,
-):
+) -> None:
     if client_type == "standard":
         batch = await clients.standard.create_batch(return_exceptions=True)
         locations = ["JFK1", "JFK1"]
@@ -100,7 +100,7 @@ async def test_batch_exception(
     mock_schema_query_01,
     clients: BothClients,
     client_type: str,
-):
+) -> None:
     if client_type == "standard":
         batch = await clients.standard.create_batch(return_exceptions=False)
         locations = ["JFK1", "JFK1"]

--- a/tests/unit/sdk/test_branch.py
+++ b/tests/unit/sdk/test_branch.py
@@ -14,14 +14,14 @@ sync_branch_methods = [method for method in dir(InfrahubBranchManagerSync) if no
 client_types = ["standard", "sync"]
 
 
-def test_method_sanity():
+def test_method_sanity() -> None:
     """Validate that there is at least one public method and that both clients look the same."""
     assert async_branch_methods
     assert async_branch_methods == sync_branch_methods
 
 
 @pytest.mark.parametrize("method", async_branch_methods)
-def test_validate_method_signature(method):
+def test_validate_method_signature(method) -> None:
     async_method = getattr(InfrahubBranchManager, method)
     sync_method = getattr(InfrahubBranchManagerSync, method)
     async_sig = inspect.signature(async_method)
@@ -31,7 +31,7 @@ def test_validate_method_signature(method):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_get_branches(clients, mock_branches_list_query, client_type):
+async def test_get_branches(clients, mock_branches_list_query, client_type) -> None:
     if client_type == "standard":
         branches = await clients.standard.branch.all()
     else:

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -29,7 +29,7 @@ batch_client_types = [
 client_types = ["standard", "sync"]
 
 
-async def test_method_sanity():
+async def test_method_sanity() -> None:
     """Validate that there is at least one public method and that both clients look the same."""
     assert async_client_methods
     assert async_client_methods == sync_client_methods
@@ -42,7 +42,7 @@ async def test_validate_method_signature(
     replace_sync_return_annotation,
     replace_async_parameter_annotations,
     replace_sync_parameter_annotations,
-):
+) -> None:
     async_method = getattr(InfrahubClient, method)
     sync_method = getattr(InfrahubClientSync, method)
     async_sig = inspect.signature(async_method)
@@ -58,7 +58,7 @@ async def test_validate_method_signature(
     assert replace_async_return_annotation(async_sig.return_annotation) == sync_sig.return_annotation
 
 
-def test_init_with_invalid_address():
+def test_init_with_invalid_address() -> None:
     with pytest.raises(ValueError) as exc:
         InfrahubClient(address="missing-schema")
 
@@ -67,7 +67,7 @@ def test_init_with_invalid_address():
 
 async def test_get_repositories(
     client: InfrahubClient, mock_branches_list_query, mock_schema_query_02, mock_repositories_query
-):
+) -> None:
     repos = await client.get_list_repositories()
 
     assert len(repos) == 2
@@ -83,7 +83,7 @@ async def test_get_repositories(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_count(clients, mock_query_repository_count, client_type):
+async def test_method_count(clients, mock_query_repository_count, client_type) -> None:
     if client_type == "standard":
         count = await clients.standard.count(kind="CoreRepository")
     else:
@@ -93,7 +93,7 @@ async def test_method_count(clients, mock_query_repository_count, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_count_with_filter(clients, mock_query_repository_count, client_type):
+async def test_method_count_with_filter(clients, mock_query_repository_count, client_type) -> None:
     if client_type == "standard":
         count = await clients.standard.count(kind="CoreRepository", name__value="test")
     else:
@@ -103,7 +103,7 @@ async def test_method_count_with_filter(clients, mock_query_repository_count, cl
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_version(clients, mock_query_infrahub_version, client_type):
+async def test_method_get_version(clients, mock_query_infrahub_version, client_type) -> None:
     if client_type == "standard":
         version = await clients.standard.get_version()
     else:
@@ -113,7 +113,7 @@ async def test_method_get_version(clients, mock_query_infrahub_version, client_t
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_user(clients, mock_query_infrahub_user, client_type):
+async def test_method_get_user(clients, mock_query_infrahub_user, client_type) -> None:
     if client_type == "standard":
         user = await clients.standard.get_user()
     else:
@@ -124,7 +124,7 @@ async def test_method_get_user(clients, mock_query_infrahub_user, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_user_permissions(clients, mock_query_infrahub_user, client_type):
+async def test_method_get_user_permissions(clients, mock_query_infrahub_user, client_type) -> None:
     if client_type == "standard":
         groups = await clients.standard.get_user_permissions()
     else:
@@ -135,7 +135,7 @@ async def test_method_get_user_permissions(clients, mock_query_infrahub_user, cl
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_all_with_limit(clients, mock_query_repository_page1_2, client_type):
+async def test_method_all_with_limit(clients, mock_query_repository_page1_2, client_type) -> None:
     if client_type == "standard":
         repos = await clients.standard.all(kind="CoreRepository", populate_store=False, limit=3)
         assert clients.standard.store.count() == 0
@@ -154,7 +154,7 @@ async def test_method_all_with_limit(clients, mock_query_repository_page1_2, cli
 @pytest.mark.parametrize("client_type", client_types)
 async def test_method_all_multiple_pages(
     clients, mock_query_repository_page1_2, mock_query_repository_page2_2, client_type
-):
+) -> None:
     if client_type == "standard":
         repos = await clients.standard.all(kind="CoreRepository", populate_store=False)
         assert clients.standard.store.count() == 0
@@ -174,7 +174,7 @@ async def test_method_all_multiple_pages(
 @pytest.mark.parametrize("client_type, use_parallel", batch_client_types)
 async def test_method_all_batching(
     clients, mock_query_location_batch_count, mock_query_location_batch, client_type, use_parallel
-):
+) -> None:
     if client_type == "standard":
         locations = await clients.standard.all(kind="BuiltinLocation", populate_store=False, parallel=use_parallel)
         assert clients.standard.store.count() == 0
@@ -192,7 +192,7 @@ async def test_method_all_batching(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_all_single_page(clients, mock_query_repository_page1_1, client_type):
+async def test_method_all_single_page(clients, mock_query_repository_page1_1, client_type) -> None:
     if client_type == "standard":
         repos = await clients.standard.all(kind="CoreRepository", populate_store=False)
         assert clients.standard.store.count() == 0
@@ -210,7 +210,7 @@ async def test_method_all_single_page(clients, mock_query_repository_page1_1, cl
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_all_generic(clients, mock_query_corenode_page1_1, client_type):
+async def test_method_all_generic(clients, mock_query_corenode_page1_1, client_type) -> None:
     if client_type == "standard":
         nodes = await clients.standard.all(kind="CoreNode")
     else:
@@ -222,7 +222,7 @@ async def test_method_all_generic(clients, mock_query_corenode_page1_1, client_t
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_by_id(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type):
+async def test_method_get_by_id(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type) -> None:
     response = {
         "data": {
             "CoreRepository": {
@@ -270,7 +270,7 @@ async def test_method_get_by_id(httpx_mock: HTTPXMock, clients, mock_schema_quer
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_by_hfid(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type):
+async def test_method_get_by_hfid(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type) -> None:
     response = {
         "data": {
             "CoreRepository": {
@@ -319,7 +319,7 @@ async def test_method_get_by_hfid(httpx_mock: HTTPXMock, clients, mock_schema_qu
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_by_default_filter(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type):
+async def test_method_get_by_default_filter(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type) -> None:
     response = {
         "data": {
             "CoreRepository": {
@@ -365,7 +365,7 @@ async def test_method_get_by_default_filter(httpx_mock: HTTPXMock, clients, mock
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_by_name(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type):
+async def test_method_get_by_name(httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type) -> None:
     response = {
         "data": {
             "CoreRepository": {
@@ -401,7 +401,9 @@ async def test_method_get_by_name(httpx_mock: HTTPXMock, clients, mock_schema_qu
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_not_found(httpx_mock: HTTPXMock, clients, mock_query_repository_page1_empty, client_type):
+async def test_method_get_not_found(
+    httpx_mock: HTTPXMock, clients, mock_query_repository_page1_empty, client_type
+) -> None:
     with pytest.raises(NodeNotFoundError):
         if client_type == "standard":
             await clients.standard.get(kind="CoreRepository", name__value="infrahub-demo-core")
@@ -412,7 +414,7 @@ async def test_method_get_not_found(httpx_mock: HTTPXMock, clients, mock_query_r
 @pytest.mark.parametrize("client_type", client_types)
 async def test_method_get_not_found_none(
     httpx_mock: HTTPXMock, clients, mock_query_repository_page1_empty, client_type
-):
+) -> None:
     if client_type == "standard":
         response = await clients.standard.get(
             kind="CoreRepository", name__value="infrahub-demo-core", raise_when_missing=False
@@ -430,7 +432,7 @@ async def test_method_get_found_many(
     mock_schema_query_01,
     mock_query_repository_page1_1,
     client_type,
-):
+) -> None:
     with pytest.raises(IndexError):
         if client_type == "standard":
             await clients.standard.get(kind="CoreRepository", id="bfae43e8-5ebb-456c-a946-bf64e930710a")
@@ -439,7 +441,7 @@ async def test_method_get_found_many(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_filters_many(httpx_mock: HTTPXMock, clients, mock_query_repository_page1_1, client_type):
+async def test_method_filters_many(httpx_mock: HTTPXMock, clients, mock_query_repository_page1_1, client_type) -> None:
     if client_type == "standard":
         repos = await clients.standard.filters(
             kind="CoreRepository",
@@ -485,7 +487,9 @@ async def test_method_filters_many(httpx_mock: HTTPXMock, clients, mock_query_re
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_filters_empty(httpx_mock: HTTPXMock, clients, mock_query_repository_page1_empty, client_type):
+async def test_method_filters_empty(
+    httpx_mock: HTTPXMock, clients, mock_query_repository_page1_empty, client_type
+) -> None:
     if client_type == "standard":
         repos = await clients.standard.filters(
             kind="CoreRepository",
@@ -514,7 +518,7 @@ async def test_allocate_next_ip_address(
     ipam_ipprefix_schema,
     ipam_ipprefix_data,
     client_type,
-):
+) -> None:
     httpx_mock.add_response(
         method="POST",
         json={
@@ -615,7 +619,7 @@ async def test_allocate_next_ip_prefix(
     ipam_ipprefix_schema,
     ipam_ipprefix_data,
     client_type,
-):
+) -> None:
     httpx_mock.add_response(
         method="POST",
         json={
@@ -730,7 +734,7 @@ VARIABLES:
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_echo(httpx_mock: HTTPXMock, echo_clients, client_type):
+async def test_query_echo(httpx_mock: HTTPXMock, echo_clients, client_type) -> None:
     httpx_mock.add_response(
         method="POST",
         json={"data": {"BuiltinTag": {"edges": []}}},

--- a/tests/unit/sdk/test_config.py
+++ b/tests/unit/sdk/test_config.py
@@ -4,31 +4,31 @@ from pydantic import ValidationError
 from infrahub_sdk.config import Config
 
 
-def test_combine_authentications():
+def test_combine_authentications() -> None:
     with pytest.raises(ValidationError) as exc:
         Config(api_token="testing", username="test", password="testpassword")
 
     assert "Unable to combine password with token based authentication" in str(exc.value)
 
 
-def test_missing_password():
+def test_missing_password() -> None:
     with pytest.raises(ValidationError) as exc:
         Config(username="test")
 
     assert "Both 'username' and 'password' needs to be set" in str(exc.value)
 
 
-def test_password_authentication():
+def test_password_authentication() -> None:
     config = Config(username="test", password="test-password")
     assert config.password_authentication
 
 
-def test_not_password_authentication():
+def test_not_password_authentication() -> None:
     config = Config()
     assert not config.password_authentication
 
 
-def test_config_address():
+def test_config_address() -> None:
     address = "http://localhost:8000"
 
     config = Config(address=address + "/")

--- a/tests/unit/sdk/test_diff_summary.py
+++ b/tests/unit/sdk/test_diff_summary.py
@@ -92,7 +92,7 @@ async def mock_diff_tree_query(httpx_mock: HTTPXMock, client: InfrahubClient) ->
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_diffsummary(clients: BothClients, mock_diff_tree_query, client_type):
+async def test_diffsummary(clients: BothClients, mock_diff_tree_query, client_type) -> None:
     if client_type == "standard":
         node_diffs = await clients.standard.get_diff_summary(
             branch="branch2",

--- a/tests/unit/sdk/test_graphql.py
+++ b/tests/unit/sdk/test_graphql.py
@@ -115,7 +115,7 @@ def input_data_01():
     return data
 
 
-def test_render_query_block(query_data_no_filter):
+def test_render_query_block(query_data_no_filter) -> None:
     lines = render_query_block(data=query_data_no_filter)
 
     expected_lines = [
@@ -158,7 +158,7 @@ def test_render_query_block(query_data_no_filter):
     assert lines == expected_lines
 
 
-def test_render_query_block_alias(query_data_alias):
+def test_render_query_block_alias(query_data_alias) -> None:
     lines = render_query_block(data=query_data_alias)
 
     expected_lines = [
@@ -180,7 +180,7 @@ def test_render_query_block_alias(query_data_alias):
     assert lines == expected_lines
 
 
-def test_render_query_block_fragment(query_data_fragment):
+def test_render_query_block_fragment(query_data_fragment) -> None:
     lines = render_query_block(data=query_data_fragment)
 
     expected_lines = [
@@ -204,7 +204,7 @@ def test_render_query_block_fragment(query_data_fragment):
     assert lines == expected_lines
 
 
-def test_render_input_block(input_data_01):
+def test_render_input_block(input_data_01) -> None:
     lines = render_input_block(data=input_data_01)
 
     expected_lines = [
@@ -259,7 +259,7 @@ def test_render_input_block(input_data_01):
     assert lines == expected_lines
 
 
-def test_query_rendering_no_vars(query_data_no_filter):
+def test_query_rendering_no_vars(query_data_no_filter) -> None:
     query = Query(query=query_data_no_filter)
 
     expected_query = """
@@ -283,7 +283,7 @@ query {
     assert query.render() == expected_query
 
 
-def test_query_rendering_empty_filter(query_data_empty_filter):
+def test_query_rendering_empty_filter(query_data_empty_filter) -> None:
     query = Query(query=query_data_empty_filter)
 
     expected_query = """
@@ -307,7 +307,7 @@ query {
     assert query.render() == expected_query
 
 
-def test_query_rendering_with_filters_and_vars(query_data_filters_01):
+def test_query_rendering_with_filters_and_vars(query_data_filters_01) -> None:
     query = Query(query=query_data_filters_01, variables={"name": str, "enabled": bool})
 
     expected_query = """
@@ -331,7 +331,7 @@ query ($name: String!, $enabled: Boolean!) {
     assert query.render() == expected_query
 
 
-def test_query_rendering_with_filters(query_data_filters_02):
+def test_query_rendering_with_filters(query_data_filters_02) -> None:
     query = Query(query=query_data_filters_02)
 
     expected_query = """
@@ -351,7 +351,7 @@ query {
     assert query.render() == expected_query
 
 
-def test_query_rendering_with_filters_convert_enum(query_data_filters_02):
+def test_query_rendering_with_filters_convert_enum(query_data_filters_02) -> None:
     query = Query(query=query_data_filters_02)
 
     expected_query = """
@@ -371,7 +371,7 @@ query {
     assert query.render(convert_enum=True) == expected_query
 
 
-def test_mutation_rendering_no_vars(input_data_01):
+def test_mutation_rendering_no_vars(input_data_01) -> None:
     query_data = {"ok": None, "object": {"id": None}}
 
     query = Mutation(mutation="myobject_create", query=query_data, input_data=input_data_01)
@@ -411,7 +411,7 @@ mutation {
     assert query.render() == expected_query
 
 
-def test_mutation_rendering_many_relationships():
+def test_mutation_rendering_many_relationships() -> None:
     query_data = {"ok": None, "object": {"id": None}}
     input_data = {
         "data": {
@@ -457,7 +457,7 @@ mutation {
     assert query.render() == expected_query
 
 
-def test_mutation_rendering_enum():
+def test_mutation_rendering_enum() -> None:
     query_data = {"ok": None, "object": {"id": None}}
     input_data = {
         "data": {
@@ -491,7 +491,7 @@ mutation {
     assert query.render() == expected_query
 
 
-def test_mutation_rendering_with_vars(input_data_01):
+def test_mutation_rendering_with_vars(input_data_01) -> None:
     query_data = {"ok": None, "object": {"id": None}}
     variables = {"name": str, "description": str, "number": int}
     query = Mutation(

--- a/tests/unit/sdk/test_group_context.py
+++ b/tests/unit/sdk/test_group_context.py
@@ -10,14 +10,16 @@ sync_methods = [method for method in dir(InfrahubGroupContextSync) if not method
 client_types = ["standard", "sync"]
 
 
-async def test_method_sanity():
+async def test_method_sanity() -> None:
     """Validate that there is at least one public method and that both clients look the same."""
     assert async_methods
     assert async_methods == sync_methods
 
 
 @pytest.mark.parametrize("method", async_methods)
-async def test_validate_method_signature(method, replace_sync_return_annotation, replace_async_return_annotation):
+async def test_validate_method_signature(
+    method, replace_sync_return_annotation, replace_async_return_annotation
+) -> None:
     async_method = getattr(InfrahubGroupContext, method)
     sync_method = getattr(InfrahubGroupContextSync, method)
     async_sig = inspect.signature(async_method)
@@ -27,7 +29,7 @@ async def test_validate_method_signature(method, replace_sync_return_annotation,
     assert replace_async_return_annotation(async_sig.return_annotation) == sync_sig.return_annotation
 
 
-def test_set_properties():
+def test_set_properties() -> None:
     context = InfrahubGroupContextBase()
     context.set_properties(identifier="MYID")
     assert context.identifier == "MYID"
@@ -39,7 +41,7 @@ def test_set_properties():
     assert context.delete_unused_nodes is True
 
 
-def test_get_params_as_str():
+def test_get_params_as_str() -> None:
     context = InfrahubGroupContextBase()
     context.set_properties(identifier="MYID", params={"one": 1, "two": "two"})
     assert context._get_params_as_str() == "one: 1, two: two"
@@ -49,7 +51,7 @@ def test_get_params_as_str():
     assert not context._get_params_as_str()
 
 
-def test_generate_group_name():
+def test_generate_group_name() -> None:
     context = InfrahubGroupContextBase()
     context.set_properties(identifier="MYID")
     assert context._generate_group_name() == "MYID"
@@ -63,7 +65,7 @@ def test_generate_group_name():
     assert context._generate_group_name(suffix="xxx") == "MYID-xxx-11aaec5206c3dca37cbbcaaabf121550"
 
 
-def test_generate_group_description(std_group_schema):
+def test_generate_group_description(std_group_schema) -> None:
     context = InfrahubGroupContextBase()
     context.set_properties(identifier="MYID")
     assert not context._generate_group_description(schema=std_group_schema)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -53,7 +53,7 @@ UNSAFE_GRAPHQL_VALUES = [
 ]
 
 
-async def test_method_sanity():
+async def test_method_sanity() -> None:
     """Validate that there is at least one public method and that both clients look the same."""
     assert async_node_methods
     assert async_node_methods == sync_node_methods
@@ -78,7 +78,7 @@ async def test_validate_method_signature(
     replace_sync_parameter_annotations,
     replace_async_return_annotation,
     replace_sync_return_annotation,
-):
+) -> None:
     EXCLUDE_PARAMETERS = ["client"]
     async_method = getattr(InfrahubNode, method)
     sync_method = getattr(InfrahubNodeSync, method)
@@ -103,14 +103,14 @@ async def test_validate_method_signature(
 
 
 @pytest.mark.parametrize("hfid,expected_kind,expected_hfid", [("BuiltinLocation__JFK1", "BuiltinLocation", ["JFK1"])])
-def test_parse_human_friendly_id(hfid: str, expected_kind: str, expected_hfid: list[str]):
+def test_parse_human_friendly_id(hfid: str, expected_kind: str, expected_hfid: list[str]) -> None:
     kind, hfid = parse_human_friendly_id(hfid)
     assert kind == expected_kind
     assert hfid == expected_hfid
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_init_node_no_data(client, location_schema, client_type):
+async def test_init_node_no_data(client, location_schema, client_type) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
     else:
@@ -123,7 +123,7 @@ async def test_init_node_no_data(client, location_schema, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_hfid(client, schema_with_hfid, client_type):
+async def test_node_hfid(client, schema_with_hfid, client_type) -> None:
     location_data = {"name": {"value": "JFK1"}, "description": {"value": "JFK Airport"}, "type": {"value": "SITE"}}
     if client_type == "standard":
         location = InfrahubNode(client=client, schema=schema_with_hfid["location"], data=location_data)
@@ -146,7 +146,7 @@ async def test_node_hfid(client, schema_with_hfid, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_init_node_data_user(client, location_schema: NodeSchemaAPI, client_type):
+async def test_init_node_data_user(client, location_schema: NodeSchemaAPI, client_type) -> None:
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -164,7 +164,7 @@ async def test_init_node_data_user(client, location_schema: NodeSchemaAPI, clien
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_init_node_data_user_with_relationships(client, location_schema: NodeSchemaAPI, client_type):
+async def test_init_node_data_user_with_relationships(client, location_schema: NodeSchemaAPI, client_type) -> None:
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -205,7 +205,7 @@ async def test_init_node_data_user_with_relationships(client, location_schema: N
 )
 async def test_init_node_data_user_with_relationships_using_related_node(
     client, location_schema: NodeSchemaAPI, client_type, rel_data
-):
+) -> None:
     rel_schema = location_schema.get_relationship(name="primary_tag")
     if client_type == "standard":
         primary_tag = RelatedNode(name="primary_tag", branch="main", client=client, schema=rel_schema, data=rel_data)
@@ -252,7 +252,7 @@ async def test_init_node_data_user_with_relationships_using_related_node(
 @pytest.mark.parametrize("client_type", client_types)
 async def test_init_node_data_graphql(
     client, location_schema: NodeSchemaAPI, location_data01, location_data01_property, client_type, property_test
-):
+) -> None:
     location_data = location_data01 if property_test == WITHOUT_PROPERTY else location_data01_property
 
     if client_type == "standard":
@@ -274,7 +274,7 @@ async def test_init_node_data_graphql(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_no_filters_property(clients, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_no_filters_property(clients, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         node = InfrahubNode(client=client, schema=location_schema)
@@ -374,7 +374,7 @@ async def test_query_data_no_filters_property(clients, location_schema: NodeSche
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_no_filters(clients, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_no_filters(clients, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         node = InfrahubNode(client=client, schema=location_schema)
@@ -418,7 +418,7 @@ async def test_query_data_no_filters(clients, location_schema: NodeSchemaAPI, cl
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         node = InfrahubNode(client=client, schema=location_schema)
@@ -482,7 +482,7 @@ async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI,
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_node(clients, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_node(clients, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         node = InfrahubNode(client=client, schema=location_schema)
@@ -514,7 +514,7 @@ async def test_query_data_node(clients, location_schema: NodeSchemaAPI, client_t
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_with_prefetch_relationships_property(clients, mock_schema_query_02, client_type):
+async def test_query_data_with_prefetch_relationships_property(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         location_schema: GenericSchema = await client.schema.get(kind="BuiltinLocation")  # type: ignore[annotation-unchecked]
@@ -650,7 +650,7 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_with_prefetch_relationships(clients, mock_schema_query_02, client_type):
+async def test_query_data_with_prefetch_relationships(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         location_schema: GenericSchema = await client.schema.get(kind="BuiltinLocation")  # type: ignore[annotation-unchecked]
@@ -702,7 +702,7 @@ async def test_query_data_with_prefetch_relationships(clients, mock_schema_query
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_node_with_prefetch_relationships_property(clients, mock_schema_query_02, client_type):
+async def test_query_data_node_with_prefetch_relationships_property(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         location_schema: GenericSchema = await client.schema.get(kind="BuiltinLocation")  # type: ignore[annotation-unchecked]
@@ -778,7 +778,7 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_node_with_prefetch_relationships(clients, mock_schema_query_02, client_type):
+async def test_query_data_node_with_prefetch_relationships(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         location_schema: GenericSchema = await client.schema.get(kind="BuiltinLocation")  # type: ignore[annotation-unchecked]
@@ -818,7 +818,7 @@ async def test_query_data_node_with_prefetch_relationships(clients, mock_schema_
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_generic_property(clients, mock_schema_query_02, client_type):
+async def test_query_data_generic_property(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         corenode_schema: GenericSchema = await client.schema.get(kind="CoreNode")  # type: ignore[annotation-unchecked]
@@ -847,7 +847,7 @@ async def test_query_data_generic_property(clients, mock_schema_query_02, client
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_generic_fragment_property(clients, mock_schema_query_02, client_type):
+async def test_query_data_generic_fragment_property(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         corenode_schema: GenericSchema = await client.schema.get(kind="CoreNode")  # type: ignore[annotation-unchecked]
@@ -993,7 +993,7 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_generic_fragment(clients, mock_schema_query_02, client_type):
+async def test_query_data_generic_fragment(clients, mock_schema_query_02, client_type) -> None:
     if client_type == "standard":
         client: InfrahubClient = getattr(clients, client_type)  # type: ignore[annotation-unchecked]
         corenode_schema: GenericSchema = await client.schema.get(kind="CoreNode")  # type: ignore[annotation-unchecked]
@@ -1055,7 +1055,7 @@ async def test_query_data_generic_fragment(clients, mock_schema_query_02, client
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_include_property(client, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_include_property(client, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(include=["tags"], property=True)
@@ -1178,7 +1178,7 @@ async def test_query_data_include_property(client, location_schema: NodeSchemaAP
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_include(client, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_include(client, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(include=["tags"])
@@ -1231,7 +1231,7 @@ async def test_query_data_include(client, location_schema: NodeSchemaAPI, client
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_exclude_property(client, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_exclude_property(client, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(exclude=["description", "primary_tag"], property=True)
@@ -1290,7 +1290,7 @@ async def test_query_data_exclude_property(client, location_schema: NodeSchemaAP
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_exclude(client, location_schema: NodeSchemaAPI, client_type):
+async def test_query_data_exclude(client, location_schema: NodeSchemaAPI, client_type) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(exclude=["description", "primary_tag"])
@@ -1321,7 +1321,7 @@ async def test_query_data_exclude(client, location_schema: NodeSchemaAPI, client
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data(client, location_schema: NodeSchemaAPI, client_type):
+async def test_create_input_data(client, location_schema: NodeSchemaAPI, client_type) -> None:
     data = {"name": {"value": "JFK1"}, "description": {"value": "JFK Airport"}, "type": {"value": "SITE"}}
 
     if client_type == "standard":
@@ -1335,7 +1335,7 @@ async def test_create_input_data(client, location_schema: NodeSchemaAPI, client_
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data__with_relationships_02(client, location_schema, client_type):
+async def test_create_input_data__with_relationships_02(client, location_schema, client_type) -> None:
     """Validate input data with variables that needs replacements"""
     data = {
         "name": {"value": "JFK1"},
@@ -1369,7 +1369,7 @@ async def test_create_input_data__with_relationships_02(client, location_schema,
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data__with_relationships_01(client, location_schema, client_type):
+async def test_create_input_data__with_relationships_01(client, location_schema, client_type) -> None:
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -1395,7 +1395,7 @@ async def test_create_input_data__with_relationships_01(client, location_schema,
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data_with_relationships_02(clients, rfile_schema, client_type):
+async def test_create_input_data_with_relationships_02(clients, rfile_schema, client_type) -> None:
     data = {
         "name": {"value": "rfile01", "is_protected": True, "source": "ffffffff", "owner": "ffffffff"},
         "template_path": {"value": "mytemplate.j2"},
@@ -1434,7 +1434,7 @@ async def test_create_input_data_with_relationships_02(clients, rfile_schema, cl
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data_with_relationships_03(clients, rfile_schema, client_type):
+async def test_create_input_data_with_relationships_03(clients, rfile_schema, client_type) -> None:
     data = {
         "name": {"value": "rfile01", "is_protected": True, "source": "ffffffff"},
         "template_path": {"value": "mytemplate.j2"},
@@ -1473,7 +1473,7 @@ async def test_create_input_data_with_relationships_03_for_update_include_unmodi
     rfile_userdata01_property,
     client_type,
     property_test,
-):
+) -> None:
     rfile_userdata = rfile_userdata01 if property_test == WITHOUT_PROPERTY else rfile_userdata01_property
 
     if client_type == "standard":
@@ -1531,7 +1531,7 @@ async def test_create_input_data_with_relationships_03_for_update_exclude_unmodi
     rfile_userdata01_property,
     client_type,
     property_test,
-):
+) -> None:
     """NOTE: Need to fix this test, the issue is tracked in https://github.com/opsmill/infrahub-sdk-python/issues/214."""
     rfile_userdata = rfile_userdata01 if property_test == WITHOUT_PROPERTY else rfile_userdata01_property
 
@@ -1568,7 +1568,7 @@ async def test_create_input_data_with_relationships_03_for_update_exclude_unmodi
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data_with_IPHost_attribute(client, ipaddress_schema, client_type):
+async def test_create_input_data_with_IPHost_attribute(client, ipaddress_schema, client_type) -> None:
     data = {"address": {"value": ipaddress.ip_interface("1.1.1.1/24"), "is_protected": True}}
 
     if client_type == "standard":
@@ -1582,7 +1582,7 @@ async def test_create_input_data_with_IPHost_attribute(client, ipaddress_schema,
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data_with_IPNetwork_attribute(client, ipnetwork_schema, client_type):
+async def test_create_input_data_with_IPNetwork_attribute(client, ipnetwork_schema, client_type) -> None:
     data = {"network": {"value": ipaddress.ip_network("1.1.1.0/24"), "is_protected": True}}
 
     if client_type == "standard":
@@ -1608,7 +1608,7 @@ async def test_update_input_data__with_relationships_01(
     tag_red_data,
     client_type,
     property_test,
-):
+) -> None:
     location_data = location_data01 if property_test == WITHOUT_PROPERTY else location_data01_property
 
     if client_type == "standard":
@@ -1655,7 +1655,7 @@ async def test_update_input_data__with_relationships_01(
 @pytest.mark.parametrize("client_type", client_types)
 async def test_update_input_data_with_relationships_02(
     client, location_schema, location_data02, location_data02_property, client_type, property_test
-):
+) -> None:
     location_data = location_data02 if property_test == WITHOUT_PROPERTY else location_data02_property
 
     if client_type == "standard":
@@ -1726,7 +1726,7 @@ async def test_update_input_data_with_relationships_02(
 @pytest.mark.parametrize("client_type", client_types)
 async def test_update_input_data_with_relationships_02_exclude_unmodified(
     client, location_schema, location_data02, location_data02_property, client_type, property_test
-):
+) -> None:
     """NOTE Need to fix this test, issue is tracked in https://github.com/opsmill/infrahub-sdk-python/issues/214."""
     location_data = location_data02 if property_test == WITHOUT_PROPERTY else location_data02_property
 
@@ -1771,7 +1771,7 @@ async def test_update_input_data_empty_relationship(
     tag_blue_data,
     client_type,
     property_test,
-):
+) -> None:
     """TODO: investigate why name and type are being returned since they haven't been modified."""
     location_data = location_data01 if property_test == WITHOUT_PROPERTY else location_data01_property
 
@@ -1819,7 +1819,7 @@ async def test_node_get_relationship_from_store(
     tag_red_data,
     tag_blue_data,
     client_type,
-):
+) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
         tag_red = InfrahubNode(client=client, schema=tag_schema, data=tag_red_data)
@@ -1840,7 +1840,7 @@ async def test_node_get_relationship_from_store(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_get_relationship_not_in_store(client, location_schema, location_data01, client_type):
+async def test_node_get_relationship_not_in_store(client, location_schema, location_data01, client_type) -> None:
     if client_type == "standard":
         node = InfrahubNode(client=client, schema=location_schema, data=location_data01)
     else:
@@ -1864,7 +1864,7 @@ async def test_node_fetch_relationship(
     tag_red_data,
     tag_blue_data,
     client_type,
-):
+) -> None:
     response1 = {
         "data": {
             "BuiltinTag": {
@@ -1926,7 +1926,7 @@ async def test_node_fetch_relationship(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_IPHost_deserialization(client, ipaddress_schema, client_type):
+async def test_node_IPHost_deserialization(client, ipaddress_schema, client_type) -> None:
     data = {
         "id": "aaaaaaaaaaaaaa",
         "address": {
@@ -1943,7 +1943,7 @@ async def test_node_IPHost_deserialization(client, ipaddress_schema, client_type
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_IPNetwork_deserialization(client, ipnetwork_schema, client_type):
+async def test_node_IPNetwork_deserialization(client, ipnetwork_schema, client_type) -> None:
     data = {
         "id": "aaaaaaaaaaaaaa",
         "network": {
@@ -1962,7 +1962,7 @@ async def test_node_IPNetwork_deserialization(client, ipnetwork_schema, client_t
 @pytest.mark.parametrize("client_type", client_types)
 async def test_get_flat_value(
     httpx_mock: HTTPXMock, mock_schema_query_01, clients, location_schema, location_data01, client_type
-):
+) -> None:
     httpx_mock.add_response(
         method="POST",
         json={"data": {"BuiltinTag": {"count": 1, "edges": [location_data01["node"]["primary_tag"]]}}},
@@ -1989,7 +1989,7 @@ async def test_get_flat_value(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_extract(clients, location_schema, location_data01, client_type):
+async def test_node_extract(clients, location_schema, location_data01, client_type) -> None:
     params = {"identifier": "id", "name": "name__value", "description": "description__value"}
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=location_schema, data=location_data01)
@@ -2014,7 +2014,7 @@ async def test_read_only_attr(
     address_schema,
     address_data,
     client_type,
-):
+) -> None:
     if client_type == "standard":
         address = InfrahubNode(client=client, schema=address_schema, data=address_data)
     else:
@@ -2032,7 +2032,7 @@ async def test_read_only_attr(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_relationships_excluded_input_data(client, location_schema, client_type):
+async def test_relationships_excluded_input_data(client, location_schema, client_type) -> None:
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -2051,7 +2051,7 @@ async def test_relationships_excluded_input_data(client, location_schema, client
 @pytest.mark.parametrize("client_type", client_types)
 async def test_create_input_data_with_resource_pool_relationship(
     client, ipaddress_pool_schema, ipam_ipprefix_schema, simple_device_schema, ipam_ipprefix_data, client_type
-):
+) -> None:
     if client_type == "standard":
         ip_prefix = InfrahubNode(client=client, schema=ipam_ipprefix_schema, data=ipam_ipprefix_data)
         ip_pool = InfrahubNode(
@@ -2103,7 +2103,7 @@ async def test_create_input_data_with_resource_pool_relationship(
 @pytest.mark.parametrize("client_type", client_types)
 async def test_create_mutation_query_with_resource_pool_relationship(
     client, ipaddress_pool_schema, ipam_ipprefix_schema, simple_device_schema, ipam_ipprefix_data, client_type
-):
+) -> None:
     if client_type == "standard":
         ip_prefix = InfrahubNode(client=client, schema=ipam_ipprefix_schema, data=ipam_ipprefix_data)
         ip_pool = InfrahubNode(
@@ -2162,7 +2162,7 @@ async def test_get_pool_allocated_resources(
     ipam_ipprefix_schema,
     ipam_ipprefix_data,
     client_type,
-):
+) -> None:
     httpx_mock.add_response(
         method="POST",
         json={
@@ -2257,7 +2257,7 @@ async def test_get_pool_allocated_resources(
 @pytest.mark.parametrize("client_type", client_types)
 async def test_get_pool_resources_utilization(
     httpx_mock: HTTPXMock, clients, ipaddress_pool_schema, ipam_ipprefix_schema, ipam_ipprefix_data, client_type
-):
+) -> None:
     httpx_mock.add_response(
         method="POST",
         json={
@@ -2319,7 +2319,7 @@ async def test_get_pool_resources_utilization(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_from_graphql(clients, mock_schema_query_01, location_data01, client_type):
+async def test_from_graphql(clients, mock_schema_query_01, location_data01, client_type) -> None:
     if client_type == "standard":
         schema = await clients.standard.schema.get(kind="BuiltinLocation", branch="main")
         node = await InfrahubNode.from_graphql(

--- a/tests/unit/sdk/test_object_store.py
+++ b/tests/unit/sdk/test_object_store.py
@@ -37,14 +37,14 @@ async def mock_upload_object_store_01(httpx_mock: HTTPXMock) -> HTTPXMock:
     return httpx_mock
 
 
-async def test_method_sanity():
+async def test_method_sanity() -> None:
     """Validate that there is at least one public method and that both clients look the same."""
     assert async_methods
     assert async_methods == sync_methods
 
 
 @pytest.mark.parametrize("method", async_methods)
-async def test_validate_method_signature(method):
+async def test_validate_method_signature(method) -> None:
     async_method = getattr(ObjectStore, method)
     sync_method = getattr(ObjectStoreSync, method)
     async_sig = inspect.signature(async_method)
@@ -54,7 +54,7 @@ async def test_validate_method_signature(method):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_object_store_get(client_type, clients, mock_get_object_store_01):
+async def test_object_store_get(client_type, clients, mock_get_object_store_01) -> None:
     client = getattr(clients, client_type)
 
     if client_type == "standard":
@@ -66,7 +66,7 @@ async def test_object_store_get(client_type, clients, mock_get_object_store_01):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_object_store_upload(client_type, clients, mock_upload_object_store_01):
+async def test_object_store_upload(client_type, clients, mock_upload_object_store_01) -> None:
     client = getattr(clients, client_type)
 
     if client_type == "standard":

--- a/tests/unit/sdk/test_protocols_generator.py
+++ b/tests/unit/sdk/test_protocols_generator.py
@@ -36,12 +36,12 @@ SYNCIFY_TEST_CASES = [
     "test_case",
     [pytest.param(tc, id=tc.name) for tc in SYNCIFY_TEST_CASES],
 )
-async def test_filter_syncify(test_case: SyncifyTestCase):
+async def test_filter_syncify(test_case: SyncifyTestCase) -> None:
     assert CodeGenerator._jinja2_filter_syncify(value=test_case.input, sync=test_case.sync) == test_case.output
     assert CodeGenerator._jinja2_filter_syncify(value=test_case.input, sync=test_case.sync) == test_case.output
 
 
-async def test_generator(client: InfrahubClient, mock_schema_query_05):
+async def test_generator(client: InfrahubClient, mock_schema_query_05) -> None:
     schemas = await client.schema.fetch(branch="main")
 
     code_generator = CodeGenerator(schema=schemas)

--- a/tests/unit/sdk/test_query_analyzer.py
+++ b/tests/unit/sdk/test_query_analyzer.py
@@ -5,7 +5,7 @@ from graphql.error import GraphQLSyntaxError
 from infrahub_sdk.analyzer import GraphQLOperation, GraphQLQueryAnalyzer
 
 
-async def test_analyzer_init_query_only(query_01, bad_query_01):
+async def test_analyzer_init_query_only(query_01, bad_query_01) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert isinstance(gqa.document, DocumentNode)
 
@@ -13,7 +13,7 @@ async def test_analyzer_init_query_only(query_01, bad_query_01):
         gqa = GraphQLQueryAnalyzer(query=bad_query_01)
 
 
-async def test_nbr_queries(query_01: str, query_03: str):
+async def test_nbr_queries(query_01: str, query_03: str) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert gqa.nbr_queries == 1
 
@@ -21,7 +21,7 @@ async def test_nbr_queries(query_01: str, query_03: str):
     assert gqa.nbr_queries == 2
 
 
-async def test_query_types(query_01: str, query_03: str, query_introspection: str):
+async def test_query_types(query_01: str, query_03: str, query_introspection: str) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert gqa.operations == [GraphQLOperation(name="TestPerson", operation_type=OperationType.QUERY)]
 
@@ -34,7 +34,7 @@ async def test_query_types(query_01: str, query_03: str, query_introspection: st
     assert gqa.operations == [GraphQLOperation(name="__schema", operation_type=OperationType.QUERY)]
 
 
-async def test_get_fields(query_01: str, query_03: str):
+async def test_get_fields(query_01: str, query_03: str) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert await gqa.get_fields() == {
         "TestPerson": {
@@ -61,7 +61,7 @@ async def test_get_fields(query_01: str, query_03: str):
     }
 
 
-async def test_calculate_depth(query_01: str, query_02: str, query_03: str, query_04: str):
+async def test_calculate_depth(query_01: str, query_02: str, query_03: str, query_04: str) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert await gqa.calculate_depth() == 9
 
@@ -75,7 +75,7 @@ async def test_calculate_depth(query_01: str, query_02: str, query_03: str, quer
     assert await gqa.calculate_depth() == 6
 
 
-async def test_calculate_height(query_01: str, query_02: str, query_03: str, query_04: str):
+async def test_calculate_height(query_01: str, query_02: str, query_03: str, query_04: str) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert await gqa.calculate_height() == 10
 
@@ -89,7 +89,7 @@ async def test_calculate_height(query_01: str, query_02: str, query_03: str, que
     assert await gqa.calculate_height() == 5
 
 
-async def test_get_variables(query_01: str, query_04: str, query_05: str, query_06: str):
+async def test_get_variables(query_01: str, query_04: str, query_05: str, query_06: str) -> None:
     gqa = GraphQLQueryAnalyzer(query=query_01)
     assert gqa.variables == []
 
@@ -151,7 +151,7 @@ async def test_get_variables(query_01: str, query_04: str, query_05: str, query_
     "var_type,var_required",
     [("[ID]", False), ("[ID]!", True), ("[ID!]", False), ("[ID!]!", True)],
 )
-async def test_get_nested_variables(var_type, var_required):
+async def test_get_nested_variables(var_type, var_required) -> None:
     query = (
         """
         query ($ids: %s){

--- a/tests/unit/sdk/test_repository.py
+++ b/tests/unit/sdk/test_repository.py
@@ -16,7 +16,7 @@ def temp_dir():
         yield tmp_dir
 
 
-def test_initialize_repo_creates_new_repo(temp_dir):
+def test_initialize_repo_creates_new_repo(temp_dir) -> None:
     """Test that a new Git repository is created if none exists."""
     manager = GitRepoManager(root_directory=temp_dir, branch="main")
 
@@ -28,7 +28,7 @@ def test_initialize_repo_creates_new_repo(temp_dir):
     assert isinstance(manager.git, Repo)
 
 
-def test_initialize_repo_uses_existing_repo(temp_dir):
+def test_initialize_repo_uses_existing_repo(temp_dir) -> None:
     """Test that the GitRepoManager uses an existing repository without an active branch."""
     # Manually initialize a repo
     Repo.init(temp_dir, default_branch=b"main")
@@ -39,7 +39,7 @@ def test_initialize_repo_uses_existing_repo(temp_dir):
     assert (Path(temp_dir) / ".git").is_dir()
 
 
-def test_active_branch_returns_correct_branch(temp_dir):
+def test_active_branch_returns_correct_branch(temp_dir) -> None:
     """Test that the active branch is correctly returned."""
     manager = GitRepoManager(temp_dir, branch="develop")
 
@@ -47,7 +47,7 @@ def test_active_branch_returns_correct_branch(temp_dir):
     assert manager.active_branch == "develop"
 
 
-def test_initialize_repo_raises_error_on_failure(monkeypatch, temp_dir):
+def test_initialize_repo_raises_error_on_failure(monkeypatch, temp_dir) -> None:
     """Test that an error is raised if the repository cannot be initialized."""
 
     def mock_init(*args, **kwargs):  # noqa: ANN002, ANN003
@@ -59,7 +59,7 @@ def test_initialize_repo_raises_error_on_failure(monkeypatch, temp_dir):
         GitRepoManager(temp_dir)
 
 
-def test_gitrepo_init(temp_dir):
+def test_gitrepo_init(temp_dir) -> None:
     src_directory = get_fixtures_dir() / "integration/mock_repo"
     repo = GitRepo(name="mock_repo", src_directory=src_directory, dst_directory=Path(temp_dir))
     assert len(list(repo._repo.git.get_walker())) == 1

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -25,14 +25,14 @@ sync_schema_methods = [method for method in dir(InfrahubSchemaSync) if not metho
 client_types = ["standard", "sync"]
 
 
-async def test_method_sanity():
+async def test_method_sanity() -> None:
     """Validate that there is at least one public method and that both clients look the same."""
     assert async_schema_methods
     assert async_schema_methods == sync_schema_methods
 
 
 @pytest.mark.parametrize("method", async_schema_methods)
-async def test_validate_method_signature(method):
+async def test_validate_method_signature(method) -> None:
     async_method = getattr(InfrahubSchema, method)
     sync_method = getattr(InfrahubSchemaSync, method)
     async_sig = inspect.signature(async_method)
@@ -42,7 +42,7 @@ async def test_validate_method_signature(method):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_fetch_schema(mock_schema_query_01, client_type):
+async def test_fetch_schema(mock_schema_query_01, client_type) -> None:
     if client_type == "standard":
         client = InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
         nodes = await client.schema.fetch(branch="main")
@@ -88,7 +88,7 @@ async def test_fetch_schema_conditional_refresh(mock_schema_query_01: HTTPXMock,
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_schema_data_validation(rfile_schema, client_type):
+async def test_schema_data_validation(rfile_schema, client_type) -> None:
     if client_type == "standard":
         client = InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
     else:
@@ -108,7 +108,9 @@ async def test_schema_data_validation(rfile_schema, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_add_dropdown_option(clients, client_type, mock_schema_query_01, mock_query_mutation_schema_dropdown_add):
+async def test_add_dropdown_option(
+    clients, client_type, mock_schema_query_01, mock_query_mutation_schema_dropdown_add
+) -> None:
     if client_type == "standard":
         await clients.standard.schema.add_dropdown_option("BuiltinTag", "status", "something")
     else:
@@ -118,7 +120,7 @@ async def test_add_dropdown_option(clients, client_type, mock_schema_query_01, m
 @pytest.mark.parametrize("client_type", client_types)
 async def test_remove_dropdown_option(
     clients, client_type, mock_schema_query_01, mock_query_mutation_schema_dropdown_remove
-):
+) -> None:
     if client_type == "standard":
         await clients.standard.schema.remove_dropdown_option("BuiltinTag", "status", "active")
     else:
@@ -126,7 +128,7 @@ async def test_remove_dropdown_option(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_add_enum_option(clients, client_type, mock_schema_query_01, mock_query_mutation_schema_enum_add):
+async def test_add_enum_option(clients, client_type, mock_schema_query_01, mock_query_mutation_schema_enum_add) -> None:
     if client_type == "standard":
         await clients.standard.schema.add_enum_option("BuiltinTag", "mode", "hard")
     else:
@@ -134,7 +136,9 @@ async def test_add_enum_option(clients, client_type, mock_schema_query_01, mock_
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_remove_enum_option(clients, client_type, mock_schema_query_01, mock_query_mutation_schema_enum_remove):
+async def test_remove_enum_option(
+    clients, client_type, mock_schema_query_01, mock_query_mutation_schema_enum_remove
+) -> None:
     if client_type == "standard":
         await clients.standard.schema.remove_enum_option("BuiltinTag", "mode", "easy")
     else:
@@ -142,7 +146,7 @@ async def test_remove_enum_option(clients, client_type, mock_schema_query_01, mo
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_add_dropdown_option_raises(clients, client_type, mock_schema_query_01):
+async def test_add_dropdown_option_raises(clients, client_type, mock_schema_query_01) -> None:
     if client_type == "standard":
         with pytest.raises(SchemaNotFoundError):
             await clients.standard.schema.add_dropdown_option("DoesNotExist", "atribute", "option")
@@ -156,7 +160,7 @@ async def test_add_dropdown_option_raises(clients, client_type, mock_schema_quer
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_add_enum_option_raises(clients, client_type, mock_schema_query_01):
+async def test_add_enum_option_raises(clients, client_type, mock_schema_query_01) -> None:
     if client_type == "standard":
         with pytest.raises(SchemaNotFoundError):
             await clients.standard.schema.add_enum_option("DoesNotExist", "atribute", "option")
@@ -170,7 +174,7 @@ async def test_add_enum_option_raises(clients, client_type, mock_schema_query_01
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_remove_dropdown_option_raises(clients, client_type, mock_schema_query_01):
+async def test_remove_dropdown_option_raises(clients, client_type, mock_schema_query_01) -> None:
     if client_type == "standard":
         with pytest.raises(SchemaNotFoundError):
             await clients.standard.schema.remove_dropdown_option("DoesNotExist", "atribute", "option")
@@ -184,7 +188,7 @@ async def test_remove_dropdown_option_raises(clients, client_type, mock_schema_q
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_remove_enum_option_raises(clients, client_type, mock_schema_query_01):
+async def test_remove_enum_option_raises(clients, client_type, mock_schema_query_01) -> None:
     if client_type == "standard":
         with pytest.raises(SchemaNotFoundError):
             await clients.standard.schema.remove_enum_option("DoesNotExist", "atribute", "option")
@@ -246,7 +250,7 @@ async def test_schema_set_cache_branch_schema(
     assert client.schema.cache["main"].nodes["CoreGraphQLQuery"]
 
 
-async def test_infrahub_repository_config_getters():
+async def test_infrahub_repository_config_getters() -> None:
     repo_config = InfrahubRepositoryConfig(
         jinja2_transforms=[
             InfrahubJinja2TransformConfig(name="rfile01", query="query01", template_path="."),
@@ -297,7 +301,7 @@ async def test_infrahub_repository_config_getters():
     assert isinstance(repo_config.get_python_transform(name="transform01"), InfrahubPythonTransformConfig)
 
 
-async def test_infrahub_repository_config_dups():
+async def test_infrahub_repository_config_dups() -> None:
     with pytest.raises(ValueError) as exc:
         InfrahubRepositoryConfig(
             jinja2_transforms=[
@@ -332,7 +336,7 @@ async def test_infrahub_repository_config_dups():
         "attributes": [{"name": "name", "kind": "Text"}, {"name": "status", "kind": "Dropdown"}],
     },
 )
-async def test_display_schema_load_errors_details_dropdown(mock_get_node):
+async def test_display_schema_load_errors_details_dropdown(mock_get_node) -> None:
     """Validate error message with details when loading schema."""
     error = {
         "detail": [
@@ -365,7 +369,7 @@ async def test_display_schema_load_errors_details_dropdown(mock_get_node):
         "attributes": [{"name": "name", "kind": "Text"}, {"name": "status", "kind": "Dropdown"}],
     },
 )
-async def test_display_schema_load_errors_details_namespace(mock_get_node):
+async def test_display_schema_load_errors_details_namespace(mock_get_node) -> None:
     """Validate error message with details when loading schema."""
     error = {
         "detail": [

--- a/tests/unit/sdk/test_schema_sorter.py
+++ b/tests/unit/sdk/test_schema_sorter.py
@@ -2,7 +2,7 @@ from infrahub_sdk import InfrahubClient
 from infrahub_sdk.transfer.schema_sorter import InfrahubSchemaTopologicalSorter
 
 
-async def test_schema_sorter(client: InfrahubClient, mock_schema_query_01):
+async def test_schema_sorter(client: InfrahubClient, mock_schema_query_01) -> None:
     schemas = await client.schema.all()
     topological_sorter = InfrahubSchemaTopologicalSorter()
 

--- a/tests/unit/sdk/test_store.py
+++ b/tests/unit/sdk/test_store.py
@@ -8,7 +8,7 @@ client_types = ["standard", "sync"]
 
 
 @pytest.mark.parametrize("client_type", client_types)
-def test_node_store_set(client_type, clients, schema_with_hfid):
+def test_node_store_set(client_type, clients, schema_with_hfid) -> None:
     if client_type == "standard":
         client = clients.standard
         store = NodeStore(default_branch="main")
@@ -33,7 +33,7 @@ def test_node_store_set(client_type, clients, schema_with_hfid):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-def test_node_store_set_no_hfid(client_type, clients, location_schema):
+def test_node_store_set_no_hfid(client_type, clients, location_schema) -> None:
     if client_type == "standard":
         client = clients.standard
         store = NodeStore(default_branch="main")
@@ -67,7 +67,7 @@ def test_node_store_set_no_hfid(client_type, clients, location_schema):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-def test_node_store_get(client_type, clients, location_schema):
+def test_node_store_get(client_type, clients, location_schema) -> None:
     if client_type == "standard":
         client = clients.standard
         store = NodeStore(default_branch="main")
@@ -111,7 +111,7 @@ def test_node_store_get(client_type, clients, location_schema):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-def test_node_store_get_with_hfid(client_type, clients, schema_with_hfid):
+def test_node_store_get_with_hfid(client_type, clients, schema_with_hfid) -> None:
     if client_type == "standard":
         client = clients.standard
         store = NodeStore(default_branch="main")

--- a/tests/unit/sdk/test_store_branch.py
+++ b/tests/unit/sdk/test_store_branch.py
@@ -6,7 +6,7 @@ from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.store import NodeStoreBranch
 
 
-def test_node_store_set(client: InfrahubClient, schema_with_hfid):
+def test_node_store_set(client: InfrahubClient, schema_with_hfid) -> None:
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -22,7 +22,7 @@ def test_node_store_set(client: InfrahubClient, schema_with_hfid):
     assert store._keys["mykey"] == node._internal_id
 
 
-def test_node_store_set_no_hfid(client: InfrahubClient, location_schema):
+def test_node_store_set_no_hfid(client: InfrahubClient, location_schema) -> None:
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -39,7 +39,7 @@ def test_node_store_set_no_hfid(client: InfrahubClient, location_schema):
     assert store._keys["mykey"] == node._internal_id
 
 
-def test_node_store_get(client: InfrahubClient, location_schema):
+def test_node_store_get(client: InfrahubClient, location_schema) -> None:
     data = {
         "id": "54f3108c-1f21-44c4-93cf-ec5737587b48",
         "name": {"value": "JFK1"},
@@ -65,7 +65,7 @@ def test_node_store_get(client: InfrahubClient, location_schema):
         store.get(key="anotherkey")
 
 
-def test_node_store_get_with_hfid(client: InfrahubClient, schema_with_hfid):
+def test_node_store_get_with_hfid(client: InfrahubClient, schema_with_hfid) -> None:
     data = {
         "id": "54f3108c-1f21-44c4-93cf-ec5737587b48",
         "name": {"value": "JFK1"},

--- a/tests/unit/sdk/test_task.py
+++ b/tests/unit/sdk/test_task.py
@@ -10,7 +10,7 @@ client_types = ["standard", "sync"]
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_all(clients, mock_query_tasks_01, client_type):
+async def test_method_all(clients, mock_query_tasks_01, client_type) -> None:
     if client_type == "standard":
         tasks = await clients.standard.task.all()
     else:
@@ -21,7 +21,7 @@ async def test_method_all(clients, mock_query_tasks_01, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_all_full(clients, mock_query_tasks_01, client_type):
+async def test_method_all_full(clients, mock_query_tasks_01, client_type) -> None:
     if client_type == "standard":
         tasks = await clients.standard.task.all(include_logs=True, include_related_nodes=True)
     else:
@@ -31,7 +31,7 @@ async def test_method_all_full(clients, mock_query_tasks_01, client_type):
     assert isinstance(tasks[0], Task)
 
 
-async def test_generate_count_query():
+async def test_generate_count_query() -> None:
     query = InfraHubTaskManagerBase._generate_count_query()
     assert query
     assert (
@@ -62,7 +62,7 @@ query {
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_filters(clients, mock_query_tasks_02_main, client_type):
+async def test_method_filters(clients, mock_query_tasks_02_main, client_type) -> None:
     if client_type == "standard":
         tasks = await clients.standard.task.filter(filter=TaskFilter(branch="main"))
     else:
@@ -73,7 +73,7 @@ async def test_method_filters(clients, mock_query_tasks_02_main, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_too_many(clients, mock_query_tasks_02_main, client_type):
+async def test_method_get_too_many(clients, mock_query_tasks_02_main, client_type) -> None:
     with pytest.raises(TooManyTasksError):
         if client_type == "standard":
             await clients.standard.task.get(id="a60f4431-6a43-451e-8f42-9ec5db9a9370")
@@ -82,7 +82,7 @@ async def test_method_get_too_many(clients, mock_query_tasks_02_main, client_typ
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_not_found(clients, mock_query_tasks_empty, client_type):
+async def test_method_get_not_found(clients, mock_query_tasks_empty, client_type) -> None:
     with pytest.raises(TaskNotFoundError):
         if client_type == "standard":
             await clients.standard.task.get(id="a60f4431-6a43-451e-8f42-9ec5db9a9370")
@@ -91,7 +91,7 @@ async def test_method_get_not_found(clients, mock_query_tasks_empty, client_type
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get(clients, mock_query_tasks_03, client_type):
+async def test_method_get(clients, mock_query_tasks_03, client_type) -> None:
     if client_type == "standard":
         task = await clients.standard.task.get(id="a60f4431-6a43-451e-8f42-9ec5db9a9370")
     else:
@@ -102,7 +102,7 @@ async def test_method_get(clients, mock_query_tasks_03, client_type):
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_full(clients, mock_query_tasks_05, client_type):
+async def test_method_get_full(clients, mock_query_tasks_05, client_type) -> None:
     if client_type == "standard":
         task = await clients.standard.task.get(id="32116fcd-9071-43a7-9f14-777901020b5b")
     else:

--- a/tests/unit/sdk/test_timestamp.py
+++ b/tests/unit/sdk/test_timestamp.py
@@ -9,7 +9,7 @@ from infrahub_sdk.timestamp import Timestamp
 UTC = timezone.utc  # Required for older versions of Python
 
 
-def test_init_empty():
+def test_init_empty() -> None:
     t1 = Timestamp()
     assert isinstance(t1, Timestamp)
     assert t1.to_datetime() == t1._obj.py_datetime()
@@ -19,7 +19,7 @@ def test_init_empty():
     assert t2.to_datetime() == t2._obj.py_datetime()
 
 
-def test_init_timestamp():
+def test_init_timestamp() -> None:
     t1 = Timestamp()
     t2 = Timestamp(t1)
     assert t1.to_string() == t2.to_string()
@@ -27,7 +27,7 @@ def test_init_timestamp():
     assert t2.to_datetime() == t2._obj.py_datetime()
 
 
-def test_parse_string():
+def test_parse_string() -> None:
     REF = "2022-01-01T10:00:00.000000Z"
 
     assert Timestamp._parse_string(REF).instant() == Instant.parse_common_iso(REF)
@@ -63,7 +63,7 @@ def test_parse_string():
         ),
     ],
 )
-def test_to_datetime(input_str, expected_datetime):
+def test_to_datetime(input_str, expected_datetime) -> None:
     assert isinstance(Timestamp(input_str).to_datetime(), datetime)
     assert Timestamp(input_str).to_datetime() == expected_datetime
 
@@ -85,25 +85,25 @@ def test_to_datetime(input_str, expected_datetime):
         ),
     ],
 )
-def test_to_string_default(input_str, expected_str, expected_str_no_z):
+def test_to_string_default(input_str, expected_str, expected_str_no_z) -> None:
     assert isinstance(Timestamp(input_str).to_string(), str)
     assert Timestamp(input_str).to_string() == expected_str
     assert Timestamp(input_str).to_string(with_z=False) == expected_str_no_z
 
 
-def test_add():
+def test_add() -> None:
     t1 = Timestamp("2022-01-01T10:01:01.123Z")
     t2 = t1.add(hours=1)
     assert t2.to_string() == "2022-01-01T11:01:01.123000Z"
 
 
-def test_subtract():
+def test_subtract() -> None:
     t1 = Timestamp("2022-01-01T10:05:01.123Z")
     t2 = t1.subtract(hours=1)
     assert t2.to_string() == "2022-01-01T09:05:01.123000Z"
 
 
-def test_compare():
+def test_compare() -> None:
     time1 = "2022-01-01T11:00:00.000000Z"
     time2 = "2022-02-01T11:00:00.000000Z"
 
@@ -119,7 +119,7 @@ def test_compare():
     assert t11 == t12
 
 
-def test_serialize():
+def test_serialize() -> None:
     time_no_z = "2022-01-01T11:00:00.000000+00:00"
     time = "2022-01-01T11:00:00.000000Z"
     timestamp = Timestamp(time)
@@ -129,6 +129,6 @@ def test_serialize():
 
 
 @pytest.mark.parametrize("invalid_str", ["blurple", "1122334455667788", "2023-45-99"])
-def test_invalid_raises_correct_error(invalid_str):
+def test_invalid_raises_correct_error(invalid_str) -> None:
     with pytest.raises(TimestampFormatError):
         Timestamp(invalid_str)

--- a/tests/unit/sdk/test_topological_sort.py
+++ b/tests/unit/sdk/test_topological_sort.py
@@ -3,11 +3,11 @@ import pytest
 from infrahub_sdk.topological_sort import DependencyCycleExistsError, topological_sort
 
 
-def test_topological_sort_empty():
+def test_topological_sort_empty() -> None:
     assert topological_sort(dict()) == []
 
 
-def test_topological_sort_with_cycle_raises_error():
+def test_topological_sort_with_cycle_raises_error() -> None:
     dependencies = {0: [1, 2], 1: [2], 2: [0]}
 
     with pytest.raises(DependencyCycleExistsError) as exc:
@@ -16,7 +16,7 @@ def test_topological_sort_with_cycle_raises_error():
     assert [0, 1, 2, 0] in exc.value.cycles or [0, 2, 0] in exc.value.cycles
 
 
-def test_topological_sort_with_two_separate_cycles_raises_error():
+def test_topological_sort_with_two_separate_cycles_raises_error() -> None:
     dependencies = {0: [1, 2], 1: [2], 2: [0], 4: [5, 6], 5: [1, 6], 6: [4]}
 
     with pytest.raises(DependencyCycleExistsError) as exc:
@@ -26,7 +26,7 @@ def test_topological_sort_with_two_separate_cycles_raises_error():
     assert [4, 5, 6, 4] in exc.value.cycles or [4, 6, 4] in exc.value.cycles
 
 
-def test_topological_sort():
+def test_topological_sort() -> None:
     dependencies = {0: [1, 2], 1: [2]}
 
     ordered = topological_sort(dependencies)
@@ -34,7 +34,7 @@ def test_topological_sort():
     assert ordered == [{2}, {1}, {0}]
 
 
-def test_topological_sort_2():
+def test_topological_sort_2() -> None:
     dependencies = {
         0: [1, 2],
         1: [2],
@@ -46,7 +46,7 @@ def test_topological_sort_2():
     assert ordered == [{3}, {2}, {1}, {0}]
 
 
-def test_topological_sort_disjoint():
+def test_topological_sort_disjoint() -> None:
     dependencies = {
         "a": ["b", "c"],
         "b": ["c"],
@@ -61,7 +61,7 @@ def test_topological_sort_disjoint():
     assert ordered == [{"h", "d"}, {"g", "c"}, {"b", "f"}, {"a", "e"}]
 
 
-def test_topological_sort_disjoint_2():
+def test_topological_sort_disjoint_2() -> None:
     dependencies = {
         "a": ["b"],
         "c": ["d"],
@@ -73,7 +73,7 @@ def test_topological_sort_disjoint_2():
     assert ordered == [{"b", "d", "f"}, {"a", "c", "e"}]
 
 
-def test_topological_sort_binary_tree():
+def test_topological_sort_binary_tree() -> None:
     """
                 a
         b               c

--- a/tests/unit/sdk/test_utils.py
+++ b/tests/unit/sdk/test_utils.py
@@ -25,13 +25,13 @@ from infrahub_sdk.utils import (
 )
 
 
-def test_generate_short_id():
+def test_generate_short_id() -> None:
     assert len(generate_short_id()) == 22
     assert isinstance(generate_short_id(), str)
     assert generate_short_id() != generate_short_id()
 
 
-def test_is_valid_uuid():
+def test_is_valid_uuid() -> None:
     assert is_valid_uuid(uuid.uuid4()) is True
     assert is_valid_uuid(uuid.UUID("ba0aecd9-546a-4d77-9187-23e17a20633e")) is True
     assert is_valid_uuid("ba0aecd9-546a-4d77-9187-23e17a20633e") is True
@@ -57,11 +57,11 @@ def test_is_valid_uuid():
         ("http:/192.168.1.10", False),
     ],
 )
-def test_is_valid_url(input, result):
+def test_is_valid_url(input, result) -> None:
     assert is_valid_url(input) is result
 
 
-def test_duplicates():
+def test_duplicates() -> None:
     assert duplicates([2, 4, 6, 8, 4, 6, 12]) == [4, 6]
     assert duplicates(["first", "second", "first", "third", "first", "last"]) == ["first"]
     assert not duplicates([2, 8, 4, 6, 12])
@@ -69,7 +69,7 @@ def test_duplicates():
     assert duplicates([None, None]) == []
 
 
-def test_compare_lists():
+def test_compare_lists() -> None:
     list_a = ["black", "blue", "red"]
     list_b = ["black", "green"]
     list_c = ["purple", "yellow"]
@@ -90,7 +90,7 @@ def test_compare_lists():
     assert in2 == []
 
 
-def test_deep_merge_dict():
+def test_deep_merge_dict() -> None:
     a = {"keyA": 1}
     b = {"keyB": {"sub1": 10}}
     c = {"keyB": {"sub2": 20}}
@@ -104,7 +104,7 @@ def test_deep_merge_dict():
     assert deep_merge_dict(f, g) == {"keyA": "foo", "keyB": "bar"}
 
 
-def test_str_to_bool():
+def test_str_to_bool() -> None:
     assert str_to_bool(True) is True
     assert str_to_bool(False) is False
 
@@ -130,21 +130,21 @@ def test_str_to_bool():
         str_to_bool(tuple("a", "b", "c"))
 
 
-def test_base36():
+def test_base36() -> None:
     assert base36encode(1412823931503067241) == "AQF8AA0006EH"
     assert base36decode("AQF8AA0006EH") == 1412823931503067241
     assert base36decode(base36encode(-9223372036721928027)) == -9223372036721928027
     assert base36decode(base36encode(1412823931503067241)) == 1412823931503067241
 
 
-def test_base16():
+def test_base16() -> None:
     assert base16encode(1412823931503067241) == "139b5be157694069"
     assert base16decode("139b5be157694069") == 1412823931503067241
     assert base16decode(base16encode(-9223372036721928027)) == -9223372036721928027
     assert base16decode(base16encode(1412823931503067241)) == 1412823931503067241
 
 
-def test_dict_hash():
+def test_dict_hash() -> None:
     assert dict_hash({"a": 1, "b": 2}) == "608de49a4600dbb5b173492759792e4a"
     assert dict_hash({"b": 2, "a": 1}) == "608de49a4600dbb5b173492759792e4a"
     assert dict_hash({"b": 2, "a": {"c": 1, "d": 2}}) == "4d8f1a3d03e0b487983383d0ff984d13"
@@ -152,7 +152,7 @@ def test_dict_hash():
     assert dict_hash({}) == "99914b932bd37a50b983c5e7c90ae93b"
 
 
-async def test_extract_fields(query_01):
+async def test_extract_fields(query_01) -> None:
     document = parse(query_01)
     expected_response = {
         "TestPerson": {
@@ -167,7 +167,7 @@ async def test_extract_fields(query_01):
     assert await extract_fields(document.definitions[0].selection_set) == expected_response
 
 
-async def test_extract_fields_fragment(query_02):
+async def test_extract_fields_fragment(query_02) -> None:
     document = parse(query_02)
 
     expected_response = {
@@ -195,7 +195,7 @@ async def test_extract_fields_fragment(query_02):
     assert await extract_fields(document.definitions[0].selection_set) == expected_response
 
 
-def test_write_to_file():
+def test_write_to_file() -> None:
     tmp_dir = tempfile.TemporaryDirectory()
     directory = Path(tmp_dir.name)
 
@@ -212,7 +212,7 @@ def test_write_to_file():
     tmp_dir.cleanup()
 
 
-def test_calculate_time_diff():
+def test_calculate_time_diff() -> None:
     time1 = Instant.now().subtract(seconds=98).format_common_iso()
     assert calculate_time_diff(time1) == "1m and 38s ago"
 

--- a/tests/unit/sdk/test_uuidt.py
+++ b/tests/unit/sdk/test_uuidt.py
@@ -4,7 +4,7 @@ from infrahub_sdk.utils import is_valid_uuid
 from infrahub_sdk.uuidt import UUIDT
 
 
-def test_uuidt():
+def test_uuidt() -> None:
     uuid1 = str(UUIDT())
     uuid2 = str(UUIDT())
     uuid3 = str(UUIDT())
@@ -19,7 +19,7 @@ def test_uuidt():
     assert sorted([uuid3, uuid2, uuid1]) == [uuid1, uuid2, uuid3]
 
 
-def test_uuidt_short():
+def test_uuidt_short() -> None:
     short1 = UUIDT().short()
     short2 = UUIDT().short()
     assert isinstance(short1, str)

--- a/tests/unit/sdk/test_yaml.py
+++ b/tests/unit/sdk/test_yaml.py
@@ -48,7 +48,7 @@ def test_read_multiple_files_invalid() -> None:
     assert yaml_files[1].valid is False
 
 
-def test_load_non_existing_folder():
+def test_load_non_existing_folder() -> None:
     with pytest.raises(FileNotValidError) as exc:
         YamlFile.load_from_disk(paths=[get_fixtures_dir() / "does_not_exist"])
     assert "does not exist" in str(exc.value)


### PR DESCRIPTION
Fixes for Ruff ANN201: Missing return type annotation for public function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added explicit None return type annotations across integration and unit tests for clearer typing.
  - Expanded Timestamp tests to cover durations, date/datetime with offsets, and invalid input handling.
  - Updated CLI “info detail” tests to validate additional output sections (e.g., Version Information, Client Info, Infrahub Info, Groups).
  - Minor signature formatting adjustments in several tests; no runtime behavior changes.
- Chores
  - General test suite cleanup and consistency improvements via type hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->