### PR TITLE
Add py.typed

### DIFF
--- a/changelog/+5f3ef109.added.md
+++ b/changelog/+5f3ef109.added.md
@@ -1,0 +1,1 @@
+Added a 'py.typed' file to the project. This is to enable type checking when the Infrahub SDK is imported from other projects. The addition of this file could cause new typing issues in external projects until all typing issues have been resolved. Adding it to the project now to better highlight remaining issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-sdk"
-version = "1.18.1"
+version = "1.19.0b0"
 description = "Python Client to interact with Infrahub"
 authors = [
     {name = "OpsMill", email = "info@opsmill.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.18.1"
+version = "1.19.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },


### PR DESCRIPTION
Create a branch where we have a `py.typed` file, this will currently cause issues within the Infrahub repo that should preferably be fixed before we merge this.

Also adds a newsfragment mentioning typing issues and the reasoning for including this file now.

Bumps the version of the SDK to 1.19.0b0 in order to create a beta release for the upcoming Infrahub 1.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.19.0b0
  * Enhanced type checking support to enable full type safety when using the SDK as an imported package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->