### PR TITLE
Fix issue with `render` ctl command not using branch environment variables

### DIFF
--- a/changelog/535.fixed.md
+++ b/changelog/535.fixed.md
@@ -1,0 +1,1 @@
+Fix branch handling in `_run_transform` and `execute_graphql_query` functions.

--- a/changelog/535.fixed.md
+++ b/changelog/535.fixed.md
@@ -1,1 +1,1 @@
-Fix branch handling in `_run_transform` and `execute_graphql_query` functions.
+Fix branch handling in `_run_transform` and `execute_graphql_query` functions in Infrahubctl to use environment variables for branch management. 

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -208,7 +208,6 @@ async def _run_transform(
         debug: Prints debug info to the command line
         repository_config: Repository config object. This is used to load the graphql query from the repository.
     """
-    branch = get_branch(branch)
 
     try:
         response = execute_graphql_query(

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -46,7 +46,7 @@ from ..protocols_generator.generator import CodeGenerator
 from ..schema import MainSchemaTypesAll, SchemaRoot
 from ..template import Jinja2Template
 from ..template.exceptions import JinjaTemplateError
-from ..utils import get_branch, write_to_file
+from ..utils import write_to_file
 from ..yaml import SchemaFile
 from .exporter import dump
 from .importer import load

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -118,7 +118,7 @@ def execute_graphql_query(
     query_str = query_object.load_query()
 
     client = initialize_client_sync()
-    
+
     if not branch:
         branch = client.config.default_infrahub_branch
 

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -118,6 +118,10 @@ def execute_graphql_query(
     query_str = query_object.load_query()
 
     client = initialize_client_sync()
+    
+    if not branch:
+        branch = client.config.default_infrahub_branch
+
     response = client.execute_graphql(
         query=query_str,
         branch_name=branch,

--- a/infrahub_sdk/ctl/validate.py
+++ b/infrahub_sdk/ctl/validate.py
@@ -14,7 +14,7 @@ from ..ctl.client import initialize_client, initialize_client_sync
 from ..ctl.exceptions import QueryNotFoundError
 from ..ctl.utils import catch_exception, find_graphql_query, parse_cli_vars
 from ..exceptions import GraphQLError
-from ..utils import get_branch, write_to_file
+from ..utils import write_to_file
 from ..yaml import SchemaFile
 from .parameters import CONFIG_PARAM
 from .utils import load_yamlfile_from_disk_and_exit
@@ -68,8 +68,6 @@ def validate_graphql(
 ) -> None:
     """Validate the format of a GraphQL Query stored locally by executing it on a remote GraphQL endpoint"""
 
-    branch = get_branch(branch)
-
     try:
         query_str = find_graphql_query(query)
     except QueryNotFoundError:
@@ -81,6 +79,10 @@ def validate_graphql(
     variables_dict = parse_cli_vars(variables)
 
     client = initialize_client_sync()
+
+    if not branch:
+        branch = client.config.default_infrahub_branch
+
     try:
         response = client.execute_graphql(
             query=query_str,

--- a/tests/fixtures/repos/ctl_integration/.infrahub.yml
+++ b/tests/fixtures/repos/ctl_integration/.infrahub.yml
@@ -26,7 +26,13 @@ generator_definitions:
     parameters:
       name: "name__value"
 
+jinja2_transforms:
+  - name: tags
+    query: "tags_query"
+    template_path: "templates/tags.j2"
 
 queries:
   - name: animal_person
     file_path: queries/animal_person.gql
+  - name: tags_query
+    file_path: templates/tags_query.gql

--- a/tests/fixtures/repos/ctl_integration/templates/tags.j2
+++ b/tests/fixtures/repos/ctl_integration/templates/tags.j2
@@ -1,0 +1,1 @@
+{{ data['BuiltinTag']['edges'][0]['node']['name']['value'] }}

--- a/tests/fixtures/repos/ctl_integration/templates/tags_query.gql
+++ b/tests/fixtures/repos/ctl_integration/templates/tags_query.gql
@@ -1,0 +1,11 @@
+query TagsQuery($name: String!) {
+  BuiltinTag(name__value: $name) {
+    edges {
+      node {
+        name {
+          value
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/ctl/test_render_app.py
+++ b/tests/unit/ctl/test_render_app.py
@@ -73,3 +73,44 @@ def test_validate_template_not_found(test_case: RenderAppFailure, httpx_mock: HT
         output = runner.invoke(app, ["render", test_case.template, "name=red"])
         assert test_case.error in strip_color(output.stdout)
         assert output.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "cli_branch,env_branch,from_git,expected_branch",
+    [
+        ("cli-branch", None, False, "cli-branch"),
+        (None, "env-branch", False, "env-branch"),
+        (None, None, True, "git-branch"),
+    ],
+)
+@requires_python_310
+def test_render_branch_selection(monkeypatch, httpx_mock: HTTPXMock, cli_branch, env_branch, from_git, expected_branch):
+    """Test that the render command uses the correct branch source."""
+
+    if from_git:
+        monkeypatch.setattr("dulwich.porcelain.active_branch", lambda _: b"git-branch")
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"http://mock/graphql/{expected_branch}",
+        json=json.loads(
+            read_fixture(
+                "red_tag.json",
+                "unit/test_infrahubctl/red_tags_query",
+            )
+        ),
+    )
+
+    with temp_repo_and_cd(source_dir=FIXTURE_BASE_DIR / "ctl_integration"):
+        args = ["render", "tags", "name=red"]
+        env = {}
+        # Add test-specific variables
+        if cli_branch:
+            args.extend(["--branch", cli_branch])
+        if env_branch:
+            env["INFRAHUB_DEFAULT_BRANCH"] = env_branch
+            env["INFRAHUB_DEFAULT_BRANCH_FROM_GIT"] = "false"
+        if from_git:
+            env["INFRAHUB_DEFAULT_BRANCH_FROM_GIT"] = "true"
+        output = runner.invoke(app, args, env=env)
+        assert output.exit_code == 0


### PR DESCRIPTION
Fixes: #535 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed branch resolution so commands and GraphQL calls consistently use the branch from CLI, environment default, or repository-detected branch.
- Tests
  - Added tests to verify branch selection across CLI, environment, and Git sources; added supporting test fixtures.
- Chores
  - Added a changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->