### PR TITLE
Add ability to query for node metadata

### DIFF
--- a/changelog/+d3b5369f.added.md
+++ b/changelog/+d3b5369f.added.md
@@ -1,0 +1,1 @@
+Add ability to query for metadata on nodes to include information such as creation and update timestamps, creator and last user to update an object.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -401,6 +401,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> SchemaType | None: ...
 
@@ -420,6 +421,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> SchemaType: ...
 
@@ -439,6 +441,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> SchemaType: ...
 
@@ -458,6 +461,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> InfrahubNode | None: ...
 
@@ -477,6 +481,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> InfrahubNode: ...
 
@@ -496,6 +501,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> InfrahubNode: ...
 
@@ -514,6 +520,7 @@ class InfrahubClient(BaseClient):
         fragment: bool = False,
         prefetch_relationships: bool = False,
         property: bool = False,
+        include_metadata: bool = False,
         **kwargs: Any,
     ) -> InfrahubNode | SchemaType | None:
         branch = branch or self.default_branch
@@ -547,6 +554,7 @@ class InfrahubClient(BaseClient):
             fragment=fragment,
             prefetch_relationships=prefetch_relationships,
             property=property,
+            include_metadata=include_metadata,
             **filters,
         )
 
@@ -650,6 +658,7 @@ class InfrahubClient(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
     ) -> list[SchemaType]: ...
 
     @overload
@@ -669,6 +678,7 @@ class InfrahubClient(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
     ) -> list[InfrahubNode]: ...
 
     async def all(
@@ -687,6 +697,7 @@ class InfrahubClient(BaseClient):
         property: bool = False,
         parallel: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
     ) -> list[InfrahubNode] | list[SchemaType]:
         """Retrieve all nodes of a given kind
 
@@ -704,6 +715,7 @@ class InfrahubClient(BaseClient):
             prefetch_relationships (bool, optional): Flag to indicate whether to prefetch related node data.
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
 
         Returns:
             list[InfrahubNode]: List of Nodes
@@ -723,6 +735,7 @@ class InfrahubClient(BaseClient):
             property=property,
             parallel=parallel,
             order=order,
+            include_metadata=include_metadata,
         )
 
     @overload
@@ -743,6 +756,7 @@ class InfrahubClient(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> list[SchemaType]: ...
 
@@ -764,6 +778,7 @@ class InfrahubClient(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> list[InfrahubNode]: ...
 
@@ -784,6 +799,7 @@ class InfrahubClient(BaseClient):
         property: bool = False,
         parallel: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
         **kwargs: Any,
     ) -> list[InfrahubNode] | list[SchemaType]:
         """Retrieve nodes of a given kind based on provided filters.
@@ -803,6 +819,7 @@ class InfrahubClient(BaseClient):
             partial_match (bool, optional): Allow partial match of filter criteria for the query.
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:
@@ -829,6 +846,7 @@ class InfrahubClient(BaseClient):
                 partial_match=partial_match,
                 property=property,
                 order=order,
+                include_metadata=include_metadata,
             )
             query = Query(query=query_data)
             response = await self.execute_graphql(
@@ -1957,6 +1975,7 @@ class InfrahubClientSync(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
     ) -> list[SchemaTypeSync]: ...
 
     @overload
@@ -1976,6 +1995,7 @@ class InfrahubClientSync(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
     ) -> list[InfrahubNodeSync]: ...
 
     def all(
@@ -1994,6 +2014,7 @@ class InfrahubClientSync(BaseClient):
         property: bool = False,
         parallel: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
     ) -> list[InfrahubNodeSync] | list[SchemaTypeSync]:
         """Retrieve all nodes of a given kind
 
@@ -2011,6 +2032,7 @@ class InfrahubClientSync(BaseClient):
             prefetch_relationships (bool, optional): Flag to indicate whether to prefetch related node data.
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
 
         Returns:
             list[InfrahubNodeSync]: List of Nodes
@@ -2030,6 +2052,7 @@ class InfrahubClientSync(BaseClient):
             property=property,
             parallel=parallel,
             order=order,
+            include_metadata=include_metadata,
         )
 
     def _process_nodes_and_relationships(
@@ -2091,6 +2114,7 @@ class InfrahubClientSync(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> list[SchemaTypeSync]: ...
 
@@ -2112,6 +2136,7 @@ class InfrahubClientSync(BaseClient):
         property: bool = ...,
         parallel: bool = ...,
         order: Order | None = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> list[InfrahubNodeSync]: ...
 
@@ -2132,6 +2157,7 @@ class InfrahubClientSync(BaseClient):
         property: bool = False,
         parallel: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
         **kwargs: Any,
     ) -> list[InfrahubNodeSync] | list[SchemaTypeSync]:
         """Retrieve nodes of a given kind based on provided filters.
@@ -2151,6 +2177,7 @@ class InfrahubClientSync(BaseClient):
             partial_match (bool, optional): Allow partial match of filter criteria for the query.
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:
@@ -2177,6 +2204,7 @@ class InfrahubClientSync(BaseClient):
                 partial_match=partial_match,
                 property=property,
                 order=order,
+                include_metadata=include_metadata,
             )
             query = Query(query=query_data)
             response = self.execute_graphql(
@@ -2266,6 +2294,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> SchemaTypeSync | None: ...
 
@@ -2285,6 +2314,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> SchemaTypeSync: ...
 
@@ -2304,6 +2334,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> SchemaTypeSync: ...
 
@@ -2323,6 +2354,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> InfrahubNodeSync | None: ...
 
@@ -2342,6 +2374,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> InfrahubNodeSync: ...
 
@@ -2361,6 +2394,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = ...,
         prefetch_relationships: bool = ...,
         property: bool = ...,
+        include_metadata: bool = ...,
         **kwargs: Any,
     ) -> InfrahubNodeSync: ...
 
