### PR TITLE
Fix typing on relogin decorator

### DIFF
--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -79,7 +79,9 @@ class ProcessRelationsNodeSync(TypedDict):
     related_nodes: list[InfrahubNodeSync]
 
 
-def handle_relogin(func: Callable[..., Coroutine[Any, Any, httpx.Response]]):  # type: ignore[no-untyped-def]
+def handle_relogin(
+    func: Callable[..., Coroutine[Any, Any, httpx.Response]],
+) -> Callable[..., Coroutine[Any, Any, httpx.Response]]:
     @wraps(func)
     async def wrapper(client: InfrahubClient, *args: Any, **kwargs: Any) -> httpx.Response:
         response = await func(client, *args, **kwargs)
@@ -93,7 +95,7 @@ def handle_relogin(func: Callable[..., Coroutine[Any, Any, httpx.Response]]):  #
     return wrapper
 
 
-def handle_relogin_sync(func: Callable[..., httpx.Response]):  # type: ignore[no-untyped-def]
+def handle_relogin_sync(func: Callable[..., httpx.Response]) -> Callable[..., httpx.Response]:
     @wraps(func)
     def wrapper(client: InfrahubClientSync, *args: Any, **kwargs: Any) -> httpx.Response:
         response = func(client, *args, **kwargs)


### PR DESCRIPTION
Fix typing on the relogin decorators so that linters can understand what they are sending back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type annotations for internal decorators to enhance code quality and developer experience with better IDE support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->