### PR TITLE
Update ruleset for shadowing builtins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ ignore = [
     "G",      # flake8-logging-format
     "RSE",    # flake8-raise
     "BLE",    # flake8-blind-except (BLE)
-    "A",      # flake8-builtins
 
     ##################################################################################################
     # The ignored rules below should be removed once the code has been updated, they are included    #
@@ -229,6 +228,19 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+
+[tool.ruff.lint.flake8-builtins]
+ignorelist = [
+    "id",
+    # Review and update builtin shadowing below this line
+    "filter",
+    "format",
+    "input",
+    "list",
+    "property",
+]
+
 
 [tool.ruff.lint.isort]
 known-first-party = ["infrahub_sdk", "infrahub_ctl"]

--- a/tests/unit/sdk/test_yaml.py
+++ b/tests/unit/sdk/test_yaml.py
@@ -11,12 +11,12 @@ here = Path(__file__).parent.resolve()
 
 def test_read_missing_file() -> None:
     file_name = "i_do_not_exist.yml"
-    dir = here / "test_data"
-    full_path = dir / file_name
+    test_data_dir = here / "test_data"
+    full_path = test_data_dir / file_name
     yaml_file = YamlFile(location=full_path)
     yaml_file.load_content()
     assert not yaml_file.valid
-    assert yaml_file.error_message == f"{file_name}: not found at {dir}"
+    assert yaml_file.error_message == f"{file_name}: not found at {test_data_dir}"
 
 
 def test_read_incorrect_encoding() -> None:


### PR DESCRIPTION
Disallow adding additional shadows for builtins, fix a case where we were shadowing `dir`, added the other known ones to an ignore list for now.