@@ -2379,6 +2413,7 @@ class InfrahubClientSync(BaseClient):
         fragment: bool = False,
         prefetch_relationships: bool = False,
         property: bool = False,
+        include_metadata: bool = False,
         **kwargs: Any,
     ) -> InfrahubNodeSync | SchemaTypeSync | None:
         branch = branch or self.default_branch
@@ -2412,6 +2447,7 @@ class InfrahubClientSync(BaseClient):
             fragment=fragment,
             prefetch_relationships=prefetch_relationships,
             property=property,
+            include_metadata=include_metadata,
             **filters,
         )
 

--- a/infrahub_sdk/node/attribute.py
+++ b/infrahub_sdk/node/attribute.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, get_args
 
 from ..protocols_base import CoreNodeBase
 from ..uuidt import UUIDT
-from .constants import IP_TYPES, PROPERTIES_FLAG, PROPERTIES_OBJECT, SAFE_VALUE
+from .constants import ATTRIBUTE_METADATA_OBJECT, IP_TYPES, PROPERTIES_FLAG, PROPERTIES_OBJECT, SAFE_VALUE
 from .property import NodeProperty
 
 if TYPE_CHECKING:
@@ -57,8 +57,13 @@ class Attribute:
 
         self.source: NodeProperty | None = None
         self.owner: NodeProperty | None = None
+        self.updated_by: NodeProperty | None = None
 
         for prop_name in self._properties_object:
+            if data.get(prop_name):
+                setattr(self, prop_name, NodeProperty(data=data.get(prop_name)))  # type: ignore[arg-type]
+
+        for prop_name in ATTRIBUTE_METADATA_OBJECT:
             if data.get(prop_name):
                 setattr(self, prop_name, NodeProperty(data=data.get(prop_name)))  # type: ignore[arg-type]
 
@@ -104,7 +109,7 @@ class Attribute:
 
         return {"data": data, "variables": variables}
 
-    def _generate_query_data(self, property: bool = False) -> dict | None:
+    def _generate_query_data(self, property: bool = False, include_metadata: bool = False) -> dict | None:
         data: dict[str, Any] = {"value": None}
 
         if property:
@@ -113,6 +118,11 @@ class Attribute:
             for prop_name in self._properties_flag:
                 data[prop_name] = None
             for prop_name in self._properties_object:
+                data[prop_name] = {"id": None, "display_label": None, "__typename": None}
+
+        if include_metadata:
+            data["updated_at"] = None
+            for prop_name in ATTRIBUTE_METADATA_OBJECT:
                 data[prop_name] = {"id": None, "display_label": None, "__typename": None}
 
         return data

--- a/infrahub_sdk/node/constants.py
+++ b/infrahub_sdk/node/constants.py
@@ -3,6 +3,17 @@ import re
 
 PROPERTIES_FLAG = ["is_protected", "updated_at"]
 PROPERTIES_OBJECT = ["source", "owner"]
+
+# Attribute-level metadata object fields (in addition to PROPERTIES_OBJECT)
+ATTRIBUTE_METADATA_OBJECT = ["updated_by"]
+
+# Node metadata fields (for node_metadata in GraphQL response)
+NODE_METADATA_FIELDS_FLAG = ["created_at", "updated_at"]
+NODE_METADATA_FIELDS_OBJECT = ["created_by", "updated_by"]
+
+# Relationship metadata fields (for relationship_metadata in GraphQL response)
+RELATIONSHIP_METADATA_FIELDS_FLAG = ["updated_at"]
+RELATIONSHIP_METADATA_FIELDS_OBJECT = ["updated_by"]
 SAFE_VALUE = re.compile(r"(^[\. /:a-zA-Z0-9_-]+$)|(^$)")
 
 IP_TYPES = ipaddress.IPv4Interface | ipaddress.IPv6Interface | ipaddress.IPv4Network | ipaddress.IPv6Network

--- a/infrahub_sdk/node/metadata.py
+++ b/infrahub_sdk/node/metadata.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from .property import NodeProperty
+
+
+class NodeMetadata:
+    """Represents metadata about a node (created_at, created_by, updated_at, updated_by)."""
+
+    def __init__(self, data: dict | None = None) -> None:
+        """
+        Args:
+            data: Data containing the metadata fields from the GraphQL response.
+        """
+        self.created_at: str | None = None
+        self.created_by: NodeProperty | None = None
+        self.updated_at: str | None = None
+        self.updated_by: NodeProperty | None = None
+
+        if data:
+            self.created_at = data.get("created_at")
+            self.updated_at = data.get("updated_at")
+            if data.get("created_by"):
+                self.created_by = NodeProperty(data["created_by"])
+            if data.get("updated_by"):
+                self.updated_by = NodeProperty(data["updated_by"])
+
+    def __repr__(self) -> str:
+        return (
+            f"NodeMetadata(created_at={self.created_at!r}, created_by={self.created_by!r}, "
+            f"updated_at={self.updated_at!r}, updated_by={self.updated_by!r})"
+        )
+
+    @classmethod
+    def _generate_query_data(cls) -> dict:
+        """Generate the query structure for node_metadata fields."""
+        return {
+            "created_at": None,
+            "created_by": {"id": None, "__typename": None, "display_label": None},
+            "updated_at": None,
+            "updated_by": {"id": None, "__typename": None, "display_label": None},
+        }
+
+
+class RelationshipMetadata:
+    """Represents metadata about a relationship edge (updated_at, updated_by)."""
+
+    def __init__(self, data: dict | None = None) -> None:
+        """
+        Args:
+            data: Data containing the metadata fields from the GraphQL response.
+        """
+        self.updated_at: str | None = None
+        self.updated_by: NodeProperty | None = None
+
+        if data:
+            self.updated_at = data.get("updated_at")
+            if data.get("updated_by"):
+                self.updated_by = NodeProperty(data["updated_by"])
+
+    def __repr__(self) -> str:
+        return f"RelationshipMetadata(updated_at={self.updated_at!r}, updated_by={self.updated_by!r})"
+
+    @classmethod
+    def _generate_query_data(cls) -> dict:
+        """Generate the query structure for relationship_metadata fields."""
+        return {
+            "updated_at": None,
+            "updated_by": {"id": None, "__typename": None, "display_label": None},
+        }

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -23,6 +23,7 @@ from .constants import (
     ARTIFACT_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE,
     PROPERTIES_OBJECT,
 )
