### PR TITLE
fix(docs): broken links to .infrahub.yml

### DIFF
--- a/docs/docs/python-sdk/topics/object_file.mdx
+++ b/docs/docs/python-sdk/topics/object_file.mdx
@@ -38,7 +38,7 @@ Multiple object files can be loaded at once by specifying the path to multiple f
 The `object load` command will create/update the objects using an `Upsert` operation. All objects previously loaded will NOT be deleted in the Infrahub instance.
 Also, if some objects present in different files are identical and dependent on each other, the `object load` command will NOT calculate the dependencies between the objects and as such it's the responsibility of the users to execute the command in the right order.
 
-> Object files can also be loaded into Infrahub when using external Git repositories. To see how to do this, please refer to the [.infrahub.yml](https://docs.infrahub.app/topics/infrahub-yml#objects) documentation.
+> Object files can also be loaded into Infrahub when using external Git repositories. To see how to do this, please refer to the [.infrahub.yml](https://docs.infrahub.app/topics/infrahub-yml) documentation.
 
 ### Validate the format of object files
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the external reference link in the “Load Object files” section to the current Infrahub YAML documentation, removing an outdated anchor, improving accuracy and navigation.
  * Enhances link reliability and consistency across the docs; no content or behavior changes to the SDK.
  * Purely editorial change; no user action required and no impact on existing workflows or integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->