### PR TITLE
IHS-154 Deprecate using `raise_for_error = False`

### DIFF
--- a/changelog/493.changed.md
+++ b/changelog/493.changed.md
@@ -1,0 +1,1 @@
+Deprecate the use of `raise_for_error=False` when using `execute_graphql` methods.

--- a/changelog/493.changed.md
+++ b/changelog/493.changed.md
@@ -1,1 +1,1 @@
-Deprecate the use of `raise_for_error=False` when using `execute_graphql` methods.
+Deprecate the use of `raise_for_error=False` across several methods, using a try/except pattern is preferred.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1649,14 +1649,17 @@ class InfrahubClientSync(BaseClient):
             branch_name (str, optional): Name of the branch on which the query will be executed. Defaults to None.
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
-            raise_for_error (bool, optional): Deprecated, flag to indicate that we need to raise an exception if the response has some errors.
-            Defaults to True.
+            raise_for_error (bool | None, optional): Deprecated. Controls only HTTP status handling.
+                - None (default) or True: HTTP errors raise via `resp.raise_for_status()`.
+                - False: HTTP errors are not automatically raised.
+              GraphQL errors always raise `GraphQLError`.
+            Defaults to None.
+
         Raises:
-            GraphQLError: When an error occurs during the execution of the GraphQL query or mutation.
+            GraphQLError: When the GraphQL response contains errors.
 
         Returns:
