### PR TITLE
IHS-170: Disable rich console print markup causing regex reformatting

### DIFF
--- a/changelog/565.fixed.md
+++ b/changelog/565.fixed.md
@@ -1,0 +1,1 @@
+Disable rich console print markup causing regex reformatting

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -73,7 +73,9 @@ def display_schema_load_errors(response: dict[str, Any], schemas_data: list[Sche
             loc_type = loc_path[-1]
             input_str = error.get("input", None)
             error_message = f"{loc_type} ({input_str}) | {error['msg']} ({error['type']})"
-            console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
+            console.print(
+                f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}", markup=False
+            )
 
         elif len(loc_path) > 6:
             loc_type = loc_path[5]
@@ -91,7 +93,9 @@ def display_schema_load_errors(response: dict[str, Any], schemas_data: list[Sche
 
             input_str = error.get("input", None)
             error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
-            console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
+            console.print(
+                f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}", markup=False
+            )
 
 
 def handle_non_detail_errors(response: dict[str, Any]) -> None:

--- a/tests/unit/ctl/test_schema_app.py
+++ b/tests/unit/ctl/test_schema_app.py
@@ -116,7 +116,7 @@ def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock) -> None:
     clean_output = remove_ansi_color(result.stdout.replace("\n", ""))
     expected_result = (
         "Unable to load the schema:  Node: OuTDevice | "
-        "namespace (OuT) | String should match pattern '^[A-Z]+$' (string_pattern_mismatch) "
+        "namespace (OuT) | String should match pattern '^[A-Z][a-z0-9]+$' (string_pattern_mismatch) "
         " Node: OuTDevice | Attribute: name (NotValid) | Value error, Only valid Attribute Kind "
         "are : ['ID', 'Dropdown']  (value_error)"
     )

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -389,7 +389,7 @@ async def test_display_schema_load_errors_details_namespace(mock_get_node) -> No
         mock_get_node.assert_called_once()
         output = console.file.getvalue()
         expected_console = """Unable to load the schema:
-  Node: OuTInstance | namespace (OuT) | String should match pattern '^[A-Z]+$' (string_pattern_mismatch)
+  Node: OuTInstance | namespace (OuT) | String should match pattern '^[A-Z][a-z0-9]+$' (string_pattern_mismatch)
 """
         assert output == expected_console
 


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub-sdk-python/issues/565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Console error messages during schema load now render as plain text (markup disabled), preventing formatting from altering regex patterns and ensuring accurate, readable error output.

* **Documentation**
  * Added a changelog entry documenting the fix to console markup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->