### PR TITLE
Fix filters `include` parameter

### DIFF
--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -539,7 +539,6 @@ class InfrahubClient(BaseClient):
         response: dict[str, Any],
         schema_kind: str,
         branch: str,
-        prefetch_relationships: bool,
         timeout: int | None = None,
     ) -> ProcessRelationsNode:
         """Processes InfrahubNode and their Relationships from the GraphQL query response.
@@ -548,7 +547,6 @@ class InfrahubClient(BaseClient):
             response (dict[str, Any]): The response from the GraphQL query.
             schema_kind (str): The kind of schema being queried.
             branch (str): The branch name.
-            prefetch_relationships (bool): Flag to indicate whether to prefetch relationship data.
             timeout (int, optional): Overrides default timeout used when querying the graphql API. Specified in seconds.
 
         Returns:
@@ -564,10 +562,9 @@ class InfrahubClient(BaseClient):
             node = await InfrahubNode.from_graphql(client=self, branch=branch, data=item, timeout=timeout)
             nodes.append(node)
 
-            if prefetch_relationships:
-                await node._process_relationships(
-                    node_data=item, branch=branch, related_nodes=related_nodes, timeout=timeout
-                )
+            await node._process_relationships(
+                node_data=item, branch=branch, related_nodes=related_nodes, timeout=timeout
+            )
 
         return ProcessRelationsNode(nodes=nodes, related_nodes=related_nodes)
 
@@ -814,7 +811,6 @@ class InfrahubClient(BaseClient):
                 response=response,
                 schema_kind=schema.kind,
                 branch=branch,
-                prefetch_relationships=prefetch_relationships,
                 timeout=timeout,
             )
             return response, process_result

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -558,9 +558,6 @@ class InfrahubClient(BaseClient):
                 - 'related_nodes': A list of InfrahubNode objects representing the related nodes
         """
 
-        # Ideally, include and relationships wouldn't be parameters of this method, they should only
-        # be used to build the request for the server, and this method would build node according to the response.
-
         nodes: list[InfrahubNode] = []
         related_nodes: list[InfrahubNode] = []
 
@@ -568,7 +565,7 @@ class InfrahubClient(BaseClient):
             node = await InfrahubNode.from_graphql(client=self, branch=branch, data=item, timeout=timeout)
             nodes.append(node)
 
-            if prefetch_relationships or include is not None:
+            if prefetch_relationships or (include and any(rel in include for rel in node._relationships)):
                 await node._process_relationships(
                     node_data=item,
                     branch=branch,
@@ -1864,7 +1861,7 @@ class InfrahubClientSync(BaseClient):
             node = InfrahubNodeSync.from_graphql(client=self, branch=branch, data=item, timeout=timeout)
             nodes.append(node)
 
-            if prefetch_relationships or include is not None:
+            if prefetch_relationships or (include and any(rel in include for rel in node._relationships)):
                 node._process_relationships(node_data=item, branch=branch, related_nodes=related_nodes, timeout=timeout)
 
         return ProcessRelationsNodeSync(nodes=nodes, related_nodes=related_nodes)

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -539,6 +539,8 @@ class InfrahubClient(BaseClient):
         response: dict[str, Any],
         schema_kind: str,
         branch: str,
+        prefetch_relationships: bool,
+        include: list[str] | None,
         timeout: int | None = None,
     ) -> ProcessRelationsNode:
         """Processes InfrahubNode and their Relationships from the GraphQL query response.
@@ -547,6 +549,7 @@ class InfrahubClient(BaseClient):
             response (dict[str, Any]): The response from the GraphQL query.
             schema_kind (str): The kind of schema being queried.
             branch (str): The branch name.
+            prefetch_relationships (bool): Flag to indicate whether to prefetch relationship data.
             timeout (int, optional): Overrides default timeout used when querying the graphql API. Specified in seconds.
 
         Returns:
@@ -562,9 +565,14 @@ class InfrahubClient(BaseClient):
             node = await InfrahubNode.from_graphql(client=self, branch=branch, data=item, timeout=timeout)
             nodes.append(node)
 
-            await node._process_relationships(
-                node_data=item, branch=branch, related_nodes=related_nodes, timeout=timeout
-            )
+            if prefetch_relationships or include is not None:
+                await node._process_relationships(
+                    node_data=item,
+                    branch=branch,
+                    related_nodes=related_nodes,
+                    timeout=timeout,
+                    include=include,
+                )
 
         return ProcessRelationsNode(nodes=nodes, related_nodes=related_nodes)
 
@@ -811,7 +819,9 @@ class InfrahubClient(BaseClient):
                 response=response,
                 schema_kind=schema.kind,
                 branch=branch,
+                prefetch_relationships=prefetch_relationships,
                 timeout=timeout,
+                include=include,
             )
             return response, process_result
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -558,6 +558,9 @@ class InfrahubClient(BaseClient):
                 - 'related_nodes': A list of InfrahubNode objects representing the related nodes
         """
 
