### PR TITLE
Fix pytest plugin for integration tests and empty YAML files

### DIFF
--- a/infrahub_sdk/pytest_plugin/items/python_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/python_transform.py
@@ -89,6 +89,7 @@ class InfrahubPythonTransformUnitProcessItem(InfrahubPythonTransformItem):
 
 class InfrahubPythonTransformIntegrationItem(InfrahubPythonTransformItem):
     def runtest(self) -> None:
+        self.instantiate_transform()
         input_data = self.session.infrahub_client.query_gql_query(  # type: ignore[attr-defined]
             self.transform_instance.query,
             variables=self.test.spec.get_variables_data(),  # type: ignore[union-attr]

--- a/infrahub_sdk/pytest_plugin/loader.py
+++ b/infrahub_sdk/pytest_plugin/loader.py
@@ -103,7 +103,7 @@ class InfrahubYamlFile(pytest.File):
     def collect(self) -> Iterable[Item]:
         raw = yaml.safe_load(self.path.open(encoding="utf-8"))
 
-        if "infrahub_tests" not in raw:
+        if not raw or "infrahub_tests" not in raw:
             return
 
         content = InfrahubTestFileV1(**raw)

--- a/infrahub_sdk/pytest_plugin/models.py
+++ b/infrahub_sdk/pytest_plugin/models.py
@@ -31,7 +31,7 @@ class InfrahubInputOutputTest(InfrahubBaseTest):
     directory: Path | None = Field(
         None, description="Path to the directory where the input and output files are located"
     )
-    input: Path = Field(
+    input: Path | None = Field(
         Path("input.json"),
         description="Path to the file with the input data for the test, can be a relative path from the config file or from the directory.",
     )
@@ -68,7 +68,7 @@ class InfrahubInputOutputTest(InfrahubBaseTest):
         else:
             self.directory = base_dir
 
-        if not self.input or not self.input.is_file():
+        if self.input is not None and not self.input.is_file():
             search_input: Path | str = self.input or "input.*"
             results = list(self.directory.rglob(str(search_input)))
 
@@ -99,6 +99,8 @@ class InfrahubInputOutputTest(InfrahubBaseTest):
 
 
 class InfrahubIntegrationTest(InfrahubInputOutputTest):
+    # Integration tests get input from live GraphQL queries, not from input files
+    input: Path | None = Field(None)
     variables: Path | dict[str, Any] = Field(
         Path("variables.json"), description="Variables and corresponding values to pass to the GraphQL query"
     )


### PR DESCRIPTION
- Add missing instantiate_transform() call in integration test runner
- Handle empty YAML files gracefully in loader to avoid TypeError
- Make input field optional in InfrahubInputOutputTest model
- Default input to None for InfrahubIntegrationTest since integration tests get input from live GraphQL queries, not files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved initialization order issue in integration tests to ensure proper setup before query execution.
  * Strengthened test data validation to gracefully handle missing or empty test data, preventing unexpected errors.

* **New Features**
  * Extended test framework to support test scenarios without requiring input files, offering greater flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->