### PR TITLE
IHS-176: Remove `is_visible` property from attribute metadata

### DIFF
--- a/changelog/+08aa1a85.removed.md
+++ b/changelog/+08aa1a85.removed.md
@@ -1,0 +1,1 @@
+Remove `is_visible` property from infrahub

--- a/infrahub_sdk/node/attribute.py
+++ b/infrahub_sdk/node/attribute.py
@@ -52,7 +52,6 @@ class Attribute:
         self.is_inherited: bool | None = data.get("is_inherited", None)
         self.updated_at: str | None = data.get("updated_at", None)
 
-        self.is_visible: bool | None = data.get("is_visible", None)
         self.is_protected: bool | None = data.get("is_protected", None)
 
         self.source: NodeProperty | None = None

--- a/infrahub_sdk/node/constants.py
+++ b/infrahub_sdk/node/constants.py
@@ -2,7 +2,7 @@ import ipaddress
 import re
 from typing import Union
 
-PROPERTIES_FLAG = ["is_visible", "is_protected"]
+PROPERTIES_FLAG = ["is_protected"]
 PROPERTIES_OBJECT = ["source", "owner"]
 SAFE_VALUE = re.compile(r"(^[\. /:a-zA-Z0-9_-]+$)|(^$)")
 

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -56,7 +56,6 @@ class Attribute(Protocol):
     is_from_profile: bool | None
     is_inherited: bool | None
     updated_at: str | None
-    is_visible: bool | None
     is_protected: bool | None
 
 

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -135,7 +135,6 @@ class InfrahubSchemaBase:
         source: str | None = None,
         owner: str | None = None,
         is_protected: bool | None = None,
-        is_visible: bool | None = None,
     ) -> dict[str, Any]:
         obj_data: dict[str, Any] = {}
         item_metadata: dict[str, Any] = {}
@@ -145,8 +144,6 @@ class InfrahubSchemaBase:
             item_metadata["owner"] = str(owner)
         if is_protected is not None:
             item_metadata["is_protected"] = is_protected
-        if is_visible is not None:
-            item_metadata["is_visible"] = is_visible
 
         for key, value in data.items():
             obj_data[key] = {}

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -306,21 +306,18 @@ async def location_data01_no_pagination():
         "display_label": "dfw1",
         "name": {
             "is_protected": True,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": "DFW",
         },
         "description": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": None,
         },
         "type": {
             "is_protected": True,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": "SITE",
@@ -330,7 +327,6 @@ async def location_data01_no_pagination():
             "display_label": "red",
             "__typename": "RelatedTag",
             "_relation__is_protected": True,
-            "_relation__is_visible": True,
             "_relation__owner": None,
             "_relation__source": None,
         },
@@ -340,7 +336,6 @@ async def location_data01_no_pagination():
                 "display_label": "blue",
                 "__typename": "RelatedTag",
                 "_relation__is_protected": True,
-                "_relation__is_visible": True,
                 "_relation__owner": None,
                 "_relation__source": None,
             }