+from .metadata import NodeMetadata
 from .related_node import RelatedNode, RelatedNodeBase, RelatedNodeSync
 from .relationship import RelationshipManager, RelationshipManagerBase, RelationshipManagerSync
 
@@ -50,6 +51,7 @@ class InfrahubNodeBase:
         self._branch = branch
         self._existing: bool = True
         self._attribute_data: dict[str, Attribute] = {}
+        self._metadata: NodeMetadata | None = None
 
         # Generate a unique ID only to be used inside the SDK
         # The format if this ID is purposely different from the ID used by the API
@@ -151,6 +153,10 @@ class InfrahubNodeBase:
     @property
     def hfid_str(self) -> str | None:
         return self.get_human_friendly_id_as_string(include_kind=True)
+
+    def get_node_metadata(self) -> NodeMetadata | None:
+        """Returns the node metadata (created_at, created_by, updated_at, updated_by) if fetched."""
+        return self._metadata
 
     def _init_attributes(self, data: dict | None = None) -> None:
         for attr_schema in self._schema.attributes:
@@ -419,11 +425,15 @@ class InfrahubNodeBase:
         exclude: list[str] | None = None,
         partial_match: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
     ) -> dict[str, Any | dict]:
         data: dict[str, Any] = {
             "count": None,
             "edges": {"node": {"id": None, "hfid": None, "display_label": None, "__typename": None}},
         }
+
+        if include_metadata:
+            data["edges"]["node_metadata"] = NodeMetadata._generate_query_data()
 
         data["@filters"] = deepcopy(filters) if filters is not None else {}
 
@@ -496,14 +506,22 @@ class InfrahubNode(InfrahubNodeBase):
         """
         self._client = client
 
-        if isinstance(data, dict) and isinstance(data.get("node"), dict):
-            data = data.get("node")
+        # Extract node_metadata before extracting node data (node_metadata is sibling to node in edges)
+        node_metadata_data: dict | None = None
+        if isinstance(data, dict):
+            node_metadata_data = data.get("node_metadata")
+            if isinstance(data.get("node"), dict):
+                data = data.get("node")
 
         self._relationship_cardinality_many_data: dict[str, RelationshipManager] = {}
         self._relationship_cardinality_one_data: dict[str, RelatedNode] = {}
         self._hierarchical_data: dict[str, RelatedNode | RelationshipManager] = {}
 
         super().__init__(schema=schema, branch=branch or client.default_branch, data=data)
+
+        # Initialize metadata after base class init
+        if node_metadata_data:
+            self._metadata = NodeMetadata(node_metadata_data)
 
     @classmethod
     async def from_graphql(
@@ -785,6 +803,7 @@ class InfrahubNode(InfrahubNodeBase):
         partial_match: bool = False,
         property: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
     ) -> dict[str, Any | dict]:
         data = self.generate_query_data_init(
             filters=filters,
@@ -794,6 +813,7 @@ class InfrahubNode(InfrahubNodeBase):
             exclude=exclude,
             partial_match=partial_match,
             order=order,
+            include_metadata=include_metadata,
         )
         data["edges"]["node"].update(
             await self.generate_query_data_node(
@@ -802,6 +822,7 @@ class InfrahubNode(InfrahubNodeBase):
                 prefetch_relationships=prefetch_relationships,
                 inherited=True,
                 property=property,
+                include_metadata=include_metadata,
             )
         )
 
@@ -825,6 +846,7 @@ class InfrahubNode(InfrahubNodeBase):
                     inherited=False,
                     insert_alias=True,
                     property=property,
+                    include_metadata=include_metadata,
                 )
 
                 if child_data:
@@ -840,6 +862,7 @@ class InfrahubNode(InfrahubNodeBase):
         insert_alias: bool = False,
         prefetch_relationships: bool = False,
         property: bool = False,
+        include_metadata: bool = False,
     ) -> dict[str, Any | dict]:
         """Generate the node part of a GraphQL Query with attributes and nodes.
 
@@ -850,6 +873,7 @@ class InfrahubNode(InfrahubNodeBase):
                                         Defaults to True.
             insert_alias (bool, optional): If True, inserts aliases in the query for each attribute or relationship.
             prefetch_relationships (bool, optional): If True, pre-fetches relationship data as part of the query.
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
 
         Returns:
             dict[str, Union[Any, Dict]]: GraphQL query in dictionary format
@@ -866,7 +890,7 @@ class InfrahubNode(InfrahubNodeBase):
             if not inherited and attr._schema.inherited:
                 continue
 
-            attr_data = attr._generate_query_data(property=property)
+            attr_data = attr._generate_query_data(property=property, include_metadata=include_metadata)
             if attr_data:
                 data[attr_name] = attr_data
                 if insert_alias:
