### PR TITLE
Correct autofixable ruff rules for Optional

### DIFF
--- a/infrahub_sdk/ctl/check.py
+++ b/infrahub_sdk/ctl/check.py
@@ -5,7 +5,7 @@ import sys
 from asyncio import run as aiorun
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
@@ -49,8 +49,8 @@ def run(
     format_json: bool,
     list_available: bool,
     variables: dict[str, str],
-    name: Optional[str] = None,
-    branch: Optional[str] = None,
+    name: str | None = None,
+    branch: str | None = None,
 ) -> None:
     """Locate and execute all checks under the defined path."""
 

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -8,7 +8,7 @@ import platform
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import typer
 import ujson
@@ -78,13 +78,13 @@ console = Console()
 @catch_exception(console=console)
 def check(
     check_name: str = typer.Argument(default="", help="Name of the Python check"),
-    branch: Optional[str] = None,
+    branch: str | None = None,
     path: str = typer.Option(".", help="Root directory"),
     debug: bool = False,
     format_json: bool = False,
     _: str = CONFIG_PARAM,
     list_available: bool = typer.Option(False, "--list", help="Show available Python checks"),
-    variables: Optional[list[str]] = typer.Argument(
+    variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),
 ) -> None:
@@ -106,12 +106,12 @@ def check(
 @catch_exception(console=console)
 async def generator(
     generator_name: str = typer.Argument(default="", help="Name of the Generator"),
-    branch: Optional[str] = None,
+    branch: str | None = None,
     path: str = typer.Option(".", help="Root directory"),
     debug: bool = False,
     _: str = CONFIG_PARAM,
     list_available: bool = typer.Option(False, "--list", help="Show available Generators"),
-    variables: Optional[list[str]] = typer.Argument(
+    variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),
 ) -> None:
@@ -134,13 +134,13 @@ async def run(
     debug: bool = False,
     _: str = CONFIG_PARAM,
     branch: str = typer.Option(None, help="Branch on which to run the script."),
-    concurrent: Optional[int] = typer.Option(
+    concurrent: int | None = typer.Option(
         None,
         help="Maximum number of requests to execute at the same time.",
         envvar="INFRAHUB_MAX_CONCURRENT_EXECUTION",
     ),
     timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUB_TIMEOUT"),
-    variables: Optional[list[str]] = typer.Argument(
+    variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),
 ) -> None:
@@ -251,7 +251,7 @@ async def _run_transform(
 @catch_exception(console=console)
 async def render(
     transform_name: str = typer.Argument(default="", help="Name of the Python transformation", show_default=False),
-    variables: Optional[list[str]] = typer.Argument(
+    variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),
     branch: str = typer.Option(None, help="Branch on which to render the transform."),
@@ -301,7 +301,7 @@ async def render(
 @catch_exception(console=console)
 def transform(
     transform_name: str = typer.Argument(default="", help="Name of the Python transformation", show_default=False),
-    variables: Optional[list[str]] = typer.Argument(
+    variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),
     branch: str = typer.Option(None, help="Branch on which to run the transformation"),

--- a/infrahub_sdk/ctl/generator.py
+++ b/infrahub_sdk/ctl/generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
@@ -22,7 +22,7 @@ async def run(
     debug: bool,
     list_available: bool,
     branch: str | None = None,
-    variables: Optional[list[str]] = None,
+    variables: list[str] | None = None,
 ) -> None:
     init_logging(debug=debug)
     repository_config = get_repository_config(find_repository_config_file())

--- a/infrahub_sdk/ctl/graphql.py
+++ b/infrahub_sdk/ctl/graphql.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 from collections import defaultdict
 from pathlib import Path
-from typing import Optional
 
 import typer
 from ariadne_codegen.client_generators.package import PackageGenerator, get_package_generator
@@ -115,7 +114,7 @@ async def export_schema(
 @app.command()
 @catch_exception(console=console)
 async def generate_return_types(
-    query: Optional[Path] = typer.Argument(
+    query: Path | None = typer.Argument(
         None, help="Location of the GraphQL query file(s). Defaults to current directory if not specified."
     ),
     schema: Path = typer.Option("schema.graphql", help="Path to the GraphQL schema file."),

--- a/infrahub_sdk/ctl/importer.py
+++ b/infrahub_sdk/ctl/importer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from asyncio import run as aiorun
 from pathlib import Path
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -27,7 +26,7 @@ def load(
     quiet: bool = typer.Option(False, help="No console output"),
     _: str = CONFIG_PARAM,
     branch: str = typer.Option(None, help="Branch from which to export"),
-    concurrent: Optional[int] = typer.Option(
+    concurrent: int | None = typer.Option(
         None,
         help="Maximum number of requests to execute at the same time.",
         envvar="INFRAHUB_MAX_CONCURRENT_EXECUTION",

--- a/infrahub_sdk/ctl/repository.py
+++ b/infrahub_sdk/ctl/repository.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Optional
 
 import typer
 import yaml
@@ -109,7 +108,7 @@ async def add(
     name: str,
     location: str,
     description: str = "",
-    username: Optional[str] = None,
+    username: str | None = None,
     password: str = "",
     ref: str = "",
     read_only: bool = False,
@@ -155,7 +154,7 @@ async def add(
 
 @app.command()
 async def list(
-    branch: Optional[str] = typer.Option(None, help="Branch on which to list repositories."),
+    branch: str | None = typer.Option(None, help="Branch on which to list repositories."),
     debug: bool = False,
     _: str = CONFIG_PARAM,
 ) -> None:
@@ -214,12 +213,12 @@ async def init(
         default="https://github.com/opsmill/infrahub-template.git",
         help="Template to use for the new repository. Can be a local path or a git repository URL.",
     ),
-    data: Optional[Path] = typer.Option(default=None, help="Path to YAML file containing answers to CLI prompt."),
-    vcs_ref: Optional[str] = typer.Option(
+    data: Path | None = typer.Option(default=None, help="Path to YAML file containing answers to CLI prompt."),
+    vcs_ref: str | None = typer.Option(
         default="HEAD",
         help="VCS reference to use for the template. Defaults to HEAD.",
     ),
-    trust: Optional[bool] = typer.Option(
+    trust: bool | None = typer.Option(
         default=False,
         help="Trust the template repository. If set, the template will be cloned without verification.",
     ),

--- a/infrahub_sdk/ctl/task.py
+++ b/infrahub_sdk/ctl/task.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -75,8 +73,8 @@ async def list_tasks(
     state: list[str] = typer.Option(
         None, "--state", "-s", help="Filter by task state. Can be provided multiple times."
     ),
-    limit: Optional[int] = typer.Option(None, help="Maximum number of tasks to retrieve."),
-    offset: Optional[int] = typer.Option(None, help="Offset for pagination."),
+    limit: int | None = typer.Option(None, help="Maximum number of tasks to retrieve."),
+    offset: int | None = typer.Option(None, help="Offset for pagination."),
     include_related_nodes: bool = typer.Option(False, help="Include related nodes in the output."),
     include_logs: bool = typer.Option(False, help="Include task logs in the output."),
     json_output: bool = typer.Option(False, "--json", help="Output the result as JSON."),

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -6,7 +6,7 @@ import traceback
 from collections.abc import Callable, Coroutine
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NoReturn, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 import typer
 from click.exceptions import Exit
@@ -149,7 +149,7 @@ def print_graphql_errors(console: Console, errors: list) -> None:
             console.print(f"[red]{escape(str(error))}")
 
 
-def parse_cli_vars(variables: Optional[list[str]]) -> dict[str, str]:
+def parse_cli_vars(variables: list[str] | None) -> dict[str, str]:
     if not variables:
         return {}
 

--- a/infrahub_sdk/ctl/validate.py
+++ b/infrahub_sdk/ctl/validate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Optional
 
 import typer
 import ujson
@@ -58,7 +57,7 @@ async def validate_schema(schema: Path, _: str = CONFIG_PARAM) -> None:
 @catch_exception(console=console)
 def validate_graphql(
     query: str,
-    variables: Optional[list[str]] = typer.Argument(
+    variables: list[str] | None = typer.Argument(
         None, help="Variables to pass along with the query. Format key=value key=value."
     ),
     debug: bool = typer.Option(False, help="Display more troubleshooting information."),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,6 @@ ignore = [
     "SIM118",  # Use `key in dict` instead of `key in dict.keys)
     "TC003",   # Move standard library import `collections.abc.Iterable` into a type-checking block
     "UP031",   # Use format specifiers instead of percent format
-    "UP045",   # Use `X | None` for type annotations
 ]
 
 


### PR DESCRIPTION
Remove stuff now that Python 3.9 is phased out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized internal type annotations across the CLI module to use current Python standards, improving code consistency and maintainability without any impact to functionality or existing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->