### PR TITLE
IHS-152 Allow unsetting one-to-one relationship

### DIFF
--- a/changelog/479.fixed.md
+++ b/changelog/479.fixed.md
@@ -1,0 +1,1 @@
+Allow unsetting optional relationship of cardinality one by setting its value to `None`

--- a/infrahub_sdk/graphql.py
+++ b/infrahub_sdk/graphql.py
@@ -8,9 +8,7 @@ from pydantic import BaseModel
 VARIABLE_TYPE_MAPPING = ((str, "String!"), (int, "Int!"), (float, "Float!"), (bool, "Boolean!"))
 
 
-def convert_to_graphql_as_string(  # noqa: PLR0911
-    value: str | bool | list | BaseModel | Enum | Any | None, convert_enum: bool = False
-) -> str:
+def convert_to_graphql_as_string(value: Any, convert_enum: bool = False) -> str:  # noqa: PLR0911
     if value is None:
         return "null"
     if isinstance(value, str) and value.startswith("$"):

--- a/infrahub_sdk/graphql.py
+++ b/infrahub_sdk/graphql.py
@@ -8,7 +8,11 @@ from pydantic import BaseModel
 VARIABLE_TYPE_MAPPING = ((str, "String!"), (int, "Int!"), (float, "Float!"), (bool, "Boolean!"))
 
 
-def convert_to_graphql_as_string(value: str | bool | list | BaseModel | Enum | Any, convert_enum: bool = False) -> str:  # noqa: PLR0911
+def convert_to_graphql_as_string(  # noqa: PLR0911
+    value: str | bool | list | BaseModel | Enum | Any | None, convert_enum: bool = False
+) -> str:
+    if value is None:
+        return "null"
     if isinstance(value, str) and value.startswith("$"):
         return value
     if isinstance(value, Enum):

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -314,7 +314,9 @@ class InfrahubNodeBase:
         original_data_item = original_data.get(item)
         original_data_item_is_none = original_data_item is None or (
             isinstance(original_data_item, dict)
-            and (("node" in original_data_item and original_data_item["node"] is None) or "id" not in original_data)
+            and (
+                ("node" in original_data_item and original_data_item["node"] is None) or "id" not in original_data_item
+            )
         )
         if item in data and (data_item in ({}, []) or (data_item is None and original_data_item_is_none)):
             data.pop(item)

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -312,12 +312,13 @@ class InfrahubNodeBase:
         # TODO: I do not feel _great_ about this
         # -> I don't even know who you are (but this is not great indeed) -- gmazoyer (quoting Thanos)
         original_data_item = original_data.get(item)
-        original_data_item_is_none = original_data_item is None or (
-            isinstance(original_data_item, dict)
-            and (
-                ("node" in original_data_item and original_data_item["node"] is None) or "id" not in original_data_item
-            )
-        )
+        original_data_item_is_none = original_data_item is None
+        if isinstance(original_data_item, dict):
+            if "node" in original_data_item:
+                original_data_item_is_none = original_data_item["node"] is None
+            elif "id" not in original_data_item:
+                original_data_item_is_none = True
+
         if item in data and (data_item in ({}, []) or (data_item is None and original_data_item_is_none)):
             data.pop(item)
 

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -310,8 +310,13 @@ class InfrahubNodeBase:
                         variables.pop(variable_key)
 
         # TODO: I do not feel _great_ about this
-        # -> I don't even know who you are -- gmazoyer (quoting Thanos)
-        if data_item in ({}, []) or (data_item is None and original_data.get(item) is None):
+        # -> I don't even know who you are (but this is not great indeed) -- gmazoyer (quoting Thanos)
+        original_data_item = original_data.get(item)
+        original_data_item_is_none = original_data_item is None or (
+            isinstance(original_data_item, dict)
+            and (("node" in original_data_item and original_data_item["node"] is None) or "id" not in original_data)
+        )
+        if item in data and (data_item in ({}, []) or (data_item is None and original_data_item_is_none)):
             data.pop(item)
 
     def _strip_unmodified(self, data: dict, variables: dict) -> tuple[dict, dict]:

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -234,15 +234,10 @@ class InfrahubNodeBase:
 
             rel: RelatedNodeBase | RelationshipManagerBase = getattr(self, item_name)
 
-            # BLOCKED by https://github.com/opsmill/infrahub/issues/330
-            # if (
-            #     item is None
-            #     and item_name in self._relationships
-            #     and self._schema.get_relationship(item_name).cardinality == "one"
-            # ):
-            #     data[item_name] = None
-            #     continue
-            # el
+            if rel_schema.cardinality == RelationshipCardinality.ONE and rel_schema.optional and not rel.initialized:
+                data[item_name] = None
+                continue
+
             if rel is None or not rel.initialized:
                 continue
 