+        # Ideally, include and relationships wouldn't be parameters of this method, they should only
+        # be used to build the request for the server, and this method would build node according to the response.
+
         nodes: list[InfrahubNode] = []
         related_nodes: list[InfrahubNode] = []
 
@@ -571,7 +574,6 @@ class InfrahubClient(BaseClient):
                     branch=branch,
                     related_nodes=related_nodes,
                     timeout=timeout,
-                    include=include,
                 )
 
         return ProcessRelationsNode(nodes=nodes, related_nodes=related_nodes)
@@ -1837,6 +1839,7 @@ class InfrahubClientSync(BaseClient):
         schema_kind: str,
         branch: str,
         prefetch_relationships: bool,
+        include: list[str] | None,
         timeout: int | None = None,
     ) -> ProcessRelationsNodeSync:
         """Processes InfrahubNodeSync and their Relationships from the GraphQL query response.
@@ -1861,7 +1864,7 @@ class InfrahubClientSync(BaseClient):
             node = InfrahubNodeSync.from_graphql(client=self, branch=branch, data=item, timeout=timeout)
             nodes.append(node)
 
-            if prefetch_relationships:
+            if prefetch_relationships or include is not None:
                 node._process_relationships(node_data=item, branch=branch, related_nodes=related_nodes, timeout=timeout)
 
         return ProcessRelationsNodeSync(nodes=nodes, related_nodes=related_nodes)
@@ -1986,6 +1989,7 @@ class InfrahubClientSync(BaseClient):
                 branch=branch,
                 prefetch_relationships=prefetch_relationships,
                 timeout=timeout,
+                include=include,
             )
             return response, process_result
 

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -730,11 +730,10 @@ class InfrahubNode(InfrahubNodeBase):
                 continue
 
             rel_schema = self._schema.get_relationship(name=rel_name)
+
             if not rel_schema or (not inherited and rel_schema.inherited):
                 continue
 
-            # Don't fetch many attribute/parent relationships unless they are specified in `include`
-            # TODO Why wouldn't we we fetch them if prefetch_relationships is True?
             if (
                 rel_schema.cardinality == RelationshipCardinality.MANY  # type: ignore[union-attr]
                 and rel_schema.kind not in [RelationshipKind.ATTRIBUTE, RelationshipKind.PARENT]  # type: ignore[union-attr]
@@ -742,36 +741,32 @@ class InfrahubNode(InfrahubNodeBase):
             ):
                 continue
 
+            peer_data: dict[str, Any] = {}
             should_fetch_relationship = prefetch_relationships or (include is not None and rel_name in include)
             if rel_schema and should_fetch_relationship:
                 peer_schema = await self._client.schema.get(kind=rel_schema.peer, branch=self._branch)
                 peer_node = InfrahubNode(client=self._client, schema=peer_schema, branch=self._branch)
                 peer_data = await peer_node.generate_query_data_node(
-                    include=include,
-                    exclude=exclude,
                     property=property,
                 )
 
-                # TODO is there a reason why we fetch here even with prefetch_relationships == False?
-                if rel_schema.cardinality == "one":
-                    rel_data = RelatedNode._generate_query_data(peer_data=peer_data, property=property)
-                    # Nodes involved in a hierarchy are required to inherit from a common ancestor node, and graphql
-                    # tries to resolve attributes in this ancestor instead of actual node. To avoid
-                    # invalid queries issues when attribute is missing in the common ancestor, we use a fragment
-                    # to explicit actual node kind we are querying.
-                    if rel_schema.kind == RelationshipKind.HIERARCHY:
-                        data_node = rel_data["node"]
-                        rel_data["node"] = {}
-                        rel_data["node"][f"...on {rel_schema.peer}"] = data_node
-                elif rel_schema.cardinality == "many":
-                    rel_data = RelationshipManager._generate_query_data(peer_data=peer_data, property=property)
-                else:
-                    raise ValueError(f"Unknown relationship cardinality {rel_schema.cardinality}")
+            if rel_schema and rel_schema.cardinality == "one":
+                rel_data = RelatedNode._generate_query_data(peer_data=peer_data, property=property)
+                # Nodes involved in a hierarchy are required to inherit from a common ancestor node, and graphql
+                # tries to resolve attributes in this ancestor instead of actual node. To avoid
+                # invalid queries issues when attribute is missing in the common ancestor, we use a fragment
+                # to explicit actual node kind we are querying.
+                if rel_schema.kind == RelationshipKind.HIERARCHY:
+                    data_node = rel_data["node"]
+                    rel_data["node"] = {}
+                    rel_data["node"][f"...on {rel_schema.peer}"] = data_node
+            elif rel_schema and rel_schema.cardinality == "many":
+                rel_data = RelationshipManager._generate_query_data(peer_data=peer_data, property=property)
 
-                data[rel_name] = rel_data
+            data[rel_name] = rel_data
 
-                if insert_alias:
-                    data[rel_name]["@alias"] = f"__alias__{self._schema.kind}__{rel_name}"
+            if insert_alias:
+                data[rel_name]["@alias"] = f"__alias__{self._schema.kind}__{rel_name}"
 
         return data
 
@@ -890,7 +885,12 @@ class InfrahubNode(InfrahubNodeBase):
         await self._process_mutation_result(mutation_name=mutation_name, response=response, timeout=timeout)
 
     async def _process_relationships(
-        self, node_data: dict[str, Any], branch: str, related_nodes: list[InfrahubNode], timeout: int | None = None
+        self,
+        node_data: dict[str, Any],
+        branch: str,
+        related_nodes: list[InfrahubNode],
+        timeout: int | None = None,
+        include: list[str] | None = None,
     ) -> None:
         """Processes the Relationships of a InfrahubNode and add Related Nodes to a list.
 
