### PR TITLE
Use ruff version from uv.lock in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,26 @@ jobs:
 
   python-lint:
     if: needs.files-changed.outputs.python == 'true'
-    needs: ["files-changed"]
+    needs: ["files-changed", "prepare-environment"]
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v5"
-      - name: "Setup environment"
-        run: "pip install ruff==0.14.5"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install UV
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "${{ needs.prepare-environment.outputs.UV_VERSION }}"
+      - name: Install dependencies
+        run: uv sync --group lint
       - name: "Linting: ruff check"
-        run: "ruff check ."
+        run: "uv run ruff check ."
       - name: "Linting: ruff format"
-        run: "ruff format --check --diff ."
+        run: "uv run ruff format --check --diff ."
 
 
   markdown-lint:


### PR DESCRIPTION
Update CI pipeline to use the ruff version from the lock file instead of having to update the CI each time uv is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies and Python environment setup process to use modern tooling. Modified linting commands to utilize the updated dependency management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->