@@ -898,11 +922,14 @@ class InfrahubNode(InfrahubNodeBase):
                 peer_node = InfrahubNode(client=self._client, schema=peer_schema, branch=self._branch)
                 peer_data = await peer_node.generate_query_data_node(
                     property=property,
+                    include_metadata=include_metadata,
                 )
 
             rel_data: dict[str, Any]
             if rel_schema and rel_schema.cardinality == "one":
-                rel_data = RelatedNode._generate_query_data(peer_data=peer_data, property=property)
+                rel_data = RelatedNode._generate_query_data(
+                    peer_data=peer_data, property=property, include_metadata=include_metadata
+                )
                 # Nodes involved in a hierarchy are required to inherit from a common ancestor node, and graphql
                 # tries to resolve attributes in this ancestor instead of actual node. To avoid
                 # invalid queries issues when attribute is missing in the common ancestor, we use a fragment
@@ -912,7 +939,9 @@ class InfrahubNode(InfrahubNodeBase):
                     rel_data["node"] = {}
                     rel_data["node"][f"...on {rel_schema.peer}"] = data_node
             elif rel_schema and rel_schema.cardinality == "many":
-                rel_data = RelationshipManager._generate_query_data(peer_data=peer_data, property=property)
+                rel_data = RelationshipManager._generate_query_data(
+                    peer_data=peer_data, property=property, include_metadata=include_metadata
+                )
             else:
                 continue
 
@@ -1285,14 +1314,22 @@ class InfrahubNodeSync(InfrahubNodeBase):
         """
         self._client = client
 
-        if isinstance(data, dict) and isinstance(data.get("node"), dict):
-            data = data.get("node")
+        # Extract node_metadata before extracting node data (node_metadata is sibling to node in edges)
+        node_metadata_data: dict | None = None
+        if isinstance(data, dict):
+            node_metadata_data = data.get("node_metadata")
+            if isinstance(data.get("node"), dict):
+                data = data.get("node")
 
         self._relationship_cardinality_many_data: dict[str, RelationshipManagerSync] = {}
         self._relationship_cardinality_one_data: dict[str, RelatedNodeSync] = {}
         self._hierarchical_data: dict[str, RelatedNodeSync | RelationshipManagerSync] = {}
 
         super().__init__(schema=schema, branch=branch or client.default_branch, data=data)
+
+        # Initialize metadata after base class init
+        if node_metadata_data:
+            self._metadata = NodeMetadata(node_metadata_data)
 
     @classmethod
     def from_graphql(
@@ -1571,6 +1608,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         partial_match: bool = False,
         property: bool = False,
         order: Order | None = None,
+        include_metadata: bool = False,
     ) -> dict[str, Any | dict]:
         data = self.generate_query_data_init(
             filters=filters,
@@ -1580,6 +1618,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
             exclude=exclude,
             partial_match=partial_match,
             order=order,
+            include_metadata=include_metadata,
         )
         data["edges"]["node"].update(
             self.generate_query_data_node(
@@ -1588,6 +1627,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
                 prefetch_relationships=prefetch_relationships,
                 inherited=True,
                 property=property,
+                include_metadata=include_metadata,
             )
         )
 
@@ -1610,6 +1650,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
                     inherited=False,
                     insert_alias=True,
                     property=property,
+                    include_metadata=include_metadata,
                 )
 
                 if child_data:
@@ -1625,6 +1666,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         insert_alias: bool = False,
         prefetch_relationships: bool = False,
         property: bool = False,
+        include_metadata: bool = False,
     ) -> dict[str, Any | dict]:
         """Generate the node part of a GraphQL Query with attributes and nodes.
 
@@ -1635,6 +1677,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
                                         Defaults to True.
             insert_alias (bool, optional): If True, inserts aliases in the query for each attribute or relationship.
             prefetch_relationships (bool, optional): If True, pre-fetches relationship data as part of the query.
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
 
         Returns:
             dict[str, Union[Any, Dict]]: GraphQL query in dictionary format
@@ -1651,7 +1694,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
             if not inherited and attr._schema.inherited:
                 continue
 
-            attr_data = attr._generate_query_data(property=property)
+            attr_data = attr._generate_query_data(property=property, include_metadata=include_metadata)
             if attr_data:
                 data[attr_name] = attr_data
                 if insert_alias:
@@ -1683,11 +1726,14 @@ class InfrahubNodeSync(InfrahubNodeBase):
                 peer_node = InfrahubNodeSync(client=self._client, schema=peer_schema, branch=self._branch)
                 peer_data = peer_node.generate_query_data_node(
                     property=property,
+                    include_metadata=include_metadata,
                 )
 
             rel_data: dict[str, Any]
             if rel_schema and rel_schema.cardinality == "one":
-                rel_data = RelatedNodeSync._generate_query_data(peer_data=peer_data, property=property)
+                rel_data = RelatedNodeSync._generate_query_data(
+                    peer_data=peer_data, property=property, include_metadata=include_metadata
+                )
                 # Nodes involved in a hierarchy are required to inherit from a common ancestor node, and graphql
                 # tries to resolve attributes in this ancestor instead of actual node. To avoid
                 # invalid queries issues when attribute is missing in the common ancestor, we use a fragment
@@ -1697,7 +1743,9 @@ class InfrahubNodeSync(InfrahubNodeBase):
                     rel_data["node"] = {}
                     rel_data["node"][f"...on {rel_schema.peer}"] = data_node
             elif rel_schema and rel_schema.cardinality == "many":
