### PR TITLE
fix(dependabot): target stable instead of develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    target-branch: develop
+    target-branch: stable
     labels:
       - "type/housekeeping"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration to target the stable release branch instead of the development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->