### PR TITLE
Fix branch creation with sync client

### DIFF
--- a/changelog/374.fixed.md
+++ b/changelog/374.fixed.md
@@ -1,0 +1,1 @@
+Fix branch creation with the sync client while setting `wait_until_completion=False`

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -292,13 +292,14 @@ class InfrahubBranchManagerSync(InfraHubBranchManagerBase):
             },
         }
 
-        query = Mutation(mutation="BranchCreate", input_data=input_data, query=MUTATION_QUERY_DATA)
+        mutation_query = MUTATION_QUERY_TASK if background_execution else MUTATION_QUERY_DATA
+        query = Mutation(mutation="BranchCreate", input_data=input_data, query=mutation_query)
         response = self.client.execute_graphql(query=query.render(), tracker="mutation-branch-create")
 
         # Make sure server version is recent enough to support background execution, as previously
         # using background_execution=True had no effect.
         if background_execution and "task" in response["BranchCreate"]:
-            return BranchData(**response["BranchCreate"]["task"]["id"])
+            return response["BranchCreate"]["task"]["id"]
         return BranchData(**response["BranchCreate"]["object"])
 
     def delete(self, branch_name: str) -> bool:


### PR DESCRIPTION
This change addresses an issue when trying to create a branch using the sync client and by setting `wait_until_completion=False`. The mutation was able to read and return the task ID properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved branch creation issues when using the sync client with wait_until_completion set to False.
  * For background executions, branch creation now returns a task ID, improving clarity and reliability.
  * Aligned async and sync clients for consistent behavior in background branch creation.
  * Non-background branch creation continues to return full branch details as before.

* **Documentation**
  * Added a changelog entry describing the branch creation fix for the sync client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->