-                rel_data = RelationshipManagerSync._generate_query_data(peer_data=peer_data, property=property)
+                rel_data = RelationshipManagerSync._generate_query_data(
+                    peer_data=peer_data, property=property, include_metadata=include_metadata
+                )
             else:
                 continue
 

--- a/infrahub_sdk/node/property.py
+++ b/infrahub_sdk/node/property.py
@@ -20,5 +20,8 @@ class NodeProperty:
             self.display_label = data.get("display_label", None)
             self.typename = data.get("__typename", None)
 
+    def __repr__(self) -> str:
+        return f"NodeProperty({{'id': {self.id!r}, 'display_label': {self.display_label!r}, '__typename': {self.typename!r}}})"
+
     def _generate_input_data(self) -> str | None:
         return self.id

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from ..exceptions import Error
 from ..protocols_base import CoreNodeBase
 from .constants import PROFILE_KIND_PREFIX, PROPERTIES_FLAG, PROPERTIES_OBJECT
+from .metadata import NodeMetadata, RelationshipMetadata
 
 if TYPE_CHECKING:
     from ..client import InfrahubClient, InfrahubClientSync
@@ -40,11 +41,13 @@ class RelatedNodeBase:
         self._typename: str | None = None
         self._kind: str | None = None
         self._source_typename: str | None = None
+        self._relationship_metadata: RelationshipMetadata | None = None
 
         if isinstance(data, (CoreNodeBase)):
             self._peer = data
             for prop in self._properties:
                 setattr(self, prop, None)
+            self._relationship_metadata = None
 
         elif isinstance(data, list):
             data = {"hfid": data}
@@ -80,6 +83,10 @@ class RelatedNodeBase:
                     setattr(self, prop, prop_data)
                 else:
                     setattr(self, prop, None)
+
+            # Parse relationship metadata (at edge level)
+            if data.get("relationship_metadata"):
+                self._relationship_metadata = RelationshipMetadata(data["relationship_metadata"])
 
     @property
     def id(self) -> str | None:
@@ -134,6 +141,10 @@ class RelatedNodeBase:
             return False
         return bool(re.match(rf"^{PROFILE_KIND_PREFIX}[A-Z]", self._source_typename))
 
+    def get_relationship_metadata(self) -> RelationshipMetadata | None:
+        """Returns the relationship metadata (updated_at, updated_by) if fetched."""
+        return self._relationship_metadata
+
     def _generate_input_data(self, allocate_from_pool: bool = False) -> dict[str, Any]:
         data: dict[str, Any] = {}
 
@@ -160,12 +171,17 @@ class RelatedNodeBase:
         return {}
 
     @classmethod
-    def _generate_query_data(cls, peer_data: dict[str, Any] | None = None, property: bool = False) -> dict:
+    def _generate_query_data(
+        cls, peer_data: dict[str, Any] | None = None, property: bool = False, include_metadata: bool = False
+    ) -> dict:
         """Generates the basic structure of a GraphQL query for a single relationship.
 
         Args:
             peer_data (dict[str, Union[Any, Dict]], optional): Additional data to be included in the query for the node.
                 This is used to add extra fields when prefetching related node data.
+            property (bool, optional): If True, includes property fields (is_protected, source, owner, etc.).
+            include_metadata (bool, optional): If True, includes node_metadata (for the peer node) and
+                relationship_metadata (for the relationship edge) fields.
 
         Returns:
             Dict: A dictionary representing the basic structure of a GraphQL query, including the node's ID, display label,
@@ -181,6 +197,13 @@ class RelatedNodeBase:
                 properties[prop_name] = {"id": None, "display_label": None, "__typename": None}
 
             data["properties"] = properties
+
+        if include_metadata:
+            # node_metadata is for the peer InfrahubNode (populated via from_graphql)
+            data["node_metadata"] = NodeMetadata._generate_query_data()
+            # relationship_metadata is for the relationship edge itself
+            data["relationship_metadata"] = RelationshipMetadata._generate_query_data()
+
         if peer_data:
             data["node"].update(peer_data)
 

--- a/infrahub_sdk/node/relationship.py
+++ b/infrahub_sdk/node/relationship.py
@@ -10,6 +10,7 @@ from ..exceptions import (
 )
 from ..types import Order
 from .constants import PROPERTIES_FLAG, PROPERTIES_OBJECT
+from .metadata import NodeMetadata, RelationshipMetadata
 from .related_node import RelatedNode, RelatedNodeSync
 
 if TYPE_CHECKING:
@@ -72,12 +73,16 @@ class RelationshipManagerBase:
         return {}
 
     @classmethod
-    def _generate_query_data(cls, peer_data: dict[str, Any] | None = None, property: bool = False) -> dict:
+    def _generate_query_data(
+        cls, peer_data: dict[str, Any] | None = None, property: bool = False, include_metadata: bool = False
+    ) -> dict:
         """Generates the basic structure of a GraphQL query for relationships with multiple nodes.
 
         Args:
             peer_data (dict[str, Union[Any, Dict]], optional): Additional data to be included in the query for each node.
                 This is used to add extra fields when prefetching related node data in many-to-many relationships.
+            property (bool, optional): If True, includes property fields (is_protected, source, owner, etc.).
+            include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata fields.
 
         Returns:
             Dict: A dictionary representing the basic structure of a GraphQL query for multiple related nodes.
@@ -96,6 +101,10 @@ class RelationshipManagerBase:
             for prop_name in PROPERTIES_OBJECT:
                 properties[prop_name] = {"id": None, "display_label": None, "__typename": None}
             data["edges"]["properties"] = properties
