### PR TITLE
Upgrade uv action version and pin Python version for test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ needs.prepare-environment.outputs.UV_VERSION }}"
       - name: Install dependencies
@@ -158,7 +158,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ needs.prepare-environment.outputs.UV_VERSION }}"
       - name: Install dependencies
@@ -185,7 +185,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ needs.prepare-environment.outputs.UV_VERSION }}"
       - name: Install dependencies
@@ -225,7 +225,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -246,9 +245,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ needs.prepare-environment.outputs.UV_VERSION }}"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
       - name: Mypy Tests
@@ -297,7 +297,7 @@ jobs:
           RUNNER_NAME=$(echo "${{ runner.name }}" | grep -o 'ghrunner[0-9]\+' | sed 's/ghrunner\([0-9]\+\)/ghrunner_\1/')
           echo "PYTEST_DEBUG_TEMPROOT=/var/lib/github/${RUNNER_NAME}/_temp" >> $GITHUB_ENV
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "${{ needs.prepare-environment.outputs.UV_VERSION }}"
       - name: Install dependencies


### PR DESCRIPTION
We noticed that Python 3.9 still existed in the test matrix and the tests were succeeding even if they shouldn't have. This change ensures that `uv` is running with the desired Python version and doesn't switch to one that's available if the intended version doesn't exist. With this change Python 3.9 is also removed from the test matrix since that job started to fail as Python 3.9 is no longer supported.