### PR TITLE
Fixes for test annotations and split up rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,12 +330,52 @@ max-complexity = 17
     "S106",    # Possible hardcoded password assigned to argument
     "ARG001",  # Unused function argument
     "ARG002",  # Unused method argument
-
-    ##################################################################################################
-    # Review and change the below later                                                              #
-    ##################################################################################################
-    "ANN001", # Missing type annotation for function argument
 ]
+
+##################################################################################################
+# ANN001 ignores - broken down for incremental cleanup                                           #
+# Remove each section as type annotations are added to that directory                            #
+##################################################################################################
+
+# tests/unit/sdk/ - 478 errors total
+"tests/unit/sdk/test_node.py" = ["ANN001"]              # 206 errors
+"tests/unit/sdk/test_client.py" = ["ANN001"]            # 85 errors
+"tests/unit/sdk/test_schema.py" = ["ANN001"]            # 36 errors
+"tests/unit/sdk/test_artifact.py" = ["ANN001"]          # 27 errors
+"tests/unit/sdk/test_hierarchical_nodes.py" = ["ANN001"] # 26 errors
+"tests/unit/sdk/test_task.py" = ["ANN001"]              # 21 errors
+"tests/unit/sdk/test_store.py" = ["ANN001"]             # 12 errors
+"tests/unit/sdk/spec/test_object.py" = ["ANN001"]       # 11 errors
+"tests/unit/sdk/conftest.py" = ["ANN001"]               # 11 errors
+"tests/unit/sdk/test_diff_summary.py" = ["ANN001"]      # 9 errors
+"tests/unit/sdk/test_object_store.py" = ["ANN001"]      # 7 errors
+"tests/unit/sdk/graphql/test_query.py" = ["ANN001"]     # 7 errors
+"tests/unit/sdk/test_timestamp.py" = ["ANN001"]         # 6 errors
+"tests/unit/sdk/test_repository.py" = ["ANN001"]        # 6 errors
+"tests/unit/sdk/test_utils.py" = ["ANN001"]             # 4 errors
+"tests/unit/sdk/test_store_branch.py" = ["ANN001"]      # 4 errors
+"tests/unit/sdk/test_query_analyzer.py" = ["ANN001"]    # 4 errors
+"tests/unit/sdk/test_group_context.py" = ["ANN001"]     # 4 errors
+"tests/unit/sdk/test_branch.py" = ["ANN001"]            # 4 errors
+"tests/unit/sdk/test_batch.py" = ["ANN001"]             # 4 errors
+"tests/unit/sdk/graphql/test_renderer.py" = ["ANN001"]  # 4 errors
+"tests/unit/sdk/checks/test_checks.py" = ["ANN001"]     # 2 errors
+"tests/unit/sdk/test_schema_sorter.py" = ["ANN001"]     # 1 error
+"tests/unit/sdk/test_protocols_generator.py" = ["ANN001"] # 1 error
+
+# tests/integration/ - 60 errors total
+"tests/integration/test_infrahub_client.py" = ["ANN001"] # 32 errors
+"tests/integration/test_node.py" = ["ANN001"]            # 15 errors
+"tests/integration/test_infrahubctl.py" = ["ANN001"]     # 9 errors
+"tests/integration/test_convert_object_type.py" = ["ANN001"] # 3 errors
+"tests/integration/test_repository.py" = ["ANN001"]      # 1 error
+
+# tests/unit/ctl/ - 25 errors total
+"tests/unit/ctl/test_repository_app.py" = ["ANN001"]  # 11 errors
+"tests/unit/ctl/test_render_app.py" = ["ANN001"]      # 5 errors
+"tests/unit/ctl/test_cli.py" = ["ANN001"]             # 5 errors
+"tests/unit/ctl/test_branch_app.py" = ["ANN001"]      # 3 errors
+"tests/unit/ctl/test_branch_report.py" = ["ANN001"]   # 1 error
 
 "tasks.py" = [
     "PLC0415", # `import` should be at the top-level of a file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ pytest_plugins = ["pytester"]
 ENV_VARS_TO_CLEAN = ["INFRAHUB_ADDRESS", "INFRAHUB_TOKEN", "INFRAHUB_BRANCH", "INFRAHUB_USERNAME", "INFRAHUB_PASSWORD"]
 
 
-def pytest_collection_modifyitems(items) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     pytest_asyncio_tests = (item for item in items if pytest_asyncio.is_async_test(item))
     session_scope_marker = pytest.mark.asyncio(loop_scope="session")
     for async_test in pytest_asyncio_tests:

--- a/tests/fixtures/integration/test_infrahubctl/tags_transform/tags_transform.py
+++ b/tests/fixtures/integration/test_infrahubctl/tags_transform/tags_transform.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from infrahub_sdk.transforms import InfrahubTransform
 
 
@@ -5,7 +7,7 @@ class TagsTransform(InfrahubTransform):
     query = "tags_query"
     url = "my-tags"
 
-    async def transform(self, data) -> dict[str, str]:
+    async def transform(self, data: dict[str, Any]) -> dict[str, str]:
         tag = data["BuiltinTag"]["edges"][0]["node"]
         tag_name = tag["name"]["value"]
         tag_description = tag["description"]["value"]

--- a/tests/fixtures/repos/ctl_integration/transforms/animal_person.py
+++ b/tests/fixtures/repos/ctl_integration/transforms/animal_person.py
@@ -6,7 +6,7 @@ from infrahub_sdk.transforms import InfrahubTransform
 class AnimalPerson(InfrahubTransform):
     query = "animal_person"
 
-    async def transform(self, data) -> dict[str, Any]:
+    async def transform(self, data: dict[str, Any]) -> dict[str, Any]:
         response_person = data["TestingPerson"]["edges"][0]["node"]
         name: str = response_person["name"]["value"]
         animal_names = sorted(

--- a/tests/fixtures/repos/ctl_integration/transforms/converted.py
+++ b/tests/fixtures/repos/ctl_integration/transforms/converted.py
@@ -7,7 +7,7 @@ from infrahub_sdk.transforms import InfrahubTransform
 class ConvertedAnimalPerson(InfrahubTransform):
     query = "animal_person"
 
-    async def transform(self, data) -> dict[str, Any]:
+    async def transform(self, data: dict[str, Any]) -> dict[str, Any]:
         response_person = data["TestingPerson"]["edges"][0]["node"]
         name: str = response_person["name"]["value"]
         person = self.store.get(key=name, kind="TestingPerson")

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -1,16 +1,19 @@
-def test_help_message(pytester) -> None:
+import pytest
+
+
+def test_help_message(pytester: pytest.Pytester) -> None:
     """Make sure that the plugin is loaded by capturing an option it adds in the help message."""
     result = pytester.runpytest("--help")
     result.stdout.fnmatch_lines(["*Infrahub configuration file for the repository*"])
 
 
-def test_without_config(pytester) -> None:
+def test_without_config(pytester: pytest.Pytester) -> None:
     """Make sure 0 tests run when test file is not found."""
     result = pytester.runpytest()
     result.assert_outcomes()
 
 
-def test_emptyconfig(pytester) -> None:
+def test_emptyconfig(pytester: pytest.Pytester) -> None:
     """Make sure that the plugin load the test file properly."""
     pytester.makefile(
         ".yml",
@@ -25,7 +28,7 @@ def test_emptyconfig(pytester) -> None:
     result.assert_outcomes()
 
 
-def test_jinja2_transform_config_missing_directory(pytester) -> None:
+def test_jinja2_transform_config_missing_directory(pytester: pytest.Pytester) -> None:
     """Make sure tests raise errors if directories are not found."""
     pytester.makefile(
         ".yml",
@@ -63,7 +66,7 @@ def test_jinja2_transform_config_missing_directory(pytester) -> None:
     result.assert_outcomes(errors=1)
 
 
-def test_jinja2_transform_config_missing_input(pytester) -> None:
+def test_jinja2_transform_config_missing_input(pytester: pytest.Pytester) -> None:
     """Make sure tests raise errors if no inputs are provided."""
     pytester.makefile(
         ".yml",
@@ -104,7 +107,7 @@ def test_jinja2_transform_config_missing_input(pytester) -> None:
     result.assert_outcomes(errors=1)
 
 
-def test_jinja2_transform_no_expected_output(pytester) -> None:
+def test_jinja2_transform_no_expected_output(pytester: pytest.Pytester) -> None:
     """Make sure tests succeed if no expect outputs are provided."""
     pytester.makefile(
         ".yml",
@@ -161,7 +164,7 @@ def test_jinja2_transform_no_expected_output(pytester) -> None:
     result.assert_outcomes(passed=1)
 
 
-def test_jinja2_transform_unexpected_output(pytester) -> None:
+def test_jinja2_transform_unexpected_output(pytester: pytest.Pytester) -> None:
     """Make sure tests fail if the expected and computed outputs don't match."""
     pytester.makefile(
         ".yml",
@@ -233,7 +236,7 @@ def test_jinja2_transform_unexpected_output(pytester) -> None:
     result.assert_outcomes(failed=1)
 
 
-def test_python_transform(pytester) -> None:
+def test_python_transform(pytester: pytest.Pytester) -> None:
     pytester.makefile(
         ".yml",
         test_python_transform="""


### PR DESCRIPTION
Split up ignores for test annotations into smaller components and fix some of the violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal type annotations across test utilities and fixtures for improved code quality and static analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->