@@ -358,7 +353,6 @@ async def location_data02_no_pagination():
         "display_label": "dfw1",
         "name": {
             "is_protected": True,
-            "is_visible": True,
             "owner": None,
             "source": {
                 "__typename": "Account",
@@ -369,14 +363,12 @@ async def location_data02_no_pagination():
         },
         "description": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": None,
         },
         "type": {
             "is_protected": True,
-            "is_visible": True,
             "owner": None,
             "source": {
                 "__typename": "Account",
@@ -390,7 +382,6 @@ async def location_data02_no_pagination():
             "display_label": "red",
             "__typename": "RelatedTag",
             "_relation__is_protected": True,
-            "_relation__is_visible": True,
             "_relation__owner": None,
             "_relation__source": {
                 "__typename": "Account",
@@ -404,7 +395,6 @@ async def location_data02_no_pagination():
                 "display_label": "blue",
                 "__typename": "RelatedTag",
                 "_relation__is_protected": True,
-                "_relation__is_visible": True,
                 "_relation__owner": None,
                 "_relation__source": {
                     "__typename": "Account",
@@ -468,21 +458,18 @@ async def location_data01_property():
             "display_label": "dfw1",
             "name": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": "DFW",
             },
             "description": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": None,
             },
             "type": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": "SITE",
@@ -490,7 +477,6 @@ async def location_data01_property():
             "primary_tag": {
                 "properties": {
                     "is_protected": True,
-                    "is_visible": True,
                     "owner": None,
                     "source": None,
                 },
@@ -506,7 +492,6 @@ async def location_data01_property():
                     {
                         "properties": {
                             "is_protected": True,
-                            "is_visible": True,
                             "owner": None,
                             "source": None,
                         },
@@ -574,7 +559,6 @@ async def location_data02_property():
             "display_label": "dfw1",
             "name": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -585,14 +569,12 @@ async def location_data02_property():
             },
             "description": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": None,
             },
             "type": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -604,7 +586,6 @@ async def location_data02_property():
             "primary_tag": {
                 "properties": {
                     "is_protected": True,
-                    "is_visible": True,
                     "owner": None,
                     "source": {
                         "__typename": "Account",
@@ -624,7 +605,6 @@ async def location_data02_property():
                     {
                         "properties": {
                             "is_protected": True,
-                            "is_visible": True,
                             "owner": None,
                             "source": {
                                 "__typename": "Account",
@@ -690,7 +670,6 @@ async def tag_blue_data_no_pagination():
         "display_label": "blue",
         "name": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": {
                 "__typename": "Account",
@@ -701,7 +680,6 @@ async def tag_blue_data_no_pagination():
         },
         "description": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": None,
@@ -718,7 +696,6 @@ async def tag_red_data_no_pagination():
         "display_label": "red",
         "name": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": {
                 "__typename": "Account",
@@ -729,7 +706,6 @@ async def tag_red_data_no_pagination():
         },
         "description": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": None,
@@ -746,7 +722,6 @@ async def tag_green_data_no_pagination():
         "display_label": "green",
         "name": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": {
                 "__typename": "Account",
@@ -757,7 +732,6 @@ async def tag_green_data_no_pagination():
         },
         "description": {
             "is_protected": False,
-            "is_visible": True,
             "owner": None,
             "source": None,
             "value": None,
@@ -775,7 +749,6 @@ async def tag_blue_data():
             "display_label": "blue",
             "name": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -786,7 +759,6 @@ async def tag_blue_data():
             },
             "description": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": None,
@@ -805,7 +777,6 @@ async def tag_red_data():
             "display_label": "red",
             "name": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -816,7 +787,6 @@ async def tag_red_data():
             },
             "description": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": None,
@@ -835,7 +805,6 @@ async def tag_green_data():
             "display_label": "green",
             "name": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -846,7 +815,6 @@ async def tag_green_data():
             },
             "description": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": None,
@@ -998,7 +966,6 @@ async def ipam_ipprefix_data():
             "display_label": "192.0.2.0/24",
             "prefix": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -1009,14 +976,12 @@ async def ipam_ipprefix_data():
             },
             "description": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": None,
             },
             "member_type": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -1027,7 +992,6 @@ async def ipam_ipprefix_data():
             },
             "is_pool": {
                 "is_protected": True,
-                "is_visible": True,
                 "owner": None,
                 "source": {
                     "__typename": "Account",
@@ -1039,7 +1003,6 @@ async def ipam_ipprefix_data():
             "ip_namespace": {
                 "properties": {
                     "is_protected": True,
-                    "is_visible": True,
                     "owner": None,
                     "source": {
                         "__typename": "Account",
@@ -1196,28 +1159,24 @@ async def address_data():
             "display_label": "test_address",
             "street_number": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": "1234",
             },
             "street_name": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": "Fake Street",
             },
             "postal_code": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": "123ABC",
             },
             "computed_address": {
                 "is_protected": False,
-                "is_visible": True,
                 "owner": None,
                 "source": None,
                 "value": "1234 Fake Street 123ABC",
@@ -1286,7 +1245,6 @@ async def device_data():
             "__typename": "InfraDevice",
             "name": {
                 "value": "atl1-edge1",
-                "is_visible": True,
                 "is_protected": True,
                 "source": {
                     "id": "1799f644-d5eb-8e37-3403-c512518ae06a",
@@ -1295,10 +1253,9 @@ async def device_data():
                 },
                 "owner": None,
             },
-            "description": {"value": None, "is_visible": True, "is_protected": False, "source": None, "owner": None},
+            "description": {"value": None, "is_protected": False, "source": None, "owner": None},
             "type": {
                 "value": "7280R3",
-                "is_visible": True,
                 "is_protected": False,
                 "source": {
                     "id": "1799f644-d5eb-8e37-3403-c512518ae06a",
@@ -1314,7 +1271,6 @@ async def device_data():
                     "__typename": "BuiltinLocation",
                 },
                 "properties": {
-                    "is_visible": True,
                     "is_protected": True,
                     "source": {
                         "id": "1799f644-d5eb-8e37-3403-c512518ae06a",
@@ -1331,7 +1287,6 @@ async def device_data():
                     "__typename": "BuiltinStatus",
                 },
                 "properties": {
-                    "is_visible": True,
                     "is_protected": None,
                     "source": None,
                     "owner": {
@@ -1348,7 +1303,6 @@ async def device_data():
                     "__typename": "BuiltinRole",
                 },
                 "properties": {
-                    "is_visible": True,
                     "is_protected": True,
                     "source": {
                         "id": "1799f644-d5eb-8e37-3403-c512518ae06a",
@@ -1369,7 +1323,6 @@ async def device_data():
                     "__typename": "InfraAutonomousSystem",
                 },
                 "properties": {
-                    "is_visible": True,
                     "is_protected": True,
                     "source": {
                         "id": "1799f644-d5eb-8e37-3403-c512518ae06a",
@@ -1392,7 +1345,7 @@ async def device_data():
                             "display_label": "green",
                             "__typename": "BuiltinTag",
                         },
-                        "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                        "properties": {"is_protected": None, "source": None, "owner": None},
                     },
                     {
                         "node": {
@@ -1400,7 +1353,7 @@ async def device_data():
                             "display_label": "red",
                             "__typename": "BuiltinTag",
                         },
-                        "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                        "properties": {"is_protected": None, "source": None, "owner": None},
                     },
                 ],
             },
@@ -1410,7 +1363,7 @@ async def device_data():
                     "display_label": "172.20.20.20/24",
                     "__typename": "InfraIPAddress",
                 },
-                "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                "properties": {"is_protected": None, "source": None, "owner": None},
             },
             "platform": {
                 "node": {
@@ -1419,7 +1372,6 @@ async def device_data():
                     "__typename": "InfraPlatform",
                 },
                 "properties": {
-                    "is_visible": True,
                     "is_protected": True,
                     "source": {
                         "id": "1799f644-d5eb-8e37-3403-c512518ae06a",
@@ -1460,7 +1412,6 @@ async def artifact_definition_data():
             "__typename": "CoreArtifactDefinition",
             "name": {
                 "value": "Startup Config for Edge devices",
-                "is_visible": True,
                 "is_protected": True,
                 "source": {
                     "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -1471,7 +1422,6 @@ async def artifact_definition_data():
             },
             "artifact_name": {
                 "value": "startup-config",
-                "is_visible": True,
                 "is_protected": True,
                 "source": {
                     "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -1927,42 +1877,36 @@ async def mock_rest_api_artifact_fetch(httpx_mock: HTTPXMock) -> HTTPXMock:
                         "__typename": "CoreArtifact",
                         "name": {
                             "value": "Startup Config for Edge devices",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "status": {
                             "value": "Ready",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "content_type": {
                             "value": "text/plain",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "checksum": {
                             "value": "58d949c1a1c0fcd06e79bc032be8373a",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "storage_id": {
                             "value": "1799fd71-950c-5a85-3041-c515082800ff",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "parameters": {
                             "value": None,
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
@@ -1973,7 +1917,7 @@ async def mock_rest_api_artifact_fetch(httpx_mock: HTTPXMock) -> HTTPXMock:
                                 "display_label": "atl1-edge1",
                                 "__typename": "InfraDevice",
                             },
-                            "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                            "properties": {"is_protected": None, "source": None, "owner": None},
                         },
                         "definition": {
                             "node": {
@@ -1981,7 +1925,7 @@ async def mock_rest_api_artifact_fetch(httpx_mock: HTTPXMock) -> HTTPXMock:
                                 "display_label": "Startup Config for Edge devices",
                                 "__typename": "CoreArtifactDefinition",
                             },
-                            "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                            "properties": {"is_protected": None, "source": None, "owner": None},
                         },
                     },
                 ]
@@ -2020,42 +1964,36 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                         "__typename": "CoreArtifact",
                         "name": {
                             "value": "Startup Config for Edge devices",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "status": {
                             "value": "Ready",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "content_type": {
                             "value": "text/plain",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "checksum": {
                             "value": "58d949c1a1c0fcd06e79bc032be8373a",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "storage_id": {
                             "value": "1799fd71-950c-5a85-3041-c515082800ff",
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
                         },
                         "parameters": {
                             "value": None,
-                            "is_visible": True,
                             "is_protected": False,
                             "source": None,
                             "owner": None,
@@ -2066,7 +2004,7 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                                 "display_label": "atl1-edge1",
                                 "__typename": "InfraDevice",
                             },
-                            "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                            "properties": {"is_protected": None, "source": None, "owner": None},
                         },
                         "definition": {
                             "node": {
@@ -2074,7 +2012,7 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                                 "display_label": "Startup Config for Edge devices",
                                 "__typename": "CoreArtifactDefinition",
                             },
-                            "properties": {"is_visible": True, "is_protected": None, "source": None, "owner": None},
+                            "properties": {"is_protected": None, "source": None, "owner": None},
                         },
                     },
                 ]
@@ -2097,7 +2035,6 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                             "__typename": "CoreArtifactDefinition",
                             "name": {
                                 "value": "Startup Config for Edge devices",
-                                "is_visible": True,
                                 "is_protected": True,
                                 "source": {
                                     "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -2108,7 +2045,6 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                             },
                             "artifact_name": {
                                 "value": "startup-config",
-                                "is_visible": True,
                                 "is_protected": True,
                                 "source": {
                                     "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -2119,14 +2055,12 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                             },
                             "description": {
                                 "value": None,
-                                "is_visible": True,
                                 "is_protected": False,
                                 "source": None,
                                 "owner": None,
                             },
                             "parameters": {
                                 "value": {"device": "name__value"},
-                                "is_visible": True,
                                 "is_protected": True,
                                 "source": {
                                     "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -2137,7 +2071,6 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                             },
                             "content_type": {
                                 "value": "text/plain",
-                                "is_visible": True,
                                 "is_protected": True,
                                 "source": {
                                     "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -2153,7 +2086,6 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                                     "__typename": "CoreStandardGroup",
                                 },
                                 "properties": {
-                                    "is_visible": True,
                                     "is_protected": True,
                                     "source": {
                                         "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",
@@ -2170,7 +2102,6 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock, schema_query_04
                                     "__typename": "CoreRFile",
                                 },
                                 "properties": {
-                                    "is_visible": True,
                                     "is_protected": True,
                                     "source": {
                                         "id": "1799fd6b-f0a9-9d23-304d-c51b05d142c5",

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -315,7 +315,6 @@ async def test_query_data_no_filters_property(clients, location_schema: NodeSche
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -332,7 +331,6 @@ async def test_query_data_no_filters_property(clients, location_schema: NodeSche
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -349,7 +347,6 @@ async def test_query_data_no_filters_property(clients, location_schema: NodeSche
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -365,7 +362,6 @@ async def test_query_data_no_filters_property(clients, location_schema: NodeSche
                     "primary_tag": {
                         "properties": {
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -450,7 +446,6 @@ async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI,
             "is_default": None,
             "is_from_profile": None,
             "is_protected": None,
-            "is_visible": None,
             "owner": {"__typename": None, "display_label": None, "id": None},
             "source": {"__typename": None, "display_label": None, "id": None},
             "value": None,
@@ -459,7 +454,6 @@ async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI,
             "is_default": None,
             "is_from_profile": None,
             "is_protected": None,
-            "is_visible": None,
             "owner": {"__typename": None, "display_label": None, "id": None},
             "source": {"__typename": None, "display_label": None, "id": None},
             "value": None,
@@ -468,7 +462,6 @@ async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI,
             "is_default": None,
             "is_from_profile": None,
             "is_protected": None,
-            "is_visible": None,
             "owner": {"__typename": None, "display_label": None, "id": None},
             "source": {"__typename": None, "display_label": None, "id": None},
             "value": None,
@@ -476,7 +469,6 @@ async def test_query_data_node_property(clients, location_schema: NodeSchemaAPI,
         "primary_tag": {
             "properties": {
                 "is_protected": None,
-                "is_visible": None,
                 "owner": {
                     "__typename": None,
                     "display_label": None,
@@ -557,7 +549,6 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -574,7 +565,6 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -591,7 +581,6 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -607,7 +596,6 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
                     "primary_tag": {
                         "properties": {
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -628,7 +616,6 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
                                 "is_default": None,
                                 "is_from_profile": None,
                                 "is_protected": None,
-                                "is_visible": None,
                                 "owner": {
                                     "__typename": None,
                                     "display_label": None,
@@ -645,7 +632,6 @@ async def test_query_data_with_prefetch_relationships_property(clients, mock_sch
                                 "is_default": None,
                                 "is_from_profile": None,
                                 "is_protected": None,
-                                "is_visible": None,
                                 "owner": {
                                     "__typename": None,
                                     "display_label": None,
@@ -736,7 +722,6 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
             "is_default": None,
             "is_from_profile": None,
             "is_protected": None,
-            "is_visible": None,
             "owner": {"__typename": None, "display_label": None, "id": None},
             "source": {"__typename": None, "display_label": None, "id": None},
             "value": None,
@@ -745,7 +730,6 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
             "is_default": None,
             "is_from_profile": None,
             "is_protected": None,
-            "is_visible": None,
             "owner": {"__typename": None, "display_label": None, "id": None},
             "source": {"__typename": None, "display_label": None, "id": None},
             "value": None,
@@ -757,7 +741,6 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
                     "is_default": None,
                     "is_from_profile": None,
                     "is_protected": None,
-                    "is_visible": None,
                     "owner": {"__typename": None, "display_label": None, "id": None},
                     "source": {"__typename": None, "display_label": None, "id": None},
                     "value": None,
@@ -769,7 +752,6 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
                     "is_default": None,
                     "is_from_profile": None,
                     "is_protected": None,
-                    "is_visible": None,
                     "owner": {"__typename": None, "display_label": None, "id": None},
                     "source": {"__typename": None, "display_label": None, "id": None},
                     "value": None,
@@ -777,7 +759,6 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
             },
             "properties": {
                 "is_protected": None,
-                "is_visible": None,
                 "owner": {"__typename": None, "display_label": None, "id": None},
                 "source": {"__typename": None, "display_label": None, "id": None},
             },
@@ -786,7 +767,6 @@ async def test_query_data_node_with_prefetch_relationships_property(clients, moc
             "is_default": None,
             "is_from_profile": None,
             "is_protected": None,
-            "is_visible": None,
             "owner": {"__typename": None, "display_label": None, "id": None},
             "source": {"__typename": None, "display_label": None, "id": None},
             "value": None,
@@ -889,7 +869,6 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
                             "is_default": None,
                             "is_from_profile": None,
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -907,7 +886,6 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
                             "is_default": None,
                             "is_from_profile": None,
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -930,7 +908,6 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
                             },
                             "properties": {
                                 "is_protected": None,
-                                "is_visible": None,
                                 "owner": {
                                     "__typename": None,
                                     "display_label": None,
@@ -948,7 +925,6 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
                             "is_default": None,
                             "is_from_profile": None,
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -968,7 +944,6 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
                             "is_default": None,
                             "is_from_profile": None,
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -986,7 +961,6 @@ async def test_query_data_generic_fragment_property(clients, mock_schema_query_0
                             "is_default": None,
                             "is_from_profile": None,
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -1101,7 +1075,6 @@ async def test_query_data_include_property(
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -1118,7 +1091,6 @@ async def test_query_data_include_property(
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -1135,7 +1107,6 @@ async def test_query_data_include_property(
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -1151,7 +1122,6 @@ async def test_query_data_include_property(
                     "primary_tag": {
                         "properties": {
                             "is_protected": None,
-                            "is_visible": None,
                             "owner": {
                                 "__typename": None,
                                 "display_label": None,
@@ -1175,7 +1145,6 @@ async def test_query_data_include_property(
                         "edges": {
                             "properties": {
                                 "is_protected": None,
-                                "is_visible": None,
                                 "owner": {
                                     "__typename": None,
                                     "display_label": None,
@@ -1284,7 +1253,6 @@ async def test_query_data_exclude_property(client, location_schema: NodeSchemaAP
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -1301,7 +1269,6 @@ async def test_query_data_exclude_property(client, location_schema: NodeSchemaAP
                         "is_default": None,
                         "is_from_profile": None,
                         "is_protected": None,
-                        "is_visible": None,
                         "owner": {
                             "__typename": None,
                             "display_label": None,
@@ -1702,10 +1669,10 @@ async def test_update_input_data__with_relationships_01(
     expected_result_with_property = {
         "data": {
             "id": "llllllll-llll-llll-llll-llllllllllll",
-            "name": {"is_protected": True, "is_visible": True, "value": "DFW"},
+            "name": {"is_protected": True, "value": "DFW"},
             "primary_tag": {"id": "gggggggg-gggg-gggg-gggg-gggggggggggg"},
             "tags": [{"id": "gggggggg-gggg-gggg-gggg-gggggggggggg"}, {"id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr"}],
-            "type": {"is_protected": True, "is_visible": True, "value": "SITE"},
+            "type": {"is_protected": True, "value": "SITE"},
         },
     }
 
@@ -1752,27 +1719,23 @@ async def test_update_input_data_with_relationships_02(
             "id": "llllllll-llll-llll-llll-llllllllllll",
             "name": {
                 "is_protected": True,
-                "is_visible": True,
                 "source": "cccccccc-cccc-cccc-cccc-cccccccccccc",
                 "value": "dfw1",
             },
             "primary_tag": {
                 "_relation__is_protected": True,
-                "_relation__is_visible": True,
                 "_relation__source": "cccccccc-cccc-cccc-cccc-cccccccccccc",
                 "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
             },
             "tags": [
                 {
                     "_relation__is_protected": True,
-                    "_relation__is_visible": True,
                     "_relation__source": "cccccccc-cccc-cccc-cccc-cccccccccccc",
                     "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
                 },
             ],
             "type": {
                 "is_protected": True,
-                "is_visible": True,
                 "source": "cccccccc-cccc-cccc-cccc-cccccccccccc",
                 "value": "SITE",
             },
@@ -1810,7 +1773,6 @@ async def test_update_input_data_with_relationships_02_exclude_unmodified(
             "id": "llllllll-llll-llll-llll-llllllllllll",
             "primary_tag": {
                 "_relation__is_protected": True,
-                "_relation__is_visible": True,
                 "_relation__source": "cccccccc-cccc-cccc-cccc-cccccccccccc",
                 "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
             },
@@ -1861,10 +1823,10 @@ async def test_update_input_data_empty_relationship(
     expected_result_with_property = {
         "data": {
             "id": "llllllll-llll-llll-llll-llllllllllll",
-            "name": {"is_protected": True, "is_visible": True, "value": "DFW"},
+            "name": {"is_protected": True, "value": "DFW"},
             "primary_tag": None,
             "tags": [],
-            "type": {"is_protected": True, "is_visible": True, "value": "SITE"},
+            "type": {"is_protected": True, "value": "SITE"},
         },
     }
 
@@ -2087,9 +2049,9 @@ async def test_read_only_attr(
     assert address._generate_input_data()["data"] == {
         "data": {
             "id": "d5994b18-b25e-4261-9e63-17c2844a0b45",
-            "street_number": {"is_protected": False, "is_visible": True, "value": "1234"},
-            "street_name": {"is_protected": False, "is_visible": True, "value": "Fake Street"},
-            "postal_code": {"is_protected": False, "is_visible": True, "value": "123ABC"},
+            "street_number": {"is_protected": False, "value": "1234"},
+            "street_name": {"is_protected": False, "value": "Fake Street"},
+            "postal_code": {"is_protected": False, "value": "123ABC"},
         },
     }
     assert address.computed_address.value == "1234 Fake Street 123ABC"


### PR DESCRIPTION
This PR removes `is_visible` property from attribute metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the is_visible attribute across the SDK — it no longer appears on attribute instances, in recognized property flags, payload generation, or produced node/relationship outputs.
* **Tests**
  * Updated unit tests and fixtures to remove expectations and sample data containing is_visible.
* **Changelog**
  * Added entry documenting the removal of the is_visible property.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->