### PR TITLE
Add `create_diff` to the clients to manually create a diff between two times.

### DIFF
--- a/changelog/529.added.md
+++ b/changelog/529.added.md
@@ -1,0 +1,2 @@
+Add `create_diff` method to create a diff summary between two timestamps
+Update `get_diff_summary` to accept optional time range parameters

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1164,12 +1164,14 @@ class InfrahubClient(BaseClient):
                 "to_time": to_time.isoformat(),
             },
         }
+
         mutation_query = MUTATION_QUERY_TASK if not wait_until_completion else {"ok": None}
         query = Mutation(mutation="DiffUpdate", input_data=input_data, query=mutation_query)
-        print(query.render())
         response = await self.execute_graphql(query=query.render(), tracker="mutation-diff-update")
+
         if not wait_until_completion and "task" in response["DiffUpdate"]:
             return response["DiffUpdate"]["task"]["id"]
+
         return response["DiffUpdate"]["ok"]
 
     async def get_diff_summary(
@@ -2317,11 +2319,37 @@ class InfrahubClientSync(BaseClient):
             resp.raise_for_status()
 
         return decode_json(response=resp)
+    
+    def create_diff(
+        self, branch: str, name: str, from_time: datetime, to_time: datetime, wait_until_completion: bool = True
+    ) -> str:
+        input_data = {
+            # Should be switched to `wait_until_completion` once `background_execution` is removed server side.
+            "wait_until_completion": wait_until_completion,
+            "data": {
+                "name": name,
+                "branch": branch,
+                "from_time": from_time.isoformat(),
+                "to_time": to_time.isoformat(),
+            },
+        }
+
+        mutation_query = MUTATION_QUERY_TASK if not wait_until_completion else {"ok": None}
+        query = Mutation(mutation="DiffUpdate", input_data=input_data, query=mutation_query)
+        response = self.execute_graphql(query=query.render(), tracker="mutation-diff-update")
+
+        if not wait_until_completion and "task" in response["DiffUpdate"]:
+            return response["DiffUpdate"]["task"]["id"]
+
+        return response["DiffUpdate"]["ok"]
+
 
     def get_diff_summary(
         self,
         branch: str,
         name: str | None = None,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
         raise_for_error: bool = True,
@@ -2330,6 +2358,9 @@ class InfrahubClientSync(BaseClient):
         input_data = {"branch_name": branch}
         if name:
             input_data["name"] = name
+        if from_time and to_time:
+            input_data["from_time"] = from_time.isoformat()
+            input_data["to_time"] = to_time.isoformat()
         response = self.execute_graphql(
             query=query,
             branch_name=branch,

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -5,6 +5,7 @@ import copy
 import logging
 import time
 from collections.abc import Coroutine, MutableMapping
+from datetime import datetime
 from functools import wraps
 from time import sleep
 from typing import (
@@ -24,6 +25,7 @@ from typing_extensions import Self
 
 from .batch import InfrahubBatch, InfrahubBatchSync
 from .branch import (
+    MUTATION_QUERY_TASK,
     BranchData,
     InfrahubBranchManager,
     InfrahubBranchManagerSync,
@@ -1149,21 +1151,48 @@ class InfrahubClient(BaseClient):
 
         return decode_json(response=resp)
 
+    async def create_diff(
+        self, branch: str, name: str, from_time: datetime, to_time: datetime, wait_until_completion: bool = True
+    ) -> str:
+        input_data = {
+            # Should be switched to `wait_until_completion` once `background_execution` is removed server side.
+            "wait_until_completion": wait_until_completion,
+            "data": {
+                "name": name,
+                "branch": branch,
+                "from_time": from_time.isoformat(),
+                "to_time": to_time.isoformat(),
+            },
+        }
+        mutation_query = MUTATION_QUERY_TASK if not wait_until_completion else {"ok": None}
+        query = Mutation(mutation="DiffUpdate", input_data=input_data, query=mutation_query)
+        print(query.render())
+        response = await self.execute_graphql(query=query.render(), tracker="mutation-diff-update")
+        if not wait_until_completion and "task" in response["DiffUpdate"]:
+            return response["DiffUpdate"]["task"]["id"]
+        return response["DiffUpdate"]["ok"]
+
+    # async def get_diff(self, branch: str, name: str) -> list
+
     async def get_diff_summary(
         self,
         branch: str,
+        name: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
         raise_for_error: bool = True,
     ) -> list[NodeDiff]:
         query = get_diff_summary_query()
+        input_data = {"branch_name": branch}
+        if name:
+            input_data["name"] = name
         response = await self.execute_graphql(
             query=query,
             branch_name=branch,
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"branch_name": branch},
+            variables=input_data,
         )
 
         node_diffs: list[NodeDiff] = []
@@ -2289,18 +2318,22 @@ class InfrahubClientSync(BaseClient):
     def get_diff_summary(
         self,
         branch: str,
+        name: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
         raise_for_error: bool = True,
     ) -> list[NodeDiff]:
         query = get_diff_summary_query()
+        input_data = {"branch_name": branch}
+        if name:
+            input_data["name"] = name
         response = self.execute_graphql(
             query=query,
             branch_name=branch,
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"branch_name": branch},
+            variables=input_data,
         )
 
         node_diffs: list[NodeDiff] = []

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1172,12 +1172,12 @@ class InfrahubClient(BaseClient):
             return response["DiffUpdate"]["task"]["id"]
         return response["DiffUpdate"]["ok"]
 
-    # async def get_diff(self, branch: str, name: str) -> list
-
     async def get_diff_summary(
         self,
         branch: str,
         name: str | None = None,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
         raise_for_error: bool = True,
@@ -1186,6 +1186,9 @@ class InfrahubClient(BaseClient):
         input_data = {"branch_name": branch}
         if name:
             input_data["name"] = name
+        if from_time and to_time:
+            input_data["from_time"] = from_time.isoformat()
+            input_data["to_time"] = to_time.isoformat()
         response = await self.execute_graphql(
             query=query,
             branch_name=branch,

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -2319,7 +2319,7 @@ class InfrahubClientSync(BaseClient):
             resp.raise_for_status()
 
         return decode_json(response=resp)
-    
+
     def create_diff(
         self, branch: str, name: str, from_time: datetime, to_time: datetime, wait_until_completion: bool = True
     ) -> str:
@@ -2342,7 +2342,6 @@ class InfrahubClientSync(BaseClient):
             return response["DiffUpdate"]["task"]["id"]
 
         return response["DiffUpdate"]["ok"]
-
 
     def get_diff_summary(
         self,

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1153,9 +1153,10 @@ class InfrahubClient(BaseClient):
 
     async def create_diff(
         self, branch: str, name: str, from_time: datetime, to_time: datetime, wait_until_completion: bool = True
-    ) -> str:
+    ) -> bool | str:
+        if from_time > to_time:
+            raise ValueError("from_time must be <= to_time")
         input_data = {
-            # Should be switched to `wait_until_completion` once `background_execution` is removed server side.
             "wait_until_completion": wait_until_completion,
             "data": {
                 "name": name,
@@ -1188,8 +1189,11 @@ class InfrahubClient(BaseClient):
         input_data = {"branch_name": branch}
         if name:
             input_data["name"] = name
-        if from_time and to_time:
+        if from_time and to_time and from_time > to_time:
+            raise ValueError("from_time must be <= to_time")
+        if from_time:
             input_data["from_time"] = from_time.isoformat()
+        if to_time:
             input_data["to_time"] = to_time.isoformat()
         response = await self.execute_graphql(
             query=query,
@@ -2322,9 +2326,10 @@ class InfrahubClientSync(BaseClient):
 
     def create_diff(
         self, branch: str, name: str, from_time: datetime, to_time: datetime, wait_until_completion: bool = True
-    ) -> str:
+    ) -> bool | str:
+        if from_time > to_time:
+            raise ValueError("from_time must be <= to_time")
         input_data = {
-            # Should be switched to `wait_until_completion` once `background_execution` is removed server side.
             "wait_until_completion": wait_until_completion,
             "data": {
                 "name": name,
@@ -2357,8 +2362,11 @@ class InfrahubClientSync(BaseClient):
         input_data = {"branch_name": branch}
         if name:
             input_data["name"] = name
-        if from_time and to_time:
+        if from_time and to_time and from_time > to_time:
+            raise ValueError("from_time must be <= to_time")
+        if from_time:
             input_data["from_time"] = from_time.isoformat()
+        if to_time:
             input_data["to_time"] = to_time.isoformat()
         response = self.execute_graphql(
             query=query,

--- a/infrahub_sdk/diff.py
+++ b/infrahub_sdk/diff.py
@@ -121,7 +121,7 @@ def diff_tree_node_to_node_diff(node_dict: dict[str, Any], branch_name: str) -> 
         branch=branch_name,
         kind=str(node_dict.get("kind")),
         id=str(node_dict.get("uuid")),
-        action=str(node_dict.get("action")),
+        action=str(node_dict.get("status")),
         display_label=str(node_dict.get("label")),
         elements=element_diffs,
     )

--- a/infrahub_sdk/diff.py
+++ b/infrahub_sdk/diff.py
@@ -37,8 +37,8 @@ class NodeDiffPeer(TypedDict):
 
 def get_diff_summary_query() -> str:
     return """
-        query GetDiffTree($branch_name: String!, $name: String) {
-            DiffTree(branch: $branch_name, name: $name) {
+        query GetDiffTree($branch_name: String!, $name: String, $from_time: DateTime, $to_time: DateTime) {
+            DiffTree(branch: $branch_name, name: $name, from_time: $from_time, to_time: $to_time) {
                 nodes {
                     uuid
                     kind

--- a/infrahub_sdk/diff.py
+++ b/infrahub_sdk/diff.py
@@ -37,8 +37,8 @@ class NodeDiffPeer(TypedDict):
 
 def get_diff_summary_query() -> str:
     return """
-        query GetDiffTree($branch_name: String!) {
-            DiffTree(branch: $branch_name) {
+        query GetDiffTree($branch_name: String!, $name: String) {
+            DiffTree(branch: $branch_name, name: $name) {
                 nodes {
                     uuid
                     kind

--- a/tests/unit/sdk/test_diff_summary.py
+++ b/tests/unit/sdk/test_diff_summary.py
@@ -109,7 +109,7 @@ async def test_diffsummary(clients: BothClients, mock_diff_tree_query, client_ty
         "branch": "branch2",
         "kind": "TestCar",
         "id": "17fbadf0-6637-4fa2-43e6-1677ea170e0f",
-        "action": "None",
+        "action": "UPDATED",
         "display_label": "nolt #444444",
         "elements": [
             {
@@ -124,7 +124,7 @@ async def test_diffsummary(clients: BothClients, mock_diff_tree_query, client_ty
         "branch": "branch2",
         "kind": "TestPerson",
         "id": "17fbadf0-634f-05a8-43e4-1677e744d4c0",
-        "action": "None",
+        "action": "UPDATED",
         "display_label": "Jane",
         "elements": [
             {
@@ -140,7 +140,7 @@ async def test_diffsummary(clients: BothClients, mock_diff_tree_query, client_ty
         "branch": "branch2",
         "kind": "TestPerson",
         "id": "17fbadf0-6243-5d3c-43ee-167718ff8dac",
-        "action": "None",
+        "action": "UPDATED",
         "display_label": "Jonathan",
         "elements": [
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Create diff summaries between two timestamps, with optional background execution.
  * Retrieve diff summaries filtered by name and/or time range.
* Bug Fixes
  * Top-level node actions in diff summaries now show UPDATED when applicable instead of None.
* Documentation
  * Changelog entry added for the new diff creation API and time-range support.
* Tests
  * Unit tests updated to reflect corrected top-level node action behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->