### PR TITLE
Configure vale to ignore toml files

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -11,5 +11,10 @@ BasedOnStyles = Infrahub
 ;(```.*?```\n) to ignore code block in .mdx
 BlockIgnores = (?s) *((import.*?\n)|(```.*?```\n))
 
+[*.toml]
+# Ignore all rules for toml files, to prevent false positives
+# in files like pyproject.toml
+BasedOnStyles =
+
 [*]
 BasedOnStyles = Infrahub


### PR DESCRIPTION
Ignores warnings in the VS Code extension for Vale with regards to unrelated files such as *.toml.

<img width="1112" height="218" alt="Screenshot 2025-11-10 at 16 36 49" src="https://github.com/user-attachments/assets/3b69e888-33e5-4de6-9aa9-6d8a4562778c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude TOML files from style validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->