### PR TITLE
Fix bug with nested object template range expansion

### DIFF
--- a/changelog/624.fixed.md
+++ b/changelog/624.fixed.md
@@ -1,0 +1,1 @@
+Fixed nested object template range expansion.

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -459,7 +459,6 @@ class InfrahubObjectFileData(BaseModel):
                             data=value,
                             branch=branch,
                             default_schema_kind=default_schema_kind,
-                            parameters=parameters,
                         )
                         clean_data[key] = nodes[0]
 
@@ -471,7 +470,9 @@ class InfrahubObjectFileData(BaseModel):
                             data=value,
                             branch=branch,
                             default_schema_kind=default_schema_kind,
-                            parameters=parameters,
+                            parameters=InfrahubObjectParameters(**value.get("parameters"))
+                            if "parameters" in value
+                            else None,
                         )
                         clean_data[key] = nodes
 
@@ -510,7 +511,9 @@ class InfrahubObjectFileData(BaseModel):
                 context=context,
                 branch=branch,
                 default_schema_kind=default_schema_kind,
-                parameters=InfrahubObjectParameters(**data[rel].get("parameters")) if "parameters" in data[rel] else None,
+                parameters=InfrahubObjectParameters(**data[rel].get("parameters"))
+                if "parameters" in data[rel]
+                else None,
             )
 
         return node

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -510,7 +510,7 @@ class InfrahubObjectFileData(BaseModel):
                 context=context,
                 branch=branch,
                 default_schema_kind=default_schema_kind,
-                parameters=InfrahubObjectParameters(**data[rel].get("parameters")),
+                parameters=InfrahubObjectParameters(**data[rel].get("parameters")) if "parameters" in data[rel] else None,
             )
 
         return node

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -209,6 +209,7 @@ class InfrahubObjectFileData(BaseModel):
                 position=[idx + 1],
                 branch=branch,
                 default_schema_kind=self.kind,
+                parameters=self.parameters,
             )
 
     @classmethod
@@ -509,7 +510,7 @@ class InfrahubObjectFileData(BaseModel):
                 context=context,
                 branch=branch,
                 default_schema_kind=default_schema_kind,
-                parameters=parameters,
+                parameters=InfrahubObjectParameters(**data[rel].get("parameters")),
             )
 
         return node

--- a/tests/unit/sdk/spec/test_object.py
+++ b/tests/unit/sdk/spec/test_object.py
@@ -100,6 +100,24 @@ def location_expansion_multiple_ranges_bad_syntax(root_location: dict) -> dict:
     return location
 
 
+@pytest.fixture
+def location_with_non_dict_parameters(root_location: dict) -> dict:
+    data = [{"name": "Mexico", "type": "Country"}]
+    location = root_location.copy()
+    location["spec"]["data"] = data
+    location["spec"]["parameters"] = "not_a_dict"
+    return location
+
+
+@pytest.fixture
+def location_with_empty_parameters(root_location: dict) -> dict:
+    data = [{"name": "Mexico", "type": "Country"}]
+    location = root_location.copy()
+    location["spec"]["data"] = data
+    location["spec"]["parameters"] = {}
+    return location
+
+
 async def test_validate_object(client: InfrahubClient, schema_query_01_data: dict, location_mexico_01) -> None:
     client.schema.set_cache(schema=schema_query_01_data, branch="main")
     obj = ObjectFile(location="some/path", content=location_mexico_01)
@@ -221,3 +239,27 @@ async def test_get_relationship_info_tags(
     rel_info = await get_relationship_info(client_with_schema_01, location_schema, "tags", data)
     assert rel_info.is_valid == is_valid
     assert rel_info.format == format
+
+
+async def test_parameters_top_level(client_with_schema_01: InfrahubClient, location_expansion) -> None:
+    obj = ObjectFile(location="some/path", content=location_expansion)
+    await obj.validate_format(client=client_with_schema_01)
+    assert obj.spec.parameters.expand_range is True
+
+
+async def test_parameters_missing(client_with_schema_01: InfrahubClient, location_mexico_01) -> None:
+    obj = ObjectFile(location="some/path", content=location_mexico_01)
+    await obj.validate_format(client=client_with_schema_01)
+    assert hasattr(obj.spec.parameters, "expand_range")
+
+
+async def test_parameters_empty_dict(client_with_schema_01: InfrahubClient, location_with_empty_parameters) -> None:
+    obj = ObjectFile(location="some/path", content=location_with_empty_parameters)
+    await obj.validate_format(client=client_with_schema_01)
+    assert hasattr(obj.spec.parameters, "expand_range")
+
+
+async def test_parameters_non_dict(client_with_schema_01: InfrahubClient, location_with_non_dict_parameters) -> None:
+    obj = ObjectFile(location="some/path", content=location_with_non_dict_parameters)
+    with pytest.raises(ValidationError):
+        await obj.validate_format(client=client_with_schema_01)


### PR DESCRIPTION
Fixes: #624 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested object template range expansion so per-item embedded parameters are respected when creating related objects, ensuring parameter overrides apply correctly and validation/expansion behave consistently.

* **Tests**
  * Added tests for parameter handling in nested objects: top-level, missing, empty, and invalid (non-dictionary) parameter cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->