+
+        if include_metadata:
+            data["edges"]["node_metadata"] = NodeMetadata._generate_query_data()
+            data["edges"]["relationship_metadata"] = RelationshipMetadata._generate_query_data()
 
         if peer_data:
             data["edges"]["node"].update(peer_data)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import inspect
 import ipaddress
 from typing import TYPE_CHECKING
 
 import pytest
-from pytest_httpx import HTTPXMock
 
 from infrahub_sdk.exceptions import NodeNotFoundError
 from infrahub_sdk.node import (
@@ -16,12 +17,16 @@ from infrahub_sdk.node import (
     parse_human_friendly_id,
 )
 from infrahub_sdk.node.constants import SAFE_VALUE
+from infrahub_sdk.node.metadata import NodeMetadata, RelationshipMetadata
+from infrahub_sdk.node.property import NodeProperty
 from infrahub_sdk.node.related_node import RelatedNode, RelatedNodeSync
-from infrahub_sdk.schema import GenericSchema, NodeSchemaAPI
-from tests.unit.sdk.conftest import BothClients
 
 if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
     from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
+    from infrahub_sdk.schema import GenericSchema, NodeSchemaAPI
+    from tests.unit.sdk.conftest import BothClients
 
 # type: ignore[attr-defined]
 
@@ -2746,3 +2751,426 @@ class TestRelationshipManagerIsFromProfile:
             name="tags", client=client, node=None, branch="main", schema=location_schema.relationships[0], data=data
         )
         assert not manager.is_from_profile
