### PR TITLE
Add  to object conversion input

### DIFF
--- a/infrahub_sdk/convert_object_type.py
+++ b/infrahub_sdk/convert_object_type.py
@@ -36,7 +36,7 @@ class ConversionFieldValue(BaseModel):  # Only one of these fields can be not No
         fields = [self.attribute_value, self.peer_id, self.peers_ids]
         set_fields = [f for f in fields if f is not None]
         if len(set_fields) != 1:
-            raise ValueError("Exactly one of attribute_value, peer_id, or peers_ids must be set")
+            raise ValueError("Exactly one of `attribute_value`, `peer_id`, or `peers_ids` must be set")
         return self
 
 
@@ -50,11 +50,11 @@ class ConversionFieldInput(BaseModel):
 
     source_field: str | None = None
     data: ConversionFieldValue | None = None
+    use_default_value: bool = False
 
     @model_validator(mode="after")
     def check_only_one_field(self) -> ConversionFieldInput:
-        if self.source_field is not None and self.data is not None:
-            raise ValueError("Only one of source_field or data can be set")
-        if self.source_field is None and self.data is None:
-            raise ValueError("Either source_field or data must be set")
+        fields_set = [self.source_field is not None, self.data is not None, self.use_default_value is True]
+        if sum(fields_set) != 1:
+            raise ValueError("Exactly one of `source_field`, `data` or `use_default_value` must be set")
         return self

--- a/infrahub_sdk/convert_object_type.py
+++ b/infrahub_sdk/convert_object_type.py
@@ -45,7 +45,8 @@ class ConversionFieldInput(BaseModel):
     Indicates how to fill in the value of the destination field during an object conversion.
     Use `source_field` to reuse the value of the corresponding field of the object being converted.
     Use `data` to specify the new value for the field.
-    Only one of `source_field` or `data` can be specified.
+    Use `use_default_value` to set the destination field to its schema default.
+    Only one of `source_field`, `data`, or `use_default_value` can be specified.
     """
 
     source_field: str | None = None


### PR DESCRIPTION
Add `use_default_value` in order to specify when we want of a field to use the default value instead of potentially reusing the value of an existing matching input field.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a boolean option to allow using a default value in conversion inputs.

* **Bug Fixes**
  * Validation now enforces exactly one of: source field, inline data, or the default-value option, preventing conflicting or missing configurations.

* **Style**
  * Improved validation error messages by wrapping field names in backticks for clearer readability and easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->