@@ -901,6 +901,8 @@ class InfrahubNode(InfrahubNodeBase):
             timeout (int, optional): Overrides default timeout used when querying the graphql API. Specified in seconds.
         """
         for rel_name in self._relationships:
+            if include is not None and rel_name not in include:
+                continue
             rel = getattr(self, rel_name)
             if rel and isinstance(rel, RelatedNode):
                 relation = node_data["node"].get(rel_name, None)

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -730,10 +730,11 @@ class InfrahubNode(InfrahubNodeBase):
                 continue
 
             rel_schema = self._schema.get_relationship(name=rel_name)
-
             if not rel_schema or (not inherited and rel_schema.inherited):
                 continue
 
+            # Don't fetch many attribute/parent relationships unless they are specified in `include`
+            # TODO Why wouldn't we we fetch them if prefetch_relationships is True?
             if (
                 rel_schema.cardinality == RelationshipCardinality.MANY  # type: ignore[union-attr]
                 and rel_schema.kind not in [RelationshipKind.ATTRIBUTE, RelationshipKind.PARENT]  # type: ignore[union-attr]
@@ -741,8 +742,8 @@ class InfrahubNode(InfrahubNodeBase):
             ):
                 continue
 
-            peer_data: dict[str, Any] = {}
-            if rel_schema and prefetch_relationships:
+            should_fetch_relationship = prefetch_relationships or (include is not None and rel_name in include)
+            if rel_schema and should_fetch_relationship:
                 peer_schema = await self._client.schema.get(kind=rel_schema.peer, branch=self._branch)
                 peer_node = InfrahubNode(client=self._client, schema=peer_schema, branch=self._branch)
                 peer_data = await peer_node.generate_query_data_node(
@@ -751,23 +752,26 @@ class InfrahubNode(InfrahubNodeBase):
                     property=property,
                 )
 
-            if rel_schema and rel_schema.cardinality == "one":
-                rel_data = RelatedNode._generate_query_data(peer_data=peer_data, property=property)
-                # Nodes involved in a hierarchy are required to inherit from a common ancestor node, and graphql
-                # tries to resolve attributes in this ancestor instead of actual node. To avoid
-                # invalid queries issues when attribute is missing in the common ancestor, we use a fragment
-                # to explicit actual node kind we are querying.
-                if rel_schema.kind == RelationshipKind.HIERARCHY:
-                    data_node = rel_data["node"]
-                    rel_data["node"] = {}
-                    rel_data["node"][f"...on {rel_schema.peer}"] = data_node
-            elif rel_schema and rel_schema.cardinality == "many":
-                rel_data = RelationshipManager._generate_query_data(peer_data=peer_data, property=property)
+                # TODO is there a reason why we fetch here even with prefetch_relationships == False?
+                if rel_schema.cardinality == "one":
+                    rel_data = RelatedNode._generate_query_data(peer_data=peer_data, property=property)
+                    # Nodes involved in a hierarchy are required to inherit from a common ancestor node, and graphql
+                    # tries to resolve attributes in this ancestor instead of actual node. To avoid
+                    # invalid queries issues when attribute is missing in the common ancestor, we use a fragment
+                    # to explicit actual node kind we are querying.
+                    if rel_schema.kind == RelationshipKind.HIERARCHY:
+                        data_node = rel_data["node"]
+                        rel_data["node"] = {}
+                        rel_data["node"][f"...on {rel_schema.peer}"] = data_node
+                elif rel_schema.cardinality == "many":
+                    rel_data = RelationshipManager._generate_query_data(peer_data=peer_data, property=property)
+                else:
+                    raise ValueError(f"Unknown relationship cardinality {rel_schema.cardinality}")
 
-            data[rel_name] = rel_data
+                data[rel_name] = rel_data
 
-            if insert_alias:
-                data[rel_name]["@alias"] = f"__alias__{self._schema.kind}__{rel_name}"
+                if insert_alias:
+                    data[rel_name]["@alias"] = f"__alias__{self._schema.kind}__{rel_name}"
 
         return data
 

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -890,7 +890,6 @@ class InfrahubNode(InfrahubNodeBase):
         branch: str,
         related_nodes: list[InfrahubNode],
         timeout: int | None = None,
-        include: list[str] | None = None,
     ) -> None:
         """Processes the Relationships of a InfrahubNode and add Related Nodes to a list.
 
