### PR TITLE
Do not fail `info` command when user not set

### DIFF
--- a/changelog/398.fixed.md
+++ b/changelog/398.fixed.md
@@ -1,0 +1,1 @@
+Fix `infrahubctl info` command when run as an anonymous user

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -310,8 +310,7 @@ class InfrahubClient(BaseClient):
 
     async def get_user(self) -> dict:
         """Return user information"""
-        user_info = await self.execute_graphql(query=QUERY_USER)
-        return user_info
+        return await self.execute_graphql(query=QUERY_USER)
 
     async def get_user_permissions(self) -> dict:
         """Return user permissions"""
@@ -1565,8 +1564,7 @@ class InfrahubClientSync(BaseClient):
 
     def get_user(self) -> dict:
         """Return user information"""
-        user_info = self.execute_graphql(query=QUERY_USER)
-        return user_info
+        return self.execute_graphql(query=QUERY_USER)
 
     def get_user_permissions(self) -> dict:
         """Return user permissions"""

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -417,12 +417,17 @@ def info(  # noqa: PLR0915
         "user_info": {},
         "groups": {},
     }
+    client = initialize_client_sync()
+    fetch_user_details = client.config.username or client.config.api_token
+
     try:
-        client = initialize_client_sync()
         info["infrahub_version"] = client.get_version()
-        info["user_info"] = client.get_user()
+
+        if fetch_user_details:
+            info["user_info"] = client.get_user()
+            info["groups"] = client.get_user_permissions()
+
         info["status"] = ":white_heavy_check_mark:"
-        info["groups"] = client.get_user_permissions()
     except Exception as e:
         info["error"] = f"{e!s} ({e.__class__.__name__})"
 
@@ -469,7 +474,7 @@ def info(  # noqa: PLR0915
         pretty_model = Pretty(client.config.model_dump(), expand_all=True)
         layout["client_info"].update(Panel(pretty_model, title="Client Info"))
 
-        # Infrahub information planel
+        # Infrahub information panel
         infrahub_info = Table(show_header=False, box=None)
         if info["user_info"]:
             infrahub_info.add_row("User:", info["user_info"]["AccountProfile"]["display_label"])
@@ -487,6 +492,8 @@ def info(  # noqa: PLR0915
                 infrahub_info.add_row("Groups:", "")
                 for group, roles in groups.items():
                     infrahub_info.add_row("", group, ", ".join(roles))
+        else:
+            infrahub_info.add_row("User:", "anonymous")
 
         layout["infrahub_info"].update(Panel(infrahub_info, title="Infrahub Info"))
 

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -409,7 +409,6 @@ def info(  # noqa: PLR0915
     _: str = CONFIG_PARAM,
 ) -> None:
     """Display the status of the Python SDK."""
-
     info: dict[str, Any] = {
         "error": None,
         "status": ":x:",

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -418,7 +418,7 @@ def info(  # noqa: PLR0915
         "groups": {},
     }
     client = initialize_client_sync()
-    fetch_user_details = client.config.username or client.config.api_token
+    fetch_user_details = bool(client.config.username) or bool(client.config.api_token)
 
     try:
         info["infrahub_version"] = client.get_version()

--- a/tests/unit/ctl/test_cli.py
+++ b/tests/unit/ctl/test_cli.py
@@ -33,7 +33,7 @@ def test_version_command() -> None:
 
 
 def test_info_command_success(mock_query_infrahub_version, mock_query_infrahub_user) -> None:
-    result = runner.invoke(app, ["info"])
+    result = runner.invoke(app, ["info"], env={"INFRAHUB_API_TOKEN": "foo"})
     assert result.exit_code == 0
     for expected in ["Connection Status", "Python Version", "SDK Version", "Infrahub Version"]:
         assert expected in result.stdout, f"'{expected}' not found in info command output"
@@ -46,15 +46,16 @@ def test_info_command_failure() -> None:
 
 
 def test_info_detail_command_success(mock_query_infrahub_version, mock_query_infrahub_user) -> None:
+    result = runner.invoke(app, ["info", "--detail"], env={"INFRAHUB_API_TOKEN": "foo"})
+    assert result.exit_code == 0
+    for expected in ["Connection Status", "Version Information", "Client Info", "Infrahub Info", "Groups:"]:
+        assert expected in result.stdout, f"'{expected}' not found in detailed info command output"
+
+
+def test_anonymous_info_detail_command_success(mock_query_infrahub_version) -> None:
     result = runner.invoke(app, ["info", "--detail"])
     assert result.exit_code == 0
-    for expected in [
-        "Connection Status",
-        "Version Information",
-        "Client Info",
-        "Infrahub Info",
-        "Groups:",
-    ]:
+    for expected in ["Connection Status", "Version Information", "Client Info", "Infrahub Info", "anonymous"]:
         assert expected in result.stdout, f"'{expected}' not found in detailed info command output"
 
 


### PR DESCRIPTION
This change fixes the behaviour of the `infrahubctl info` command when no username/password or API token are provided. Since the GraphQL queries are run as anonymous, in this case, we have to skip fetching user details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - infrahubctl info now works when run without authentication.
  - Detailed output shows “User: anonymous” when no credentials are provided.
  - User and group details are shown only when authenticated (username or API token).
  - Minor wording correction in the Infrahub information panel.

- Tests
  - Added tests for authenticated info and detailed outputs.
  - Added test to validate anonymous detailed output, including presence of “anonymous” and key sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->