### PR TITLE
Set vale to ignore yaml files

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -16,5 +16,10 @@ BlockIgnores = (?s) *((import.*?\n)|(```.*?```\n))
 # in files like pyproject.toml
 BasedOnStyles =
 
+[*.yml]
+# Ignore all rules for yaml files, to prevent false positives
+# in files for GitHub Actions or other CI/CD configurations
+BasedOnStyles =
+
 [*]
 BasedOnStyles = Infrahub


### PR DESCRIPTION
Causes visual linting issues in the editor if the vale extension is installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized linting configuration to reduce false positives in YAML-based configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->