### PR TITLE
Respect default branch for client.query_gql_query()

### DIFF
--- a/changelog/236.fixed.md
+++ b/changelog/236.fixed.md
@@ -1,0 +1,1 @@
+Respect default branch for client.query_gql_query() and client.set_context_properties()

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -209,7 +209,7 @@ class BaseClient:
             delete_unused_nodes=delete_unused_nodes,
             group_type=group_type,
             group_params=group_params,
-            branch=branch,
+            branch=branch or self.default_branch,
         )
 
     def _graphql_url(
@@ -1103,13 +1103,13 @@ class InfrahubClient(BaseClient):
     ) -> dict:
         url = f"{self.address}/api/query/{name}"
         url_params = copy.deepcopy(params or {})
+        url_params["branch"] = branch_name or self.default_branch
+
         headers = copy.copy(self.headers or {})
 
         if self.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if branch_name:
-            url_params["branch"] = branch_name
         if at:
             url_params["at"] = at
 
@@ -2242,13 +2242,13 @@ class InfrahubClientSync(BaseClient):
     ) -> dict:
         url = f"{self.address}/api/query/{name}"
         url_params = copy.deepcopy(params or {})
+        url_params["branch"] = branch_name or self.default_branch
+
         headers = copy.copy(self.headers or {})
 
         if self.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if branch_name:
-            url_params["branch"] = branch_name
         if at:
             url_params["at"] = at
         if subscribers:


### PR DESCRIPTION
Fixes #236.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured all GraphQL requests (async and sync) always include a branch parameter, defaulting to the configured default branch when none is provided. This delivers consistent branch-scoped behavior across requests and prevents unintended cross-branch queries; other request parameters remain unchanged.

* **Documentation**
  * Added changelog entry noting respect for the default branch in relevant client operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->