+
+
+def test_node_property_repr_with_dict_data() -> None:
+    data = {"id": "account-123", "display_label": "Admin User", "__typename": "CoreAccount"}
+    prop = NodeProperty(data)
+    result = repr(prop)
+    assert result == "NodeProperty({'id': 'account-123', 'display_label': 'Admin User', '__typename': 'CoreAccount'})"
+
+
+def test_node_metadata_repr_with_full_data() -> None:
+    data = {
+        "created_at": "2024-01-15T10:30:00Z",
+        "created_by": {"id": "account-1", "display_label": "Admin", "__typename": "CoreAccount"},
+        "updated_at": "2024-01-16T14:45:00Z",
+        "updated_by": {"id": "account-2", "display_label": "Editor", "__typename": "CoreAccount"},
+    }
+    metadata = NodeMetadata(data)
+    result = repr(metadata)
+    assert "NodeMetadata(created_at='2024-01-15T10:30:00Z'" in result
+    assert "created_by=NodeProperty({'id': 'account-1'" in result
+    assert "updated_at='2024-01-16T14:45:00Z'" in result
+    assert "updated_by=NodeProperty({'id': 'account-2'" in result
+
+
+def test_relationship_metadata_repr_with_full_data() -> None:
+    data = {
+        "updated_at": "2024-01-16T14:45:00Z",
+        "updated_by": {"id": "account-1", "display_label": "Admin", "__typename": "CoreAccount"},
+    }
+    metadata = RelationshipMetadata(data)
+    result = repr(metadata)
+    assert "RelationshipMetadata(updated_at='2024-01-16T14:45:00Z'" in result
+    assert "updated_by=NodeProperty({'id': 'account-1'" in result
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_data_with_include_metadata(
+    clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Test that include_metadata=True adds node_metadata and attribute-level updated_by to the query."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema)
+        data = await node.generate_query_data(include_metadata=True)
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema)
+        data = node.generate_query_data(include_metadata=True)
+
+    edges = data["BuiltinLocation"]["edges"]
+
+    # Verify node_metadata is present at the edge level
+    assert "node_metadata" in edges
+    assert edges["node_metadata"] == {
+        "created_at": None,
+        "created_by": {"id": None, "__typename": None, "display_label": None},
+        "updated_at": None,
+        "updated_by": {"id": None, "__typename": None, "display_label": None},
+    }
+
+    # Verify attribute-level metadata fields
+    node_data = edges["node"]
+    assert node_data["name"]["updated_at"] is None
+    assert node_data["name"]["updated_by"] == {"id": None, "display_label": None, "__typename": None}
+    assert node_data["description"]["updated_at"] is None
+    assert node_data["description"]["updated_by"] == {"id": None, "display_label": None, "__typename": None}
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_data_with_include_metadata_and_property(
+    clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Test that include_metadata=True combined with property=True produces expected query structure."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema)
+        data = await node.generate_query_data(property=True, include_metadata=True)
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema)
+        data = node.generate_query_data(property=True, include_metadata=True)
+
+    edges = data["BuiltinLocation"]["edges"]
+
+    # Verify node_metadata is present
+    assert "node_metadata" in edges
+
+    # Verify attribute has both property fields and metadata fields
+    node_data = edges["node"]
+    name_attr = node_data["name"]
+
+    # Property fields
+    assert "is_protected" in name_attr
+    assert "source" in name_attr
+    assert "owner" in name_attr
+    assert "is_default" in name_attr
+    assert "is_from_profile" in name_attr
+
+    # Metadata fields
+    assert "updated_at" in name_attr
+    assert "updated_by" in name_attr
+    assert name_attr["updated_by"] == {"id": None, "display_label": None, "__typename": None}
+
+    # Verify relationship also has relationship_metadata
+    primary_tag = node_data["primary_tag"]
+    assert "relationship_metadata" in primary_tag
+    assert primary_tag["relationship_metadata"] == {
+        "updated_at": None,
+        "updated_by": {"id": None, "__typename": None, "display_label": None},
+    }
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_data_without_include_metadata(
+    clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Test that include_metadata=False (default) does not add metadata fields."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema)
+        data = await node.generate_query_data(include_metadata=False)
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema)
+        data = node.generate_query_data(include_metadata=False)
+
+    edges = data["BuiltinLocation"]["edges"]
+
+    # Verify node_metadata is NOT present
+    assert "node_metadata" not in edges
+
+    # Verify attribute-level metadata fields are NOT present
+    node_data = edges["node"]
+    assert "updated_by" not in node_data["name"]
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_metadata_from_graphql_response(
+    clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Test that NodeMetadata is correctly parsed from GraphQL response data."""
+    location_data = {
+        "node": {
+            "__typename": "BuiltinLocation",
+            "id": "llllllll-llll-llll-llll-llllllllllll",
+            "display_label": "dfw1",
+            "name": {"value": "DFW"},
+            "description": {"value": None},
+            "type": {"value": "SITE"},
+            "primary_tag": {
+                "node": {
+                    "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
+                    "display_label": "red",
+                    "__typename": "BuiltinTag",
+                },
+            },
+            "tags": {
+                "count": 0,
+                "edges": [],
+            },
+        },
+        "node_metadata": {
+            "created_at": "2024-01-15T10:30:00Z",
+            "created_by": {"id": "account-1", "display_label": "Admin", "__typename": "CoreAccount"},
+            "updated_at": "2024-01-16T14:45:00Z",
+            "updated_by": {"id": "account-2", "display_label": "Editor", "__typename": "CoreAccount"},
+        },
+    }
+
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema, data=location_data)
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema, data=location_data)
+
+    metadata = node.get_node_metadata()
+
+    assert metadata is not None
+    assert metadata.created_at == "2024-01-15T10:30:00Z"
+    assert metadata.created_by.id == "account-1"
+    assert metadata.created_by.display_label == "Admin"
+    assert metadata.updated_at == "2024-01-16T14:45:00Z"
+    assert metadata.updated_by.id == "account-2"
+    assert metadata.updated_by.display_label == "Editor"
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_relationship_metadata_from_graphql_response(
+    clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Test that RelationshipMetadata is correctly parsed from GraphQL response data."""
+    location_data = {
+        "node": {
+            "__typename": "BuiltinLocation",
+            "id": "llllllll-llll-llll-llll-llllllllllll",
+            "display_label": "dfw1",
+            "name": {"value": "DFW"},
+            "description": {"value": None},
+            "type": {"value": "SITE"},
+            "primary_tag": {
+                "node": {
+                    "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
+                    "display_label": "red",
+                    "__typename": "BuiltinTag",
+                },
+                "relationship_metadata": {
+                    "updated_at": "2024-01-17T08:00:00Z",
+                    "updated_by": {"id": "account-3", "display_label": "Updater", "__typename": "CoreAccount"},
+                },
+            },
+            "tags": {
+                "count": 0,
+                "edges": [],
+            },
+        },
+    }
+
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema, data=location_data)
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema, data=location_data)
+
+    rel_metadata = node.primary_tag.get_relationship_metadata()
+
+    assert rel_metadata is not None
+    assert rel_metadata.updated_at == "2024-01-17T08:00:00Z"
+    assert rel_metadata.updated_by.id == "account-3"
+    assert rel_metadata.updated_by.display_label == "Updater"
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_attribute_metadata_from_graphql_response(
+    clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Test that attribute-level metadata (updated_at, updated_by) is correctly parsed."""
+    location_data = {
+        "node": {
+            "__typename": "BuiltinLocation",
+            "id": "llllllll-llll-llll-llll-llllllllllll",
+            "display_label": "dfw1",
+            "name": {
+                "value": "DFW",
+                "updated_at": "2024-01-18T09:00:00Z",
+                "updated_by": {"id": "account-4", "display_label": "NameUpdater", "__typename": "CoreAccount"},
+            },
+            "description": {
+                "value": None,
+                "updated_at": "2024-01-19T10:00:00Z",
+                "updated_by": None,
+            },
+            "type": {"value": "SITE"},
+            "primary_tag": {
+                "node": {
+                    "id": "rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr",
+                    "display_label": "red",
+                    "__typename": "BuiltinTag",
+                },
+            },
+            "tags": {
+                "count": 0,
+                "edges": [],
+            },
+        },
+    }
+
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=location_schema, data=location_data)
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=location_schema, data=location_data)
+
+    assert node.name.updated_at == "2024-01-18T09:00:00Z"
+    assert node.name.updated_by is not None
+    assert node.name.updated_by.id == "account-4"
+    assert node.name.updated_by.display_label == "NameUpdater"
+
+    assert node.description.updated_at == "2024-01-19T10:00:00Z"
+    assert node.description.updated_by is None
+
+
+def test_node_metadata_with_no_data() -> None:
+    """Test NodeMetadata initialization with no data argument."""
+    metadata = NodeMetadata()
+
+    assert metadata.created_at is None
+    assert metadata.created_by is None
+    assert metadata.updated_at is None
+    assert metadata.updated_by is None
+
+
+def test_node_metadata_with_none_data() -> None:
+    """Test NodeMetadata initialization with explicit None data."""
+    metadata = NodeMetadata(data=None)
+
+    assert metadata.created_at is None
+    assert metadata.created_by is None
+    assert metadata.updated_at is None
+    assert metadata.updated_by is None
+
+
+def test_node_metadata_with_partial_data_missing_created_by() -> None:
+    """Test NodeMetadata with data that has created_by as None."""
+    data = {
+        "created_at": "2024-01-15T10:30:00Z",
+        "created_by": None,
+        "updated_at": "2024-01-16T14:45:00Z",
+        "updated_by": {"id": "account-2", "display_label": "Editor", "__typename": "CoreAccount"},
+    }
+    metadata = NodeMetadata(data=data)
+
+    assert metadata.created_at == "2024-01-15T10:30:00Z"
+    assert metadata.created_by is None
+    assert metadata.updated_at == "2024-01-16T14:45:00Z"
+    assert metadata.updated_by is not None
+    assert metadata.updated_by.id == "account-2"
+
+
+def test_node_metadata_with_partial_data_missing_updated_by() -> None:
+    """Test NodeMetadata with data that has updated_by as None."""
+    data = {
+        "created_at": "2024-01-15T10:30:00Z",
+        "created_by": {"id": "account-1", "display_label": "Admin", "__typename": "CoreAccount"},
+        "updated_at": "2024-01-16T14:45:00Z",
+        "updated_by": None,
+    }
+    metadata = NodeMetadata(data=data)
+
+    assert metadata.created_at == "2024-01-15T10:30:00Z"
+    assert metadata.created_by is not None
+    assert metadata.created_by.id == "account-1"
+    assert metadata.updated_at == "2024-01-16T14:45:00Z"
+    assert metadata.updated_by is None
+
+
+def test_node_metadata_with_partial_data_missing_both() -> None:
+    """Test NodeMetadata with data that has both created_by and updated_by as None."""
+    data = {
+        "created_at": "2024-01-15T10:30:00Z",
+        "created_by": None,
+        "updated_at": "2024-01-16T14:45:00Z",
+        "updated_by": None,
+    }
+    metadata = NodeMetadata(data=data)
+
+    assert metadata.created_at == "2024-01-15T10:30:00Z"
+    assert metadata.created_by is None
+    assert metadata.updated_at == "2024-01-16T14:45:00Z"
+    assert metadata.updated_by is None
+
+
+def test_relationship_metadata_with_no_data() -> None:
+    """Test RelationshipMetadata initialization with no data argument."""
+    metadata = RelationshipMetadata()
+
+    assert metadata.updated_at is None
+    assert metadata.updated_by is None
+
+
+def test_relationship_metadata_with_none_data() -> None:
+    """Test RelationshipMetadata initialization with explicit None data."""
+    metadata = RelationshipMetadata(data=None)
+
+    assert metadata.updated_at is None
+    assert metadata.updated_by is None
+
+
+def test_relationship_metadata_with_partial_data_missing_updated_by() -> None:
+    """Test RelationshipMetadata with data that has updated_by as None."""
+    data = {
+        "updated_at": "2024-01-17T08:00:00Z",
+        "updated_by": None,
+    }
+    metadata = RelationshipMetadata(data=data)
+
+    assert metadata.updated_at == "2024-01-17T08:00:00Z"
+    assert metadata.updated_by is None
+
+
+def test_relationship_manager_generate_query_data_with_include_metadata() -> None:
+    """Test that RelationshipManagerBase._generate_query_data includes metadata when include_metadata=True."""
+    data = RelationshipManagerBase._generate_query_data(include_metadata=True)
+
+    assert "count" in data
+    assert "edges" in data
+    assert "node" in data["edges"]
+    assert data["edges"]["node"]["id"] is None
+    assert data["edges"]["node"]["hfid"] is None
+    assert data["edges"]["node"]["display_label"] is None
+    assert data["edges"]["node"]["__typename"] is None
+
+    assert "node_metadata" in data["edges"]
+    node_metadata = data["edges"]["node_metadata"]
+    assert "created_at" in node_metadata
+    assert "created_by" in node_metadata
+    assert "updated_at" in node_metadata
+    assert "updated_by" in node_metadata
+    assert node_metadata["created_by"] == {"id": None, "__typename": None, "display_label": None}
+    assert node_metadata["updated_by"] == {"id": None, "__typename": None, "display_label": None}
+
+    assert "relationship_metadata" in data["edges"]
+    rel_metadata = data["edges"]["relationship_metadata"]
+    assert "updated_at" in rel_metadata
+    assert "updated_by" in rel_metadata
+    assert rel_metadata["updated_by"] == {"id": None, "__typename": None, "display_label": None}
+
+
+def test_relationship_manager_generate_query_data_with_include_metadata_and_property() -> None:
+    """Test RelationshipManagerBase._generate_query_data with both include_metadata=True and property=True."""
+    data = RelationshipManagerBase._generate_query_data(include_metadata=True, property=True)
+
+    assert "node_metadata" in data["edges"]
+    assert "relationship_metadata" in data["edges"]
+    assert "properties" in data["edges"]
+
+    properties = data["edges"]["properties"]
+    assert "is_protected" in properties
+    assert "updated_at" in properties
+    assert "source" in properties
+    assert "owner" in properties
+
+
+def test_relationship_manager_generate_query_data_without_include_metadata() -> None:
+    """Test that RelationshipManagerBase._generate_query_data excludes metadata when include_metadata=False."""
+    data = RelationshipManagerBase._generate_query_data(include_metadata=False)
+
+    assert "node_metadata" not in data["edges"]
+    assert "relationship_metadata" not in data["edges"]
+
+    assert "count" in data
+    assert "edges" in data
+    assert "node" in data["edges"]


### PR DESCRIPTION
Adds include_metadata to query parameters to expose metadata under attributes and through `.get_node_metadata()` at the node level and `.get_relationship_metadata()` on the related nodes.

Will look at a follow up PR for integration tests when we have a working image to test against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query methods (`get`, `all`, `filters`) now support an `include_metadata` parameter to retrieve node and relationship metadata
  * Metadata includes creation and update timestamps, creator, and the user who last updated each object
  * New accessor methods provide programmatic access to retrieved metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->