### PR TITLE
IHS-128: Replace `Sync` in protocol sync classes schema name

### DIFF
--- a/changelog/380.fixed.md
+++ b/changelog/380.fixed.md
@@ -1,0 +1,1 @@
+Replaced the `Sync` word in the protocol schema name so that the correct kind can be gotten from the cache

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import warnings
 from collections.abc import MutableMapping
@@ -185,11 +186,15 @@ class InfrahubSchemaBase:
 
     @staticmethod
     def _get_schema_name(schema: type[SchemaType | SchemaTypeSync] | str) -> str:
-        if hasattr(schema, "_is_runtime_protocol") and schema._is_runtime_protocol:  # type: ignore[union-attr]
-            return schema.__name__.replace("Sync", "")  # type: ignore[union-attr]
-
         if isinstance(schema, str):
             return schema
+
+        if hasattr(schema, "_is_runtime_protocol") and getattr(schema, "_is_runtime_protocol", None):
+            if inspect.iscoroutinefunction(schema.save):
+                return schema.__name__
+            if schema.__name__[-4:] == "Sync":
+                return schema.__name__[:-4]
+            return schema.__name__
 
         raise ValueError("schema must be a protocol or a string")
 

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -186,7 +186,7 @@ class InfrahubSchemaBase:
     @staticmethod
     def _get_schema_name(schema: type[SchemaType | SchemaTypeSync] | str) -> str:
         if hasattr(schema, "_is_runtime_protocol") and schema._is_runtime_protocol:  # type: ignore[union-attr]
-            return schema.__name__  # type: ignore[union-attr]
+            return schema.__name__.replace("Sync", "")  # type: ignore[union-attr]
 
         if isinstance(schema, str):
             return schema

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -9,7 +9,8 @@ from rich.console import Console
 from infrahub_sdk import Config, InfrahubClient, InfrahubClientSync
 from infrahub_sdk.ctl.schema import display_schema_load_errors
 from infrahub_sdk.exceptions import SchemaNotFoundError, ValidationError
-from infrahub_sdk.schema import BranchSchema, InfrahubSchema, InfrahubSchemaSync, NodeSchemaAPI
+from infrahub_sdk.protocols import BuiltinIPAddressSync, BuiltinTagSync
+from infrahub_sdk.schema import BranchSchema, InfrahubSchema, InfrahubSchemaBase, InfrahubSchemaSync, NodeSchemaAPI
 from infrahub_sdk.schema.repository import (
     InfrahubCheckDefinitionConfig,
     InfrahubJinja2TransformConfig,
@@ -452,3 +453,8 @@ async def test_display_schema_load_errors_details_when_error_is_in_attribute_or_
   Node: SecurityTailscaleSSHRule | Attribute: check_period (10080) | Extra inputs are not permitted (extra_forbidden)
 """
         assert output == expected_console
+
+
+def test_schema_base__get_schema_name__returns_correct_schema_name_for_protocols():
+    assert InfrahubSchemaBase._get_schema_name(schema=BuiltinTagSync) == "BuiltinTag"
+    assert InfrahubSchemaBase._get_schema_name(schema=BuiltinIPAddressSync) == "BuiltinIPAddress"

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -9,7 +9,7 @@ from rich.console import Console
 from infrahub_sdk import Config, InfrahubClient, InfrahubClientSync
 from infrahub_sdk.ctl.schema import display_schema_load_errors
 from infrahub_sdk.exceptions import SchemaNotFoundError, ValidationError
-from infrahub_sdk.protocols import BuiltinIPAddressSync, BuiltinTagSync
+from infrahub_sdk.protocols import BuiltinIPAddress, BuiltinIPAddressSync, BuiltinTag, BuiltinTagSync
 from infrahub_sdk.schema import BranchSchema, InfrahubSchema, InfrahubSchemaBase, InfrahubSchemaSync, NodeSchemaAPI
 from infrahub_sdk.schema.repository import (
     InfrahubCheckDefinitionConfig,
@@ -457,4 +457,8 @@ async def test_display_schema_load_errors_details_when_error_is_in_attribute_or_
 
 def test_schema_base__get_schema_name__returns_correct_schema_name_for_protocols():
     assert InfrahubSchemaBase._get_schema_name(schema=BuiltinTagSync) == "BuiltinTag"
+    assert InfrahubSchemaBase._get_schema_name(schema=BuiltinTag) == "BuiltinTag"
+    assert InfrahubSchemaBase._get_schema_name(schema="BuiltinTag") == "BuiltinTag"
     assert InfrahubSchemaBase._get_schema_name(schema=BuiltinIPAddressSync) == "BuiltinIPAddress"
+    assert InfrahubSchemaBase._get_schema_name(schema=BuiltinIPAddress) == "BuiltinIPAddress"
+    assert InfrahubSchemaBase._get_schema_name(schema="BuiltinIPAddress") == "BuiltinIPAddress"


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub-sdk-python/issues/380

This PR replaces the `Sync` word in the protocol schema name so that the correct kind can be gotten from the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changelog**
  * Added an entry noting a protocol schema name change related to "Sync" handling.

* **Bug Fixes**
  * Fixed protocol schema name resolution so the correct schema kind is retrieved from cache (handles names ending with "Sync").

* **Tests**
  * Added unit tests validating schema name resolution for protocol-based schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->