### PR TITLE
fix improperly escaped special characters in `HFID`

### DIFF
--- a/changelog/+escape-hfid.fixed.md
+++ b/changelog/+escape-hfid.fixed.md
@@ -1,0 +1,1 @@
+- Fixed issue with improperly escaped special characters in `hfid` fields and other string values in GraphQL mutations by implementing proper JSON-style string escaping

--- a/infrahub_sdk/graphql.py
+++ b/infrahub_sdk/graphql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from enum import Enum
 from typing import Any
 
@@ -18,7 +19,9 @@ def convert_to_graphql_as_string(value: Any, convert_enum: bool = False) -> str:
             return convert_to_graphql_as_string(value=value.value, convert_enum=True)
         return value.name
     if isinstance(value, str):
-        return f'"{value}"'
+        # Use json.dumps() to properly escape the string according to JSON rules,
+        # which are compatible with GraphQL string escaping
+        return json.dumps(value)
     if isinstance(value, bool):
         return repr(value).lower()
     if isinstance(value, list):


### PR DESCRIPTION
Fixed issue with improperly escaped special characters in `hfid` fields and other string values in GraphQL mutations by implementing proper JSON-style string escaping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly escape special characters in string values (including hfid fields) within GraphQL mutations, preventing malformed requests and related errors.
- Documentation
  - Added a changelog entry noting the string-escaping fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->