@@ -315,7 +310,8 @@ class InfrahubNodeBase:
                         variables.pop(variable_key)
 
         # TODO: I do not feel _great_ about this
-        if not data_item and data_item != [] and item in data:
+        # -> I don't even know who you are -- gmazoyer (quoting Thanos)
+        if data_item in ({}, []) or (data_item is None and original_data.get(item) is None):
             data.pop(item)
 
     def _strip_unmodified(self, data: dict, variables: dict) -> tuple[dict, dict]:
@@ -324,7 +320,9 @@ class InfrahubNodeBase:
             relationship_property = getattr(self, relationship)
             if not relationship_property or relationship not in data:
                 continue
-            if not relationship_property.initialized:
+            if not relationship_property.initialized and (
+                not isinstance(relationship_property, RelatedNodeBase) or not relationship_property.schema.optional
+            ):
                 data.pop(relationship)
             elif isinstance(relationship_property, RelationshipManagerBase) and not relationship_property.has_update:
                 data.pop(relationship)

--- a/tests/integration/test_infrahub_client.py
+++ b/tests/integration/test_infrahub_client.py
@@ -170,6 +170,12 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         person_sophia = await client.get(kind=TESTING_PERSON, id=person_sophia.id, prefetch_relationships=True)
         assert person_sophia.favorite_animal.id == cat_luna.id
 
+        # Ensure that nullify it will remove the relationship related node
+        person_sophia.favorite_animal = None
+        await person_sophia.save()
+        person_sophia = await client.get(kind=TESTING_PERSON, id=person_sophia.id, prefetch_relationships=True)
+        assert not person_sophia.favorite_animal.id
+
     async def test_task_query(self, client: InfrahubClient, base_dataset, set_pagination_size3) -> None:
         nbr_tasks = await client.task.count()
         assert nbr_tasks

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1330,7 +1330,12 @@ async def test_create_input_data(client, location_schema: NodeSchemaAPI, client_
         node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
 
     assert node._generate_input_data()["data"] == {
-        "data": {"name": {"value": "JFK1"}, "description": {"value": "JFK Airport"}, "type": {"value": "SITE"}}
+        "data": {
+            "name": {"value": "JFK1"},
+            "description": {"value": "JFK Airport"},
+            "type": {"value": "SITE"},
+            "primary_tag": None,
+        }
     }
 
 
@@ -1577,7 +1582,7 @@ async def test_create_input_data_with_IPHost_attribute(client, ipaddress_schema,
         ip_address = InfrahubNodeSync(client=client, schema=ipaddress_schema, data=data)
 
     assert ip_address._generate_input_data()["data"] == {
-        "data": {"address": {"value": "1.1.1.1/24", "is_protected": True}}
+        "data": {"address": {"value": "1.1.1.1/24", "is_protected": True}, "interface": None}
     }
 
 
@@ -1591,7 +1596,7 @@ async def test_create_input_data_with_IPNetwork_attribute(client, ipnetwork_sche
         ip_network = InfrahubNodeSync(client=client, schema=ipnetwork_schema, data=data)
 
     assert ip_network._generate_input_data()["data"] == {
-        "data": {"network": {"value": "1.1.1.0/24", "is_protected": True}}
+        "data": {"network": {"value": "1.1.1.0/24", "is_protected": True}, "site": None}
     }
 
 
@@ -1789,7 +1794,7 @@ async def test_update_input_data_empty_relationship(
         "data": {
             "id": "llllllll-llll-llll-llll-llllllllllll",
             "name": {"value": "DFW"},
-            # "primary_tag": None,
+            "primary_tag": None,
             "tags": [],
             "type": {"value": "SITE"},
         },
@@ -1798,7 +1803,7 @@ async def test_update_input_data_empty_relationship(
         "data": {
             "id": "llllllll-llll-llll-llll-llllllllllll",
             "name": {"is_protected": True, "is_visible": True, "value": "DFW"},
-            # "primary_tag": None,
+            "primary_tag": None,
             "tags": [],
             "type": {"is_protected": True, "is_visible": True, "value": "SITE"},
         },


### PR DESCRIPTION
This change fixes the use of `my_object.my_relationship = None` by ensuring this is removing the link between an object and a related one tied together by an optional relationship of cardinality one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Allow unsetting optional one-to-one relationships by assigning None.
- Bug Fixes
  - Correctly serialize None to GraphQL null, preventing incorrect “None” strings.
- Tests
  - Added integration coverage to verify nullifying a HFID-based relationship removes the link.
  - Updated unit tests to expect None for optional relationships in generated input data.
- Documentation
  - Added changelog entry describing the ability to unset optional one-to-one relationships via None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->