### PR TITLE
Prevent InfrahubNode from instantiating optional relationships of car…

### DIFF
--- a/changelog/630.fixed.md
+++ b/changelog/630.fixed.md
@@ -1,0 +1,1 @@
+Prevent InfrahubNode from instantiating optional relationships of cardinality one with None data.

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -235,7 +235,6 @@ class InfrahubNodeBase:
             rel: RelatedNodeBase | RelationshipManagerBase = getattr(self, item_name)
 
             if rel_schema.cardinality == RelationshipCardinality.ONE and rel_schema.optional and not rel.initialized:
-                data[item_name] = None
                 continue
 
             if rel is None or not rel.initialized:

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1365,7 +1365,6 @@ async def test_create_input_data(client, location_schema: NodeSchemaAPI, client_
             "name": {"value": "JFK1"},
             "description": {"value": "JFK Airport"},
             "type": {"value": "SITE"},
-            "primary_tag": None,
         }
     }
 
@@ -1393,7 +1392,6 @@ async def test_create_input_data_with_dropdown(client, location_schema_with_drop
             "description": {"value": "JFK Airport"},
             "type": {"value": "SITE"},
             "status": {"value": None},
-            "primary_tag": None,
         }
     }
 
@@ -1641,7 +1639,7 @@ async def test_create_input_data_with_IPHost_attribute(client, ipaddress_schema,
         ip_address = InfrahubNodeSync(client=client, schema=ipaddress_schema, data=data)
 
     assert ip_address._generate_input_data()["data"] == {
-        "data": {"address": {"value": "1.1.1.1/24", "is_protected": True}, "interface": None}
+        "data": {"address": {"value": "1.1.1.1/24", "is_protected": True}}
     }
 
 
@@ -1655,7 +1653,7 @@ async def test_create_input_data_with_IPNetwork_attribute(client, ipnetwork_sche
         ip_network = InfrahubNodeSync(client=client, schema=ipnetwork_schema, data=data)
 
     assert ip_network._generate_input_data()["data"] == {
-        "data": {"network": {"value": "1.1.1.0/24", "is_protected": True}, "site": None}
+        "data": {"network": {"value": "1.1.1.0/24", "is_protected": True}}
     }
 
 
@@ -1853,7 +1851,7 @@ async def test_update_input_data_empty_relationship(
         "data": {
             "id": "llllllll-llll-llll-llll-llllllllllll",
             "name": {"value": "DFW"},
-            "primary_tag": None,
+            # "primary_tag": None,
             "tags": [],
             "type": {"value": "SITE"},
         },
@@ -1862,7 +1860,7 @@ async def test_update_input_data_empty_relationship(
         "data": {
             "id": "llllllll-llll-llll-llll-llllllllllll",
             "name": {"is_protected": True, "is_visible": True, "value": "DFW"},
-            "primary_tag": None,
+            # "primary_tag": None,
             "tags": [],
             "type": {"is_protected": True, "is_visible": True, "value": "SITE"},
         },


### PR DESCRIPTION
…dinality one with None data.

Fixes: #630 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of optional one-to-one relationships. Uninitialized optional relationships are now properly excluded from mutation requests instead of being set to None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->