### PR TITLE
fix: python 3.14 deprecation warnings

### DIFF
--- a/changelog/+1b40f022.housekeeping.md
+++ b/changelog/+1b40f022.housekeeping.md
@@ -1,0 +1,1 @@
+Fixed Python 3.14 compatibility warnings. Testing now requires pytest>=9.

--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import asyncio
 import importlib
+import inspect
 import os
 import warnings
 from abc import abstractmethod
@@ -160,7 +160,7 @@ class InfrahubCheck:
             data = await self.collect_data()
         unpacked = data.get("data") or data
 
-        if asyncio.iscoroutinefunction(self.validate):
+        if inspect.iscoroutinefunction(self.validate):
             await self.validate(data=unpacked)
         else:
             self.validate(data=unpacked)

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import importlib
+import inspect
 import logging
 import platform
 import sys
@@ -240,7 +241,7 @@ async def _run_transform(
                 console.print("[yellow]   you can specify a different branch with --branch")
         raise typer.Abort()
 
-    if asyncio.iscoroutinefunction(transform_func):
+    if inspect.iscoroutinefunction(transform_func):
         output = await transform_func(response)
     else:
         output = transform_func(response)

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+import inspect
 import logging
 import traceback
 from collections.abc import Callable, Coroutine
@@ -83,7 +83,7 @@ def catch_exception(
         console = Console()
 
     def decorator(func: Callable[..., T]) -> Callable[..., T | Coroutine[Any, Any, T]]:
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> T:

--- a/infrahub_sdk/transforms.py
+++ b/infrahub_sdk/transforms.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+import inspect
 import os
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
@@ -75,7 +75,7 @@ class InfrahubTransform(InfrahubOperation):
         unpacked = data.get("data") or data
         await self.process_nodes(data=unpacked)
 
-        if asyncio.iscoroutinefunction(self.transform):
+        if inspect.iscoroutinefunction(self.transform):
             return await self.transform(data=unpacked)
 
         return self.transform(data=unpacked)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,8 @@ all = [
 # Core optional dependencies
 tests = [
     "infrahub-testcontainers>=1.5.1",
-    "pytest",
-    "pytest-asyncio<0.23",
+    "pytest>=9.0,<9.1",
+    "pytest-asyncio>=1.3,<1.4",
     "pytest-clarity>=1.0.1",
     "pytest-cov>=4.0.0",
     "pytest-httpx>=0.30",
@@ -108,6 +108,7 @@ exclude_lines = ["if TYPE_CHECKING:", "raise NotImplementedError()"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
 filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
-import asyncio
 import os
 from collections.abc import Generator
 
 import pytest
+import pytest_asyncio
 
 from infrahub_sdk.ctl import config
 
@@ -11,13 +11,11 @@ pytest_plugins = ["pytester"]
 ENV_VARS_TO_CLEAN = ["INFRAHUB_ADDRESS", "INFRAHUB_TOKEN", "INFRAHUB_BRANCH", "INFRAHUB_USERNAME", "INFRAHUB_PASSWORD"]
 
 
-@pytest.fixture(scope="session")
-def event_loop() -> Generator[asyncio.AbstractEventLoop]:
-    """Overrides pytest default function scoped event loop"""
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()
+def pytest_collection_modifyitems(items) -> None:
+    pytest_asyncio_tests = (item for item in items if pytest_asyncio.is_async_test(item))
+    session_scope_marker = pytest.mark.asyncio(loop_scope="session")
+    for async_test in pytest_asyncio_tests:
+        async_test.add_marker(session_scope_marker, append=False)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -125,6 +125,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -848,8 +857,8 @@ dev = [
     { name = "ipython" },
     { name = "mypy", specifier = "==1.11.2" },
     { name = "pre-commit", specifier = ">=2.20.0" },
-    { name = "pytest" },
-    { name = "pytest-asyncio", specifier = "<0.23" },
+    { name = "pytest", specifier = ">=9.0,<9.1" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<1.4" },
     { name = "pytest-clarity", specifier = ">=1.0.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30" },
@@ -870,8 +879,8 @@ lint = [
 ]
 tests = [
     { name = "infrahub-testcontainers", specifier = ">=1.5.1" },
-    { name = "pytest" },
-    { name = "pytest-asyncio", specifier = "<0.23" },
+    { name = "pytest", specifier = ">=9.0,<9.1" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<1.4" },
     { name = "pytest-clarity", specifier = ">=1.0.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30" },
@@ -1972,7 +1981,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1983,21 +1992,23 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.21.2"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/53/57663d99acaac2fcdafdc697e52a9b1b7d6fcf36616281ff9768a44e7ff3/pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45", size = 30656, upload-time = "2024-04-29T13:23:24.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/ce/1e4b53c213dce25d6e8b163697fbce2d43799d76fa08eea6ad270451c370/pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b", size = 13368, upload-time = "2024-04-29T13:23:23.126Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -2027,15 +2038,15 @@ wheels = [
 
 [[package]]
 name = "pytest-httpx"
-version = "0.35.0"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146, upload-time = "2024-11-28T19:16:54.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/5574834da9499066fa1a5ea9c336f94dba2eae02298d36dab192fcf95c86/pytest_httpx-0.36.0.tar.gz", hash = "sha256:9edb66a5fd4388ce3c343189bc67e7e1cb50b07c2e3fc83b97d511975e8a831b", size = 56793, upload-time = "2025-12-02T16:34:57.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442, upload-time = "2024-11-28T19:16:52.787Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d2/1eb1ea9c84f0d2033eb0b49675afdc71aa4ea801b74615f00f3c33b725e3/pytest_httpx-0.36.0-py3-none-any.whl", hash = "sha256:bd4c120bb80e142df856e825ec9f17981effb84d159f9fa29ed97e2357c3a9c8", size = 20229, upload-time = "2025-12-02T16:34:56.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test framework dependencies and default asyncio test fixture scope.

* **Refactor**
  * Standardized coroutine detection across the SDK for improved compatibility.

* **Tests**
  * Reworked async test setup to use a session-scoped async marker instead of a per-test event loop fixture.

* **Documentation**
  * Noted fix for Python 3.14 compatibility warnings in the changelog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->