### PR TITLE
Use specific rule codes when using noqa

### DIFF
--- a/infrahub_sdk/config.py
+++ b/infrahub_sdk/config.py
@@ -173,7 +173,7 @@ class Config(ConfigBase):
         # When using structlog the logger doesn't expose the expected methods by looking at the
         # object to pydantic rejects them. This is a workaround to allow structlog to be used
         # as a logger
-        return self.log  # type: ignore
+        return self.log  # type: ignore[return-value]
 
     @model_validator(mode="before")
     @classmethod

--- a/infrahub_sdk/query_groups.py
+++ b/infrahub_sdk/query_groups.py
@@ -168,7 +168,7 @@ class InfrahubGroupContext(InfrahubGroupContextBase):
             return
 
         # Calculate how many nodes should be deleted
-        self.unused_member_ids = set(existing_group.members.peer_ids) - set(members)  # type: ignore
+        self.unused_member_ids = list(set(existing_group.members.peer_ids) - set(members))  # type: ignore[union-attr]
 
         if not self.delete_unused_nodes:
             return
@@ -262,7 +262,7 @@ class InfrahubGroupContextSync(InfrahubGroupContextBase):
             return
 
         # Calculate how many nodes should be deleted
-        self.unused_member_ids = set(existing_group.members.peer_ids) - set(members)  # type: ignore
+        self.unused_member_ids = list(set(existing_group.members.peer_ids) - set(members))  # type: ignore[union-attr]
 
         if not self.delete_unused_nodes:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ ignore = [
     # Rules below needs to be Investigated                                                           #
     ##################################################################################################
     "PT",     # flake8-pytest-style
-    "PGH",    # pygrep-hooks
     "ERA",    # eradicate commented-out code
     "SLF001", # flake8-self
     "EM",     # flake8-errmsg

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,5 +3,5 @@ import builtins
 from rich import inspect as rinspect
 from rich import print as rprint
 
-builtins.rprint = rprint  # type: ignore
-builtins.rinspect = rinspect  # type: ignore
+builtins.rprint = rprint  # type: ignore[attr-defined]
+builtins.rinspect = rinspect  # type: ignore[attr-defined]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -248,7 +248,7 @@ TEST_IN_DOCKER = str_to_bool(os.environ.get("INFRAHUB_TEST_IN_DOCKER", "false"))
 #             },
 #         ],
 #     }
-#     return NodeSchema(**data)  # type: ignore
+#     return NodeSchema(**data)
 
 
 # @pytest.fixture

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,4 +2,4 @@ import builtins
 
 from rich import print as rprint
 
-builtins.rprint = rprint  # type: ignore
+builtins.rprint = rprint  # type: ignore[attr-defined]

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -174,7 +174,7 @@ async def location_schema() -> NodeSchemaAPI:
             },
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -216,7 +216,7 @@ async def location_schema_with_dropdown() -> NodeSchemaAPI:
             },
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -281,7 +281,7 @@ async def schema_with_hfid() -> dict[str, NodeSchemaAPI]:
             ],
         },
     }
-    return {k: NodeSchema(**v).convert_api() for k, v in data.items()}  # type: ignore
+    return {k: NodeSchema(**v).convert_api() for k, v in data.items()}
 
 
 @pytest.fixture
@@ -295,7 +295,7 @@ async def std_group_schema() -> NodeSchemaAPI:
             {"name": "description", "kind": "String", "optional": True},
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -679,7 +679,7 @@ async def tag_schema() -> NodeSchemaAPI:
             {"name": "description", "kind": "Text", "optional": True},
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -917,7 +917,7 @@ async def ipaddress_schema() -> NodeSchemaAPI:
             }
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -941,7 +941,7 @@ async def ipnetwork_schema() -> NodeSchemaAPI:
             }
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -954,7 +954,7 @@ async def ipam_ipprefix_schema() -> NodeSchemaAPI:
         "order_by": ["prefix_value"],
         "inherit_from": ["BuiltinIPAddress"],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -986,7 +986,7 @@ async def simple_device_schema() -> NodeSchemaAPI:
             },
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -1106,7 +1106,7 @@ async def ipaddress_pool_schema() -> NodeSchemaAPI:
             },
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -1165,7 +1165,7 @@ async def ipprefix_pool_schema() -> NodeSchemaAPI:
             },
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -1274,7 +1274,7 @@ async def device_schema() -> NodeSchemaAPI:
             {"name": "artifacts", "peer": "CoreArtifact", "optional": True, "cardinality": "many", "kind": "Generic"},
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture
@@ -1448,7 +1448,7 @@ async def artifact_definition_schema() -> NodeSchemaAPI:
             {"name": "artifact_name", "kind": "Text"},
         ],
     }
-    return NodeSchema(**data).convert_api()  # type: ignore
+    return NodeSchema(**data).convert_api()
 
 
 @pytest.fixture

--- a/tests/unit/sdk/test_template.py
+++ b/tests/unit/sdk/test_template.py
@@ -220,7 +220,7 @@ FAILING_FILE_TEST_CASES = [
                         name="top-level template code",
                     ),
                     syntax=Syntax(
-                        code="<html>\n<body>\n<ul>\n{% for server in servers %}\n    <li>{{server.name}}: {{ server.ip.primary }}</li>\n{% endfor %}\n</ul>\n\n</body>\n\n</html>\n",  # noqa E501
+                        code="<html>\n<body>\n<ul>\n{% for server in servers %}\n    <li>{{server.name}}: {{ server.ip.primary }}</li>\n{% endfor %}\n</ul>\n\n</body>\n\n</html>\n",  # noqa: E501
                         lexer="",
                     ),
                 )


### PR DESCRIPTION
Use specific ignore types where applicable instead of ignoring everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type hint specificity and static type checking across the codebase.

* **Chores**
  * Updated build configuration and removed outdated code quality rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->