@@ -901,8 +900,6 @@ class InfrahubNode(InfrahubNodeBase):
             timeout (int, optional): Overrides default timeout used when querying the graphql API. Specified in seconds.
         """
         for rel_name in self._relationships:
-            if include is not None and rel_name not in include:
-                continue
             rel = getattr(self, rel_name)
             if rel and isinstance(rel, RelatedNode):
                 relation = node_data["node"].get(rel_name, None)
@@ -1369,7 +1366,8 @@ class InfrahubNodeSync(InfrahubNodeBase):
                 continue
 
             peer_data: dict[str, Any] = {}
-            if rel_schema and prefetch_relationships:
+            should_fetch_relationship = prefetch_relationships or (include is not None and rel_name in include)
+            if rel_schema and should_fetch_relationship:
                 peer_schema = self._client.schema.get(kind=rel_schema.peer, branch=self._branch)
                 peer_node = InfrahubNodeSync(client=self._client, schema=peer_schema, branch=self._branch)
                 peer_data = peer_node.generate_query_data_node(include=include, exclude=exclude, property=property)

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -85,6 +85,39 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         assert node_after.owner.peer.id == person_joe.id
         assert node_after.owner.peer.typename == "TestingPerson"
 
+    async def test_node_filters_include(
+        self,
+        default_branch: str,
+        client: InfrahubClient,
+        initial_schema: None,
+        manufacturer_mercedes,
+        person_joe,
+        tag_red,
+    ) -> None:
+        car = await client.create(
+            kind=TESTING_CAR,
+            name="Tiguan2",
+            color="Black",
+            manufacturer=manufacturer_mercedes,
+            owner=person_joe,
+            tags=[tag_red],
+        )
+        await car.save(allow_upsert=True)
+        assert car.id is not None
+
+        node_after = await client.get(kind=TESTING_CAR, id=car.id)
+
+        with pytest.raises(ValueError):
+            # match=r"Node must have at least one identifier (ID or HFID) to query it."
+            _ = node_after.owner.peer
+
+        assert len(node_after.tags.peers) == 0
+
+        # Test both one and many relationships
+        node_after = await client.get(kind=TESTING_CAR, id=car.id, include=["tags", "owner"])
+        assert [tag.id for tag in node_after.tags.peers] == [tag_red.id]
+        assert node_after.owner.peer.id == person_joe.id, f"{person_joe.id=}"
+
     async def test_node_update_with_original_data(
         self,
         default_branch: str,

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -105,10 +105,11 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaCarPerson):
         await car.save(allow_upsert=True)
         assert car.id is not None
 
+        # Clear store, as when we call `owner.peer`, we actually rely on the peer having being stored in store.
+        client.store._branches = {}
         node_after = await client.get(kind=TESTING_CAR, id=car.id)
 
-        with pytest.raises(ValueError):
-            # match=r"Node must have at least one identifier (ID or HFID) to query it."
+        with pytest.raises(NodeNotFoundError, match=f"Unable to find the node '{person_joe.id}' in the store"):
             _ = node_after.owner.peer
 
         assert len(node_after.tags.peers) == 0

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -34,6 +34,11 @@ async def client() -> InfrahubClient:
 
 
 @pytest.fixture
+async def client_sync() -> InfrahubClientSync:
+    return InfrahubClientSync(config=Config(address="http://mock", insert_tracker=True, pagination_size=3))
+
+
+@pytest.fixture
 async def clients() -> BothClients:
     both = BothClients(
         standard=InfrahubClient(config=Config(address="http://mock", insert_tracker=True, pagination_size=3)),
@@ -2641,3 +2646,20 @@ async def mock_query_tasks_05(httpx_mock: HTTPXMock) -> HTTPXMock:
         is_reusable=True,
     )
     return httpx_mock
+
+
+async def set_builtin_tag_schema_cache(client) -> None:
+    # Set tag schema in cache to avoid needed to request the server.
+    builtin_tag_schema = {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Tag",
+                "namespace": "Builtin",
+                "default_filter": "name__value",
+                "display_label": "name__value",
+                "branch": "aware",
+            }
+        ],
+    }
+    client.schema.set_cache(builtin_tag_schema)

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -2646,20 +2646,3 @@ async def mock_query_tasks_05(httpx_mock: HTTPXMock) -> HTTPXMock:
         is_reusable=True,
     )
     return httpx_mock
-
-
-async def set_builtin_tag_schema_cache(client) -> None:
-    # Set tag schema in cache to avoid needed to request the server.
-    builtin_tag_schema = {
-        "version": "1.0",
-        "nodes": [
-            {
-                "name": "Tag",
-                "namespace": "Builtin",
-                "default_filter": "name__value",
-                "display_label": "name__value",
-                "branch": "aware",
-            }
-        ],
-    }
-    client.schema.set_cache(builtin_tag_schema)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -17,7 +17,6 @@ from infrahub_sdk.node import (
 from infrahub_sdk.node.constants import SAFE_VALUE
 from infrahub_sdk.node.related_node import RelatedNode, RelatedNodeSync
 from infrahub_sdk.schema import GenericSchema, NodeSchemaAPI
-from tests.unit.sdk.conftest import set_builtin_tag_schema_cache
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
@@ -52,6 +51,23 @@ UNSAFE_GRAPHQL_VALUES = [
     pytest.param('No "quote"', id="disallow-quotes"),
     pytest.param("Line \n break", id="disallow-linebreaks"),
 ]
+
+
+async def set_builtin_tag_schema_cache(client) -> None:
+    # Set tag schema in cache to avoid needed to request the server.
+    builtin_tag_schema = {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Tag",
+                "namespace": "Builtin",
+                "default_filter": "name__value",
+                "display_label": "name__value",
+                "branch": "aware",
+            }
+        ],
+    }
+    client.schema.set_cache(builtin_tag_schema)
 
 
 async def test_method_sanity() -> None:

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -17,6 +17,7 @@ from infrahub_sdk.node import (
 from infrahub_sdk.node.constants import SAFE_VALUE
 from infrahub_sdk.node.related_node import RelatedNode, RelatedNodeSync
 from infrahub_sdk.schema import GenericSchema, NodeSchemaAPI
+from tests.unit.sdk.conftest import set_builtin_tag_schema_cache
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
@@ -1055,12 +1056,19 @@ async def test_query_data_generic_fragment(clients, mock_schema_query_02, client
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_include_property(client, location_schema: NodeSchemaAPI, client_type) -> None:
+async def test_query_data_include_property(
+    client,
+    client_sync,
+    location_schema: NodeSchemaAPI,
+    client_type,
+) -> None:
     if client_type == "standard":
+        await set_builtin_tag_schema_cache(client)
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(include=["tags"], property=True)
     else:
-        node = InfrahubNodeSync(client=client, schema=location_schema)
+        await set_builtin_tag_schema_cache(client_sync)
+        node = InfrahubNodeSync(client=client_sync, schema=location_schema)
         data = node.generate_query_data(include=["tags"], property=True)
 
     assert data == {
@@ -1178,12 +1186,19 @@ async def test_query_data_include_property(client, location_schema: NodeSchemaAP
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_query_data_include(client, location_schema: NodeSchemaAPI, client_type) -> None:
+async def test_query_data_include(
+    client,
+    client_sync,
+    location_schema: NodeSchemaAPI,
+    client_type,
+) -> None:
     if client_type == "standard":
+        await set_builtin_tag_schema_cache(client)
         node = InfrahubNode(client=client, schema=location_schema)
         data = await node.generate_query_data(include=["tags"])
     else:
-        node = InfrahubNodeSync(client=client, schema=location_schema)
+        await set_builtin_tag_schema_cache(client_sync)
+        node = InfrahubNodeSync(client=client_sync, schema=location_schema)
         data = node.generate_query_data(include=["tags"])
 
     assert data == {


### PR DESCRIPTION
Help to fix https://github.com/opsmill/infrahub/issues/6976

Fix `client.filters(include=[...])` that was not fetching relationships

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Specifying include now loads selected relationships without enabling prefetch in both async and sync clients.
  - Include-driven relationship loading expands nested relationship fetches appropriately across modes.

- Bug Fixes
  - Ensures peers are expanded when relationships are explicitly included, preventing empty/missing data when prefetch is off.

- Tests
  - Added integration test validating include behavior for owner and tags.
  - Extended unit tests and fixtures to cover both async and sync clients and schema caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->