### PR TITLE
Increase default timeouts for transform/checks from 10 to 60.

### DIFF
--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -33,7 +33,7 @@ class InfrahubCheckInitializer(BaseModel):
 class InfrahubCheck:
     name: str | None = None
     query: str = ""
-    timeout: int = 10
+    timeout: int = 60
 
     def __init__(
         self,

--- a/infrahub_sdk/transforms.py
+++ b/infrahub_sdk/transforms.py
@@ -17,7 +17,7 @@ INFRAHUB_TRANSFORM_VARIABLE_TO_IMPORT = "INFRAHUB_TRANSFORMS"
 class InfrahubTransform(InfrahubOperation):
     name: str | None = None
     query: str
-    timeout: int = 10
+    timeout: int = 60
 
     def __init__(
         self,


### PR DESCRIPTION
This is related to: https://github.com/opsmill/infrahub/pull/7299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default timeout from 10s to 60s for checks and transforms, reducing premature timeouts on longer-running operations.
  * Users can still override the timeout as needed.

* **Documentation**
  * Clarified default timeout behavior to reflect the new 60s setting.

* **Chores**
  * Standardized timeout defaults across related components for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->