### PR TITLE
Add `graph_version` and `status` to branch

### DIFF
--- a/changelog/+branch-graph-version-status.added.md
+++ b/changelog/+branch-graph-version-status.added.md
@@ -1,0 +1,1 @@
+Add `graph_version` and `status` properties to `Branch`

--- a/changelog/+branch-graph-version.added.md
+++ b/changelog/+branch-graph-version.added.md
@@ -1,1 +1,0 @@
-Add `graph_version` property to `Branch`

--- a/changelog/+branch-graph-version.added.md
+++ b/changelog/+branch-graph-version.added.md
@@ -1,0 +1,1 @@
+Add `graph_version` property to `Branch`

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from enum import StrEnum
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, overload
 from urllib.parse import urlencode
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .client import InfrahubClient, InfrahubClientSync
 
 
-class BranchStatus(StrEnum):
+class BranchStatus(str, Enum):
     OPEN = "OPEN"
     NEED_REBASE = "NEED_REBASE"
     NEED_UPGRADE_REBASE = "NEED_UPGRADE_REBASE"

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -30,7 +30,7 @@ class BranchData(BaseModel):
     is_default: bool
     has_schema_changes: bool
     graph_version: int | None = None
-    status: BranchStatus
+    status: BranchStatus = BranchStatus.OPEN
     origin_branch: str | None = None
     branched_from: str
 

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -21,6 +21,7 @@ class BranchData(BaseModel):
     sync_with_git: bool
     is_default: bool
     has_schema_changes: bool
+    graph_version: int | None = None
     origin_branch: str | None = None
     branched_from: str
 
@@ -34,6 +35,7 @@ BRANCH_DATA = {
     "is_default": None,
     "sync_with_git": None,
     "has_schema_changes": None,
+    "graph_version": None,
 }
 
 BRANCH_DATA_FILTER = {"@filters": {"name": "$branch_name"}}

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, overload
 from urllib.parse import urlencode
 
@@ -14,6 +15,13 @@ if TYPE_CHECKING:
     from .client import InfrahubClient, InfrahubClientSync
 
 
+class BranchStatus(StrEnum):
+    OPEN = "OPEN"
+    NEED_REBASE = "NEED_REBASE"
+    NEED_UPGRADE_REBASE = "NEED_UPGRADE_REBASE"
+    DELETING = "DELETING"
+
+
 class BranchData(BaseModel):
     id: str
     name: str
@@ -22,6 +30,7 @@ class BranchData(BaseModel):
     is_default: bool
     has_schema_changes: bool
     graph_version: int | None = None
+    status: BranchStatus
     origin_branch: str | None = None
     branched_from: str
 
@@ -36,6 +45,7 @@ BRANCH_DATA = {
     "sync_with_git": None,
     "has_schema_changes": None,
     "graph_version": None,
+    "status": None,
 }
 
 BRANCH_DATA_FILTER = {"@filters": {"name": "$branch_name"}}

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -46,7 +46,6 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
     table.add_column("Sync with Git")
     table.add_column("Has Schema Changes")
     table.add_column("Is Default")
-    table.add_column("Graph Version")
     table.add_column("Status")
 
     # identify the default branch and always print it first
@@ -59,7 +58,6 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
         "[green]True" if default_branch.sync_with_git else "[#FF7F50]False",
         "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
         "[green]True" if default_branch.is_default else "[#FF7F50]False",
-        str(default_branch.graph_version) if default_branch.graph_version else "",
         default_branch.status,
     )
 
@@ -75,7 +73,6 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
             "[green]True" if branch.sync_with_git else "[#FF7F50]False",
             "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
             "[green]True" if branch.is_default else "[#FF7F50]False",
-            str(branch.graph_version) if branch.graph_version else "",
             branch.status,
         )
 

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -75,7 +75,7 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
             "[green]True" if branch.sync_with_git else "[#FF7F50]False",
             "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
             "[green]True" if branch.is_default else "[#FF7F50]False",
