### PR TITLE
Add `tls_ca_file` and `tls_insecure` configuration settings to infrahubctl

### DIFF
--- a/docs/docs/infrahubctl/infrahubctl.mdx
+++ b/docs/docs/infrahubctl/infrahubctl.mdx
@@ -31,6 +31,8 @@ The `infrahubctl` command line utility is installed as a part of the [Infrahub S
 | `INFRAHUB_ADDRESS`        | http://localhost:8000                  |
 | `INFRAHUB_API_TOKEN`      | `06438eb2-8019-4776-878c-0941b1f1d1ec` |
 | `INFRAHUB_DEFAULT_BRANCH` | main                                   |
+| `INFRAHUB_TLS_CA_FILE`    | /path/to/ca.crt                        |
+| `INFRAHUB_TLS_INSECURE`   | true                                   |
 
 > You can also provide the location of a configuration file via the environment variable `INFRAHUBCTL_CONFIG`.
 
@@ -39,4 +41,7 @@ The `infrahubctl` command line utility is installed as a part of the [Infrahub S
 ```toml title="infrahubctl.toml"
 server_address="http://localhost:8000"
 api_token="06438eb2-8019-4776-878c-0941b1f1d1ec"
+default_branch="main"
+tls_ca_file="/path/to/ca.crt"
+tls_insecure=true
 ```

--- a/infrahub_sdk/ctl/client.py
+++ b/infrahub_sdk/ctl/client.py
@@ -59,6 +59,12 @@ def _define_config(
     if config.SETTINGS.active.api_token:
         client_config["api_token"] = config.SETTINGS.active.api_token
 
+    if config.SETTINGS.active.tls_ca_file:
+        client_config["tls_ca_file"] = config.SETTINGS.active.tls_ca_file
+
+    if config.SETTINGS.active.tls_insecure:
+        client_config["tls_insecure"] = config.SETTINGS.active.tls_insecure
+
     if timeout:
         client_config["timeout"] = timeout
 

--- a/infrahub_sdk/ctl/config.py
+++ b/infrahub_sdk/ctl/config.py
@@ -21,6 +21,14 @@ class Settings(BaseSettings):
     server_address: str = Field(default="http://localhost:8000", validation_alias="infrahub_address")
     api_token: str | None = Field(default=None)
     default_branch: str = Field(default="main")
+    tls_insecure: bool = Field(
+        default=False,
+        description="""
+    Indicates if TLS certificates are verified.
+    Enabling this option will disable: CA verification, expiry date verification, hostname verification).
+    Can be useful to test with self-signed certificates.""",
+    )
+    tls_ca_file: str | None = Field(default=None, description="File path to CA cert or bundle in PEM format")
 
     @field_validator("server_address")
     @classmethod


### PR DESCRIPTION
Add the `tls_ca_file` and `tls_insecure` configuration settings for infrahubctl.
This allows you to define these configuration settings in the infrahubctl configuration file. 

It was already possible to configure these settings through environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS options to configure a custom CA certificate file and optionally disable certificate verification.
  * Available via environment variables (INFRAHUB_TLS_CA_FILE, INFRAHUB_TLS_INSECURE) and corresponding configuration file entries.
  * Client now respects these settings when establishing connections.

* **Documentation**
  * Updated environment variables table and configuration examples to include the new TLS options and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->