### PR TITLE
Remove unnecessary  call (rewrite as a literal)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,6 @@ ignore = [
     ##################################################################################################
     "B008",    # Do not perform function call `typer.Option` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
     "B904",    # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-    "C408",    # Unnecessary `dict` call (rewrite as a literal)
     "FURB110", # Replace ternary `if` expression with `or` operator
     "FURB113", # Use `lines.extend((" " * self.indentation + "}", "}"))` instead of repeatedly calling `lines.append()`
     "FURB177", # Prefer `Path.cwd()` over `Path().resolve()` for current-directory lookups

--- a/tests/unit/sdk/test_topological_sort.py
+++ b/tests/unit/sdk/test_topological_sort.py
@@ -4,7 +4,7 @@ from infrahub_sdk.topological_sort import DependencyCycleExistsError, topologica
 
 
 def test_topological_sort_empty():
-    assert topological_sort(dict()) == []
+    assert topological_sort({}) == []
 
 
 def test_topological_sort_with_cycle_raises_error():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Chores
  - Updated linting configuration to flag unnecessary dict() calls, improving code quality and consistency. This may surface new warnings locally and in CI, with no runtime impact.
- Tests
  - Adjusted a unit test to use {} for empty dictionaries, maintaining behavior and coverage while aligning with linting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->