-            str(branch.graph_version) if default_branch.graph_version else "",
+            str(branch.graph_version) if branch.graph_version else "",
             branch.status,
         )
 

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -59,7 +59,7 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
         "[green]True" if default_branch.sync_with_git else "[#FF7F50]False",
         "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
         "[green]True" if default_branch.is_default else "[#FF7F50]False",
-        str(default_branch.graph_version),
+        str(default_branch.graph_version) if default_branch.graph_version else "",
         default_branch.status,
     )
 
@@ -75,7 +75,7 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
             "[green]True" if branch.sync_with_git else "[#FF7F50]False",
             "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
             "[green]True" if branch.is_default else "[#FF7F50]False",
-            str(branch.graph_version),
+            str(branch.graph_version) if default_branch.graph_version else "",
             branch.status,
         )
 

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -46,6 +46,8 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
     table.add_column("Sync with Git")
     table.add_column("Has Schema Changes")
     table.add_column("Is Default")
+    table.add_column("Graph Version")
+    table.add_column("Status")
 
     # identify the default branch and always print it first
     default_branch = [branch for branch in branches.values() if branch.is_default][0]
@@ -57,6 +59,8 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
         "[green]True" if default_branch.sync_with_git else "[#FF7F50]False",
         "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
         "[green]True" if default_branch.is_default else "[#FF7F50]False",
+        str(default_branch.graph_version),
+        default_branch.status,
     )
 
     for branch in branches.values():
@@ -71,6 +75,8 @@ async def list_branch(_: str = CONFIG_PARAM) -> None:
             "[green]True" if branch.sync_with_git else "[#FF7F50]False",
             "[green]True" if default_branch.has_schema_changes else "[#FF7F50]False",
             "[green]True" if branch.is_default else "[#FF7F50]False",
+            str(branch.graph_version),
+            branch.status,
         )
 
     console.print(table)

--- a/tests/unit/ctl/conftest.py
+++ b/tests/unit/ctl/conftest.py
@@ -36,6 +36,8 @@ async def mock_branches_list_query(httpx_mock: HTTPXMock) -> HTTPXMock:
                     "origin_branch": "main",
                     "branched_from": "2023-02-17T09:30:17.811719Z",
                     "has_schema_changes": False,
+                    "graph_version": 99,
+                    "status": "OPEN",
                 },
                 {
                     "id": "7d9f817a-b958-4e76-8528-8afd0c689ada",
@@ -45,6 +47,8 @@ async def mock_branches_list_query(httpx_mock: HTTPXMock) -> HTTPXMock:
                     "origin_branch": "main",
                     "branched_from": "2023-02-17T09:30:17.811719Z",
                     "has_schema_changes": True,
+                    "graph_version": None,
+                    "status": "NEED_UPGRADE_REBASE",
                 },
             ]
         }

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -1498,6 +1498,8 @@ async def mock_branches_list_query(httpx_mock: HTTPXMock) -> HTTPXMock:
                     "origin_branch": "main",
                     "branched_from": "2023-02-17T09:30:17.811719Z",
                     "has_schema_changes": False,
+                    "graph_version": 99,
+                    "status": "OPEN",
                 },
                 {
                     "id": "7d9f817a-b958-4e76-8528-8afd0c689ada",
@@ -1507,6 +1509,8 @@ async def mock_branches_list_query(httpx_mock: HTTPXMock) -> HTTPXMock:
                     "origin_branch": "main",
                     "branched_from": "2023-02-17T09:30:17.811719Z",
                     "has_schema_changes": True,
+                    "graph_version": None,
+                    "status": "NEED_UPGRADE_REBASE",
                 },
             ]
         }


### PR DESCRIPTION
This PR simply adds the `graph_version` and `status` properties on `Branch` as they will be available in Infrahub 1.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch list/table now shows Graph Version and Status (Open, Needs Rebase, Needs Upgrade Rebase, Deleting).
* **Bug Fixes**
  * Non-default branches now display their own Graph Version and Status instead of inheriting the default branch value.
* **Tests**
  * Test fixtures updated to include Graph Version and Status for branch data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->