### PR TITLE
fix(cli): hide file paths in log output unless debug mode enabled

### DIFF
--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -46,7 +46,7 @@ def init_logging(debug: bool = False) -> None:
 
     log_level = "DEBUG" if debug else "INFO"
     FORMAT = "%(message)s"
-    logging.basicConfig(level=log_level, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
+    logging.basicConfig(level=log_level, format=FORMAT, datefmt="[%X]", handlers=[RichHandler(show_path=debug)])
     logging.getLogger("infrahubctl")
 
 


### PR DESCRIPTION
Configure RichHandler to only show file paths (e.g., object.py:568)
when the --debug flag is used. This provides cleaner output for
normal usage while preserving detailed logging for troubleshooting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced debug logging to display file paths when debug mode is enabled, providing better diagnostics for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->