-            dict: The result of the GraphQL query or mutation.
-        """
+            dict: The GraphQL data payload (`response["data"]`).
         if raise_for_error is not None:
             warnings.warn(
                 "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -950,7 +950,9 @@ class InfrahubClient(BaseClient):
         response = decode_json(response=resp)
 
         if "errors" in response:
-            raise GraphQLError(errors=response["errors"], query=query, variables=variables)
+            if raise_for_error:
+                raise GraphQLError(errors=response["errors"], query=query, variables=variables)
+            return response["errors"]
 
         return response["data"]
 
@@ -1694,7 +1696,9 @@ class InfrahubClientSync(BaseClient):
         response = decode_json(response=resp)
 
         if "errors" in response:
-            raise GraphQLError(errors=response["errors"], query=query, variables=variables)
+            if raise_for_error:
+                raise GraphQLError(errors=response["errors"], query=query, variables=variables)
+            return response["errors"]
 
         return response["data"]
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1660,6 +1660,7 @@ class InfrahubClientSync(BaseClient):
 
         Returns:
             dict: The GraphQL data payload (`response["data"]`).
+        """
         if raise_for_error is not None:
             warnings.warn(
                 "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import logging
 import time
+import warnings
 from collections.abc import Coroutine, MutableMapping
 from functools import wraps
 from time import sleep
@@ -893,13 +894,20 @@ class InfrahubClient(BaseClient):
             branch_name (str, optional): Name of the branch on which the query will be executed. Defaults to None.
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
-            raise_for_error (bool, optional): Flag to indicate that we need to raise an exception if the response has some errors. Defaults to True.
+            raise_for_error (bool, optional): Deprecated, flag to indicate that we need to raise an exception if the response has some errors.
+            Defaults to True.
         Raises:
             GraphQLError: _description_
 
         Returns:
             _type_: _description_
         """
+        if not raise_for_error:
+            warnings.warn(
+                "Setting `raise_for_error=False` is deprecated, use `try/except` to handle errors.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
 
         branch_name = branch_name or self.default_branch
         url = self._graphql_url(branch_name=branch_name, at=at)
@@ -950,9 +958,7 @@ class InfrahubClient(BaseClient):
         response = decode_json(response=resp)
 
         if "errors" in response:
-            if raise_for_error:
-                raise GraphQLError(errors=response["errors"], query=query, variables=variables)
-            return response["errors"]
+            raise GraphQLError(errors=response["errors"], query=query, variables=variables)
 
         return response["data"]
 
@@ -1639,13 +1645,20 @@ class InfrahubClientSync(BaseClient):
             branch_name (str, optional): Name of the branch on which the query will be executed. Defaults to None.
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
-            raise_for_error (bool, optional): Flag to indicate that we need to raise an exception if the response has some errors. Defaults to True.
+            raise_for_error (bool, optional): Deprecated, flag to indicate that we need to raise an exception if the response has some errors.
+            Defaults to True.
         Raises:
             GraphQLError: When an error occurs during the execution of the GraphQL query or mutation.
 
         Returns:
             dict: The result of the GraphQL query or mutation.
         """
+        if not raise_for_error:
+            warnings.warn(
+                "Setting `raise_for_error=False` is deprecated, use `try/except` to handle errors.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
 
         branch_name = branch_name or self.default_branch
         url = self._graphql_url(branch_name=branch_name, at=at)
@@ -1696,9 +1709,7 @@ class InfrahubClientSync(BaseClient):
         response = decode_json(response=resp)
 
         if "errors" in response:
-            if raise_for_error:
-                raise GraphQLError(errors=response["errors"], query=query, variables=variables)
-            return response["errors"]
+            raise GraphQLError(errors=response["errors"], query=query, variables=variables)
 
         return response["data"]
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -894,13 +894,17 @@ class InfrahubClient(BaseClient):
             branch_name (str, optional): Name of the branch on which the query will be executed. Defaults to None.
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
-            raise_for_error (bool, optional): Deprecated, flag to indicate that we need to raise an exception if the response has some errors.
-            Defaults to True.
+            raise_for_error (bool | None, optional): Deprecated. Controls only HTTP status handling.
+                - None (default) or True: HTTP errors raise via resp.raise_for_status().
+                - False: HTTP errors are not automatically raised.
+              GraphQL errors always raise GraphQLError.
+            Defaults to None.
+
         Raises:
-            GraphQLError: _description_
+            GraphQLError: When the GraphQL response contains errors.
 
         Returns:
-            _type_: _description_
+            dict: The GraphQL data payload (response["data"]).
         """
         if raise_for_error is not None:
             warnings.warn(

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -106,6 +106,15 @@ def handle_relogin_sync(func: Callable[..., httpx.Response]):  # type: ignore[no
     return wrapper
 
 
+def raise_for_error_deprecation_warning(value: bool | None) -> None:
+    if value is not None:
+        warnings.warn(
+            "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+
 class BaseClient:
     """Base class for InfrahubClient and InfrahubClientSync"""
 
@@ -896,9 +905,7 @@ class InfrahubClient(BaseClient):
             timeout (int, optional): Timeout in second for the query. Defaults to None.
             raise_for_error (bool | None, optional): Deprecated. Controls only HTTP status handling.
                 - None (default) or True: HTTP errors raise via resp.raise_for_status().
-                - False: HTTP errors are not automatically raised.
-              GraphQL errors always raise GraphQLError.
-            Defaults to None.
+                - False: HTTP errors are not automatically raised. Defaults to None.
 
         Raises:
             GraphQLError: When the GraphQL response contains errors.
@@ -906,12 +913,7 @@ class InfrahubClient(BaseClient):
         Returns:
             dict: The GraphQL data payload (response["data"]).
         """
-        if raise_for_error is not None:
-            warnings.warn(
-                "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
+        raise_for_error_deprecation_warning(value=raise_for_error)
 
         branch_name = branch_name or self.default_branch
         url = self._graphql_url(branch_name=branch_name, at=at)
@@ -1111,8 +1113,10 @@ class InfrahubClient(BaseClient):
         at: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> dict:
+        raise_for_error_deprecation_warning(value=raise_for_error)
+
         url = f"{self.address}/api/query/{name}"
         url_params = copy.deepcopy(params or {})
         headers = copy.copy(self.headers or {})
@@ -1157,7 +1161,7 @@ class InfrahubClient(BaseClient):
             timeout=timeout or self.default_timeout,
         )
 
-        if raise_for_error:
+        if raise_for_error in (None, True):
             resp.raise_for_status()
 
         return decode_json(response=resp)
@@ -1167,7 +1171,7 @@ class InfrahubClient(BaseClient):
         branch: str,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> list[NodeDiff]:
         query = get_diff_summary_query()
         response = await self.execute_graphql(
@@ -1232,7 +1236,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> SchemaType: ...
 
     @overload
@@ -1277,7 +1281,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> CoreNode | None: ...
 
     async def allocate_next_ip_address(
@@ -1291,7 +1295,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> CoreNode | SchemaType | None:
         """Allocate a new IP address by using the provided resource pool.
 
@@ -1304,7 +1308,7 @@ class InfrahubClient(BaseClient):
             branch (str, optional): Name of the branch to allocate from. Defaults to default_branch.
             timeout (int, optional): Flag to indicate whether to populate the store with the retrieved nodes.
             tracker (str, optional): The offset for pagination.
-            raise_for_error (bool, optional): The limit for pagination.
+            raise_for_error (bool, optional): Deprecated, raise an error if the HTTP status is not 2XX.
         Returns:
             InfrahubNode: Node corresponding to the allocated resource.
         """
@@ -1379,7 +1383,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> SchemaType: ...
 
     @overload
@@ -1427,7 +1431,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> CoreNode | None: ...
 
     async def allocate_next_ip_prefix(
@@ -1442,7 +1446,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> CoreNode | SchemaType | None:
         """Allocate a new IP prefix by using the provided resource pool.
 
@@ -1456,7 +1460,7 @@ class InfrahubClient(BaseClient):
             branch: Name of the branch to allocate from. Defaults to default_branch.
             timeout: Flag to indicate whether to populate the store with the retrieved nodes.
             tracker: The offset for pagination.
-            raise_for_error: The limit for pagination.
+            raise_for_error (bool, optional): Deprecated, raise an error if the HTTP status is not 2XX.
         Returns:
             InfrahubNode: Node corresponding to the allocated resource.
         """
@@ -1652,8 +1656,7 @@ class InfrahubClientSync(BaseClient):
             raise_for_error (bool | None, optional): Deprecated. Controls only HTTP status handling.
                 - None (default) or True: HTTP errors raise via `resp.raise_for_status()`.
                 - False: HTTP errors are not automatically raised.
-              GraphQL errors always raise `GraphQLError`.
-            Defaults to None.
+              GraphQL errors always raise `GraphQLError`. Defaults to None.
 
         Raises:
             GraphQLError: When the GraphQL response contains errors.
@@ -1661,12 +1664,7 @@ class InfrahubClientSync(BaseClient):
         Returns:
             dict: The GraphQL data payload (`response["data"]`).
         """
-        if raise_for_error is not None:
-            warnings.warn(
-                "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
+        raise_for_error_deprecation_warning(value=raise_for_error)
 
         branch_name = branch_name or self.default_branch
         url = self._graphql_url(branch_name=branch_name, at=at)
@@ -2261,8 +2259,10 @@ class InfrahubClientSync(BaseClient):
         at: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> dict:
+        raise_for_error_deprecation_warning(value=raise_for_error)
+
         url = f"{self.address}/api/query/{name}"
         url_params = copy.deepcopy(params or {})
         headers = copy.copy(self.headers or {})
@@ -2306,7 +2306,7 @@ class InfrahubClientSync(BaseClient):
             timeout=timeout or self.default_timeout,
         )
 
-        if raise_for_error:
+        if raise_for_error in (None, True):
             resp.raise_for_status()
 
         return decode_json(response=resp)
@@ -2316,7 +2316,7 @@ class InfrahubClientSync(BaseClient):
         branch: str,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> list[NodeDiff]:
         query = get_diff_summary_query()
         response = self.execute_graphql(
@@ -2381,7 +2381,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> SchemaTypeSync: ...
 
     @overload
@@ -2426,7 +2426,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> CoreNodeSync | None: ...
 
     def allocate_next_ip_address(
@@ -2440,7 +2440,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> CoreNodeSync | SchemaTypeSync | None:
         """Allocate a new IP address by using the provided resource pool.
 
@@ -2524,7 +2524,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> SchemaTypeSync: ...
 
     @overload
@@ -2572,7 +2572,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = ...,
         timeout: int | None = ...,
         tracker: str | None = ...,
-        raise_for_error: bool = ...,
+        raise_for_error: bool | None = ...,
     ) -> CoreNodeSync | None: ...
 
     def allocate_next_ip_prefix(
@@ -2587,7 +2587,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
     ) -> CoreNodeSync | SchemaTypeSync | None:
         """Allocate a new IP prefix by using the provided resource pool.
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -882,7 +882,7 @@ class InfrahubClient(BaseClient):
         branch_name: str | None = None,
         at: str | Timestamp | None = None,
         timeout: int | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
         tracker: str | None = None,
     ) -> dict:
         """Execute a GraphQL query (or mutation).
@@ -902,9 +902,9 @@ class InfrahubClient(BaseClient):
         Returns:
             _type_: _description_
         """
-        if not raise_for_error:
+        if raise_for_error is not None:
             warnings.warn(
-                "Setting `raise_for_error=False` is deprecated, use `try/except` to handle errors.",
+                "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",
                 DeprecationWarning,
                 stacklevel=1,
             )
@@ -930,7 +930,7 @@ class InfrahubClient(BaseClient):
             try:
                 resp = await self._post(url=url, payload=payload, headers=headers, timeout=timeout)
 
-                if raise_for_error:
+                if raise_for_error in (None, True):
                     resp.raise_for_status()
 
                 retry = False
@@ -1633,7 +1633,7 @@ class InfrahubClientSync(BaseClient):
         branch_name: str | None = None,
         at: str | Timestamp | None = None,
         timeout: int | None = None,
-        raise_for_error: bool = True,
+        raise_for_error: bool | None = None,
         tracker: str | None = None,
     ) -> dict:
         """Execute a GraphQL query (or mutation).
@@ -1653,9 +1653,9 @@ class InfrahubClientSync(BaseClient):
         Returns:
             dict: The result of the GraphQL query or mutation.
         """
-        if not raise_for_error:
+        if raise_for_error is not None:
             warnings.warn(
-                "Setting `raise_for_error=False` is deprecated, use `try/except` to handle errors.",
+                "Using `raise_for_error` is deprecated, use `try/except` to handle errors.",
                 DeprecationWarning,
                 stacklevel=1,
             )
@@ -1681,7 +1681,7 @@ class InfrahubClientSync(BaseClient):
             try:
                 resp = self._post(url=url, payload=payload, headers=headers, timeout=timeout)
 
-                if raise_for_error:
+                if raise_for_error in (None, True):
                     resp.raise_for_status()
 
                 retry = False

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from infrahub_sdk import InfrahubClient, InfrahubClientSync
-from infrahub_sdk.exceptions import NodeNotFoundError
+from infrahub_sdk.exceptions import GraphQLError, NodeNotFoundError
 from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
 from tests.unit.sdk.conftest import BothClients
 
@@ -800,3 +800,35 @@ async def test_clone_define_branch(clients: BothClients, client_type: str) -> No
     assert clone.default_branch == clone_branch
     assert original_branch != clone_branch
     assert clone.store._default_branch == clone_branch
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_execute_graphql_error(httpx_mock: HTTPXMock, clients, client_type) -> None:
+    httpx_mock.add_response(method="POST", json={"errors": ["foo"]}, is_reusable=True)
+
+    query = """
+    query GetTags {
+        BuiltinTag {
+            edges {
+                node {
+                    id
+                    display_label
+                }
+            }
+        }
+    }
+    """
+
+    if client_type == "standard":
+        with pytest.raises(GraphQLError):
+            await clients.standard.execute_graphql(query=query, raise_for_error=True)
+
+        response = await clients.standard.execute_graphql(query=query, raise_for_error=False)
+    else:
+        with pytest.raises(GraphQLError):
+            clients.sync.execute_graphql(query=query, raise_for_error=True)
+
+        response = clients.sync.execute_graphql(query=query, raise_for_error=False)
+
+    assert response
+    assert response[0] == "foo"

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from infrahub_sdk import InfrahubClient, InfrahubClientSync
-from infrahub_sdk.exceptions import GraphQLError, NodeNotFoundError
+from infrahub_sdk.exceptions import NodeNotFoundError
 from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
 from tests.unit.sdk.conftest import BothClients
 
@@ -800,35 +800,3 @@ async def test_clone_define_branch(clients: BothClients, client_type: str) -> No
     assert clone.default_branch == clone_branch
     assert original_branch != clone_branch
     assert clone.store._default_branch == clone_branch
-
-
-@pytest.mark.parametrize("client_type", client_types)
-async def test_execute_graphql_error(httpx_mock: HTTPXMock, clients, client_type) -> None:
-    httpx_mock.add_response(method="POST", json={"errors": ["foo"]}, is_reusable=True)
-
-    query = """
-    query GetTags {
-        BuiltinTag {
-            edges {
-                node {
-                    id
-                    display_label
-                }
-            }
-        }
-    }
-    """
-
-    if client_type == "standard":
-        with pytest.raises(GraphQLError):
-            await clients.standard.execute_graphql(query=query, raise_for_error=True)
-
-        response = await clients.standard.execute_graphql(query=query, raise_for_error=False)
-    else:
-        with pytest.raises(GraphQLError):
-            clients.sync.execute_graphql(query=query, raise_for_error=True)
-
-        response = clients.sync.execute_graphql(query=query, raise_for_error=False)
-
-    assert response
-    assert response[0] == "foo"


### PR DESCRIPTION
This is a simple change that adds a warning when using a client's method with the named parameter `raise_for_error` set. This parameter must be removed later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Documented deprecation of explicitly setting raise_for_error (now optional); guidance to use try/except for custom HTTP error handling and note that GraphQL errors still raise regardless.

- Chores
  - Emit deprecation warnings when raise_for_error is provided (non-null) in both sync and async client calls.
  - Made raise_for_error optional: unset or true → HTTP errors raised; false → HTTP errors not raised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->