### PR TITLE
Clear out test restrictions for Python 3.9

### DIFF
--- a/tests/unit/ctl/test_render_app.py
+++ b/tests/unit/ctl/test_render_app.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -16,8 +15,6 @@ runner = CliRunner()
 
 
 FIXTURE_BASE_DIR = Path(Path(os.path.abspath(__file__)).parent / ".." / ".." / "fixtures" / "repos")
-
-requires_python_310 = pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
 
 
 @dataclass
@@ -55,7 +52,6 @@ RENDER_APP_FAIL_TEST_CASES = [
     "test_case",
     [pytest.param(tc, id=tc.name) for tc in RENDER_APP_FAIL_TEST_CASES],
 )
-@requires_python_310
 def test_validate_template_not_found(test_case: RenderAppFailure, httpx_mock: HTTPXMock) -> None:
     """Ensure that the correct errors are caught"""
     httpx_mock.add_response(
@@ -83,7 +79,6 @@ def test_validate_template_not_found(test_case: RenderAppFailure, httpx_mock: HT
         (None, None, True, "git-branch"),
     ],
 )
-@requires_python_310
 def test_render_branch_selection(monkeypatch, httpx_mock: HTTPXMock, cli_branch, env_branch, from_git, expected_branch):
     """Test that the render command uses the correct branch source."""
 

--- a/tests/unit/ctl/test_transform_app.py
+++ b/tests/unit/ctl/test_transform_app.py
@@ -3,7 +3,6 @@
 import json
 import os
 import shutil
-import sys
 import tempfile
 from pathlib import Path
 
@@ -22,8 +21,6 @@ runner = CliRunner()
 FIXTURE_BASE_DIR = Path(
     Path(os.path.abspath(__file__)).parent / ".." / ".." / "fixtures" / "integration" / "test_infrahubctl"
 )
-
-requires_python_310 = pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
 
 
 @pytest.fixture
@@ -51,7 +48,6 @@ class TestInfrahubctlTransform:
     """Groups the 'infrahubctl transform' test cases."""
 
     @staticmethod
-    @requires_python_310
     def test_transform_not_exist_in_infrahub_yml(tags_transform_dir: str) -> None:
         """Case transform is not specified in the infrahub.yml file."""
         transform_name = "not_existing_transform"
@@ -61,7 +57,6 @@ class TestInfrahubctlTransform:
             assert output.exit_code == 1
 
     @staticmethod
-    @requires_python_310
     def test_transform_python_file_not_defined(tags_transform_dir: str) -> None:
         """Case transform python file not defined."""
         # Remove transform file
@@ -76,7 +71,6 @@ class TestInfrahubctlTransform:
             assert output.exit_code == 1
 
     @staticmethod
-    @requires_python_310
     def test_transform_python_class_not_defined(tags_transform_dir: str) -> None:
         """Case transform python class not defined."""
         # Rename transform inside of python file so the class name searched for no longer exists
@@ -96,7 +90,6 @@ class TestInfrahubctlTransform:
             assert output.exit_code == 1
 
     @staticmethod
-    @requires_python_310
     def test_gql_query_not_defined(tags_transform_dir: str) -> None:
         """Case GraphQL Query is not defined"""
         # Remove GraphQL Query file
@@ -110,7 +103,6 @@ class TestInfrahubctlTransform:
             assert output.exit_code == 1
 
     @staticmethod
-    @requires_python_310
     def test_infrahubctl_transform_cmd_success(httpx_mock: HTTPXMock, tags_transform_dir: str) -> None:
         """Case infrahubctl transform command executes successfully"""
         httpx_mock.add_response(


### PR DESCRIPTION
As we've removed support for Python 3.9 we can delete the marker to ignore things that didn't work in 3.9.