### PR TITLE
Add telemetry CLI commands for airgapped data export

### DIFF
--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -119,8 +119,8 @@ def generate_proposed_change_tables(proposed_changes: list[CoreProposedChange]) 
         proposed_change_table.add_row("Name", pc.name.value)
         proposed_change_table.add_row("State", str(pc.state.value))
         proposed_change_table.add_row("Is draft", "Yes" if pc.is_draft.value else "No")
-        proposed_change_table.add_row("Created by", pc.created_by.peer.name.value)  # type: ignore[union-attr]
-        proposed_change_table.add_row("Created at", format_timestamp(str(pc.created_by.updated_at)))
+        proposed_change_table.add_row("Created by", pc.created_by.peer.name.value)  # type: ignore[union-attr, attr-defined]
+        proposed_change_table.add_row("Created at", format_timestamp(str(pc.created_by.updated_at)))  # type: ignore[attr-defined]
         proposed_change_table.add_row("Approvals", str(len(pc.approved_by.peers)))
         proposed_change_table.add_row("Rejections", str(len(pc.rejected_by.peers)))
 

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -35,6 +35,7 @@ from ..ctl.repository import app as repository_app
 from ..ctl.repository import find_repository_config_file, get_repository_config
 from ..ctl.schema import app as schema_app
 from ..ctl.task import app as task_app
+from ..ctl.telemetry import app as telemetry_app
 from ..ctl.transform import list_transforms
 from ..ctl.utils import (
     catch_exception,
@@ -68,6 +69,7 @@ app.add_typer(menu_app, name="menu")
 app.add_typer(object_app, name="object")
 app.add_typer(graphql_app, name="graphql")
 app.add_typer(task_app, name="task")
+app.add_typer(telemetry_app, name="telemetry")
 
 app.command(name="dump")(dump)
 app.command(name="load")(load)

--- a/infrahub_sdk/ctl/telemetry.py
+++ b/infrahub_sdk/ctl/telemetry.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 import typer
 from rich.console import Console
@@ -25,6 +26,25 @@ app = AsyncTyper()
 console = Console()
 
 
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a string for use in a filename."""
+    # Replace spaces and special chars with underscores, keep alphanumeric and dashes
+    sanitized = re.sub(r"[^a-zA-Z0-9\-]", "_", name)
+    # Collapse multiple underscores
+    sanitized = re.sub(r"_+", "_", sanitized)
+    # Remove leading/trailing underscores
+    return sanitized.strip("_").lower()
+
+
+def _generate_export_filename(customer_name: str | None) -> Path:
+    """Generate a descriptive export filename with customer name and date."""
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    if customer_name:
+        sanitized_name = _sanitize_filename(customer_name)
+        return Path(f"{sanitized_name}-telemetry-export-{today}.json")
+    return Path(f"telemetry-export-{today}.json")
+
+
 @app.callback()
 def callback() -> None:
     """Manage telemetry data export and operations.
@@ -37,11 +57,11 @@ def callback() -> None:
 @app.command(name="export")
 @catch_exception(console=console)
 async def export_telemetry(
-    output: Path = typer.Option(
-        Path("telemetry-export.json"),
+    output: Path | None = typer.Option(
+        None,
         "--output",
         "-o",
-        help="Output file path for the export",
+        help="Output file path for the export (default: {customer}-telemetry-export-{date}.json)",
     ),
     from_date: str | None = typer.Option(
         None,
@@ -81,23 +101,30 @@ async def export_telemetry(
     client = initialize_client()
 
     # Build query parameters for the REST API
-    params: dict[str, Any] = {}
+    query_parts: list[str] = []
     if from_date:
-        params["from_date"] = from_date
+        query_parts.append(f"from_date={from_date}")
     if to_date:
-        params["to_date"] = to_date
+        query_parts.append(f"to_date={to_date}")
     if export_all:
-        params["all"] = "true"
+        query_parts.append("all=true")
 
     # Query the REST API for telemetry export
     url = f"{client.address}/api/telemetry/export"
-    response = await client._get(url=url, params=params, timeout=client.default_timeout)
+    if query_parts:
+        url = f"{url}?{'&'.join(query_parts)}"
+    response = await client._get(url=url, timeout=client.default_timeout)
 
     if response.status_code != 200:
         console.print(f"[red]Error: {response.text}")
         raise typer.Exit(1)
 
     export_data = response.json()
+
+    # Generate filename with customer name and date if not specified
+    license_info = export_data.get("license", {})
+    if output is None:
+        output = _generate_export_filename(license_info.get("customer_name"))
 
     # Write to file (using Path.write_text for non-blocking file operations)
     output.write_text(json.dumps(export_data, indent=2, default=str), encoding="utf-8")

--- a/infrahub_sdk/ctl/telemetry.py
+++ b/infrahub_sdk/ctl/telemetry.py
@@ -26,8 +26,15 @@ app = AsyncTyper()
 console = Console()
 
 
-def _sanitize_filename(name: str) -> str:
-    """Sanitize a string for use in a filename."""
+def sanitize_filename(name: str) -> str:
+    """Sanitize a string for use in a filename.
+
+    Args:
+        name: The string to sanitize.
+
+    Returns:
+        A lowercase string safe for use in filenames.
+    """
     # Replace spaces and special chars with underscores, keep alphanumeric and dashes
     sanitized = re.sub(r"[^a-zA-Z0-9\-]", "_", name)
     # Collapse multiple underscores
@@ -36,11 +43,18 @@ def _sanitize_filename(name: str) -> str:
     return sanitized.strip("_").lower()
 
 
-def _generate_export_filename(customer_name: str | None) -> Path:
-    """Generate a descriptive export filename with customer name and date."""
+def generate_export_filename(customer_name: str | None) -> Path:
+    """Generate a descriptive export filename with customer name and date.
+
+    Args:
+        customer_name: The customer name to include in the filename, or None.
+
+    Returns:
+        A Path object with the generated filename.
+    """
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
     if customer_name:
-        sanitized_name = _sanitize_filename(customer_name)
+        sanitized_name = sanitize_filename(customer_name)
         return Path(f"{sanitized_name}-telemetry-export-{today}.json")
     return Path(f"telemetry-export-{today}.json")
 
@@ -123,11 +137,10 @@ async def export_telemetry(
 
     # Generate filename with customer name and date if not specified
     license_info = export_data.get("license", {})
-    if output is None:
-        output = _generate_export_filename(license_info.get("customer_name"))
+    output_path = output if output is not None else generate_export_filename(license_info.get("customer_name"))
 
     # Write to file (using Path.write_text for non-blocking file operations)
-    output.write_text(json.dumps(export_data, indent=2, default=str), encoding="utf-8")
+    output_path.write_text(json.dumps(export_data, indent=2, default=str), encoding="utf-8")
 
     # Show summary
     snapshots = export_data.get("snapshots", [])
@@ -146,12 +159,12 @@ async def export_telemetry(
         last_date = snapshots[-1].get("date", "N/A")
         table.add_row("Date Range", f"{first_date} to {last_date}")
 
-    table.add_row("Output File", str(output))
+    table.add_row("Output File", str(output_path))
 
     console.print()
     console.print(table)
     console.print()
-    console.print(Panel(f"[green]Export complete: {output}[/green]", border_style="green"))
+    console.print(Panel(f"[green]Export complete: {output_path}[/green]", border_style="green"))
 
 
 @app.command(name="list")

--- a/infrahub_sdk/ctl/telemetry.py
+++ b/infrahub_sdk/ctl/telemetry.py
@@ -1,0 +1,216 @@
+"""Telemetry CLI commands for exporting and managing telemetry data.
+
+This module provides CLI commands to export locally stored telemetry data
+for airgapped environments and to list available telemetry files.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from ..async_typer import AsyncTyper
+from .client import initialize_client
+from .parameters import CONFIG_PARAM
+from .utils import catch_exception
+
+app = AsyncTyper()
+console = Console()
+
+
+@app.callback()
+def callback() -> None:
+    """Manage telemetry data export and operations.
+
+    Export locally stored telemetry data for airgapped environments
+    or list available telemetry files.
+    """
+
+
+@app.command(name="export")
+@catch_exception(console=console)
+async def export_telemetry(
+    output: Path = typer.Option(
+        Path("telemetry-export.json"),
+        "--output",
+        "-o",
+        help="Output file path for the export",
+    ),
+    from_date: str | None = typer.Option(
+        None,
+        "--from",
+        help="Start date for export range (YYYY-MM-DD)",
+    ),
+    to_date: str | None = typer.Option(
+        None,
+        "--to",
+        help="End date for export range (YYYY-MM-DD)",
+    ),
+    export_all: bool = typer.Option(
+        False,
+        "--all",
+        help="Export all available telemetry data",
+    ),
+    _: str = CONFIG_PARAM,
+) -> None:
+    """Export telemetry data from Infrahub for airgapped transfer.
+
+    This command exports locally stored telemetry data into a format
+    suitable for manual transfer to OpsMill for airgapped environments.
+
+    Examples:
+
+        # Export last 30 days
+        infrahubctl telemetry export --from 2025-01-01 --to 2025-01-31
+
+        # Export all available data
+        infrahubctl telemetry export --all
+
+        # Export to specific file
+        infrahubctl telemetry export --all --output my-export.json
+    """
+    logging.getLogger("infrahub_sdk").setLevel(logging.CRITICAL)
+
+    client = initialize_client()
+
+    # Build query parameters for the REST API
+    params: dict[str, Any] = {}
+    if from_date:
+        params["from_date"] = from_date
+    if to_date:
+        params["to_date"] = to_date
+    if export_all:
+        params["all"] = "true"
+
+    # Query the REST API for telemetry export
+    url = f"{client.address}/api/telemetry/export"
+    response = await client._get(url=url, params=params, timeout=client.default_timeout)
+
+    if response.status_code != 200:
+        console.print(f"[red]Error: {response.text}")
+        raise typer.Exit(1)
+
+    export_data = response.json()
+
+    # Write to file (using Path.write_text for non-blocking file operations)
+    output.write_text(json.dumps(export_data, indent=2, default=str), encoding="utf-8")
+
+    # Show summary
+    snapshots = export_data.get("snapshots", [])
+    license_info = export_data.get("license", {})
+
+    table = Table(title="Export Summary", show_header=False, box=None)
+    table.add_column(justify="left", style="cyan")
+    table.add_column(justify="right", style="green")
+
+    table.add_row("Customer", license_info.get("customer_name", "Unknown"))
+    table.add_row("Product Tier", license_info.get("product_tier", "Unknown"))
+    table.add_row("Snapshots", str(len(snapshots)))
+
+    if snapshots:
+        first_date = snapshots[0].get("date", "N/A")
+        last_date = snapshots[-1].get("date", "N/A")
+        table.add_row("Date Range", f"{first_date} to {last_date}")
+
+    table.add_row("Output File", str(output))
+
+    console.print()
+    console.print(table)
+    console.print()
+    console.print(Panel(f"[green]Export complete: {output}[/green]", border_style="green"))
+
+
+@app.command(name="list")
+@catch_exception(console=console)
+async def list_telemetry(
+    _: str = CONFIG_PARAM,
+) -> None:
+    """List available local telemetry files.
+
+    Shows all telemetry files stored locally on the Infrahub instance,
+    including their dates and sizes.
+    """
+    logging.getLogger("infrahub_sdk").setLevel(logging.CRITICAL)
+
+    client = initialize_client()
+
+    url = f"{client.address}/api/telemetry/list"
+    response = await client._get(url=url, timeout=client.default_timeout)
+
+    if response.status_code != 200:
+        console.print(f"[red]Error: {response.text}")
+        raise typer.Exit(1)
+
+    files = response.json().get("files", [])
+
+    if not files:
+        console.print("[yellow]No telemetry files found[/yellow]")
+        return
+
+    table = Table(title="Local Telemetry Files")
+    table.add_column("Date", style="cyan")
+    table.add_column("Filename", style="green")
+    table.add_column("Size", style="yellow", justify="right")
+
+    for f in files:
+        table.add_row(f.get("date", "N/A"), f.get("filename", "N/A"), f.get("size", "N/A"))
+
+    console.print()
+    console.print(table)
+    console.print()
+
+
+@app.command(name="status")
+@catch_exception(console=console)
+async def telemetry_status(
+    _: str = CONFIG_PARAM,
+) -> None:
+    """Show telemetry configuration and status.
+
+    Displays the current telemetry configuration including whether
+    telemetry is enabled, the storage path, and retention settings.
+    """
+    logging.getLogger("infrahub_sdk").setLevel(logging.CRITICAL)
+
+    client = initialize_client()
+
+    url = f"{client.address}/api/telemetry/status"
+    response = await client._get(url=url, timeout=client.default_timeout)
+
+    if response.status_code != 200:
+        console.print(f"[red]Error: {response.text}")
+        raise typer.Exit(1)
+
+    status = response.json()
+
+    table = Table(title="Telemetry Status", show_header=False, box=None)
+    table.add_column(justify="left", style="cyan")
+    table.add_column(justify="right")
+
+    enabled = status.get("enabled", False)
+    table.add_row("Telemetry Enabled", "[green]Yes[/green]" if enabled else "[red]No[/red]")
+    table.add_row("Storage Path", status.get("storage_path", "N/A"))
+    table.add_row("Retention Days", str(status.get("retention_days", "N/A")))
+    table.add_row("Files Count", str(status.get("files_count", 0)))
+
+    if status.get("latest_file"):
+        table.add_row("Latest File", status.get("latest_file", "N/A"))
+
+    if status.get("license"):
+        license_info = status["license"]
+        table.add_row("", "")  # Spacer
+        table.add_row("[bold]License Information[/bold]", "")
+        table.add_row("Customer Name", license_info.get("customer_name", "N/A"))
+        table.add_row("Product Tier", license_info.get("product_tier", "N/A"))
+        table.add_row("License Valid", "[green]Yes[/green]" if license_info.get("valid") else "[red]No[/red]")
+
+    console.print()
+    console.print(table)
+    console.print()

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -227,6 +227,7 @@ class CoreValidator(CoreNode):
 class CoreWebhook(CoreNode):
     name: String
     event_type: Enum
+    active: Boolean
     branch_scope: Dropdown
     node_kind: StringOptional
     description: StringOptional
@@ -499,7 +500,6 @@ class CoreProposedChange(CoreTaskTarget):
     approved_by: RelationshipManager
     rejected_by: RelationshipManager
     reviewers: RelationshipManager
-    created_by: RelatedNode
     comments: RelationshipManager
     threads: RelationshipManager
     validations: RelationshipManager
@@ -784,6 +784,7 @@ class CoreValidatorSync(CoreNodeSync):
 class CoreWebhookSync(CoreNodeSync):
     name: String
     event_type: Enum
+    active: Boolean
     branch_scope: Dropdown
     node_kind: StringOptional
     description: StringOptional
@@ -1056,7 +1057,6 @@ class CoreProposedChangeSync(CoreTaskTargetSync):
     approved_by: RelationshipManagerSync
     rejected_by: RelationshipManagerSync
     reviewers: RelationshipManagerSync
-    created_by: RelatedNodeSync
     comments: RelationshipManagerSync
     threads: RelationshipManagerSync
     validations: RelationshipManagerSync

--- a/tests/unit/ctl/test_telemetry_app.py
+++ b/tests/unit/ctl/test_telemetry_app.py
@@ -1,0 +1,341 @@
+"""Tests for the telemetry CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from infrahub_sdk.ctl.telemetry import (
+    app,
+    generate_export_filename,
+    sanitize_filename,
+)
+
+runner = CliRunner()
+
+pytestmark = pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+
+class TestSanitizeFilename:
+    """Tests for the sanitize_filename helper function."""
+
+    def test_simple_name(self) -> None:
+        assert sanitize_filename("acme") == "acme"
+
+    def test_name_with_spaces(self) -> None:
+        assert sanitize_filename("Acme Corporation") == "acme_corporation"
+
+    def test_name_with_special_chars(self) -> None:
+        assert sanitize_filename("Acme & Co.") == "acme_co"
+
+    def test_name_with_multiple_special_chars(self) -> None:
+        assert sanitize_filename("Acme!@#$%Corp") == "acme_corp"
+
+    def test_name_with_dashes(self) -> None:
+        assert sanitize_filename("acme-corp") == "acme-corp"
+
+    def test_name_with_leading_trailing_special(self) -> None:
+        assert sanitize_filename("__acme__") == "acme"
+
+    def test_name_with_multiple_underscores(self) -> None:
+        assert sanitize_filename("acme   corp") == "acme_corp"
+
+    def test_uppercase_converted_to_lowercase(self) -> None:
+        assert sanitize_filename("ACME") == "acme"
+
+    def test_mixed_case_and_special(self) -> None:
+        assert sanitize_filename("Acme Corp. (US)") == "acme_corp_us"
+
+
+class TestGenerateExportFilename:
+    """Tests for the generate_export_filename helper function."""
+
+    def test_with_customer_name(self) -> None:
+        with patch("infrahub_sdk.ctl.telemetry.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+            result = generate_export_filename("Acme Corp")
+            assert result == Path("acme_corp-telemetry-export-2026-01-15.json")
+
+    def test_without_customer_name(self) -> None:
+        with patch("infrahub_sdk.ctl.telemetry.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+            result = generate_export_filename(None)
+            assert result == Path("telemetry-export-2026-01-15.json")
+
+    def test_with_empty_customer_name(self) -> None:
+        with patch("infrahub_sdk.ctl.telemetry.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+            result = generate_export_filename("")
+            assert result == Path("telemetry-export-2026-01-15.json")
+
+
+class TestTelemetryExportCommand:
+    """Tests for the telemetry export command."""
+
+    def test_export_success(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        export_data = {
+            "license": {
+                "customer_name": "Acme Corp",
+                "product_tier": "medium",
+            },
+            "snapshots": [
+                {"date": "2026-01-01", "data": {}},
+                {"date": "2026-01-02", "data": {}},
+            ],
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/export?all=true",
+            json=export_data,
+        )
+
+        output_file = tmp_path / "export.json"
+        result = runner.invoke(app=app, args=["export", "--all", "--output", str(output_file)])
+
+        assert result.exit_code == 0
+        assert "Export Summary" in result.stdout
+        assert "Acme Corp" in result.stdout
+        assert "medium" in result.stdout
+        assert "2" in result.stdout  # 2 snapshots
+        assert output_file.exists()
+
+        written_data = json.loads(output_file.read_text())
+        assert written_data == export_data
+
+    def test_export_with_date_range(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        export_data = {
+            "license": {"customer_name": "Test Co"},
+            "snapshots": [{"date": "2026-01-15", "data": {}}],
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/export?from_date=2026-01-01&to_date=2026-01-31",
+            json=export_data,
+        )
+
+        output_file = tmp_path / "export.json"
+        result = runner.invoke(
+            app=app,
+            args=["export", "--from", "2026-01-01", "--to", "2026-01-31", "--output", str(output_file)],
+        )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+
+    def test_export_auto_generated_filename(
+        self, httpx_mock: HTTPXMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        export_data = {
+            "license": {"customer_name": "Acme Corp"},
+            "snapshots": [],
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/export?all=true",
+            json=export_data,
+        )
+
+        with patch("infrahub_sdk.ctl.telemetry.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+            result = runner.invoke(app=app, args=["export", "--all"])
+
+        assert result.exit_code == 0
+        expected_file = tmp_path / "acme_corp-telemetry-export-2026-01-15.json"
+        assert expected_file.exists()
+
+    def test_export_error_response(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/export?all=true",
+            status_code=500,
+            text="Internal Server Error",
+        )
+
+        result = runner.invoke(app=app, args=["export", "--all"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.stdout
+
+    def test_export_no_snapshots(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        export_data = {
+            "license": {"customer_name": "Empty Corp", "product_tier": "small"},
+            "snapshots": [],
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/export?all=true",
+            json=export_data,
+        )
+
+        output_file = tmp_path / "export.json"
+        result = runner.invoke(app=app, args=["export", "--all", "--output", str(output_file)])
+
+        assert result.exit_code == 0
+        assert "0" in result.stdout  # 0 snapshots
+
+
+class TestTelemetryListCommand:
+    """Tests for the telemetry list command."""
+
+    def test_list_with_files(self, httpx_mock: HTTPXMock) -> None:
+        list_response = {
+            "files": [
+                {"date": "2026-01-01", "filename": "telemetry-abc-2026-01-01.json", "size": "1.2 KB"},
+                {"date": "2026-01-02", "filename": "telemetry-abc-2026-01-02.json", "size": "1.3 KB"},
+            ]
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/list",
+            json=list_response,
+        )
+
+        result = runner.invoke(app=app, args=["list"])
+
+        assert result.exit_code == 0
+        assert "Local Telemetry Files" in result.stdout
+        assert "2026-01-01" in result.stdout
+        assert "2026-01-02" in result.stdout
+        assert "1.2 KB" in result.stdout
+
+    def test_list_empty(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/list",
+            json={"files": []},
+        )
+
+        result = runner.invoke(app=app, args=["list"])
+
+        assert result.exit_code == 0
+        assert "No telemetry files found" in result.stdout
+
+    def test_list_error_response(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/list",
+            status_code=404,
+            text="Not Found",
+        )
+
+        result = runner.invoke(app=app, args=["list"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.stdout
+
+
+class TestTelemetryStatusCommand:
+    """Tests for the telemetry status command."""
+
+    def test_status_enabled_with_license(self, httpx_mock: HTTPXMock) -> None:
+        status_response = {
+            "enabled": True,
+            "storage_path": "/var/lib/infrahub/telemetry",
+            "retention_days": 90,
+            "files_count": 15,
+            "latest_file": "telemetry-abc-2026-01-15.json",
+            "license": {
+                "customer_name": "Acme Corp",
+                "product_tier": "medium",
+                "valid": True,
+            },
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/status",
+            json=status_response,
+        )
+
+        result = runner.invoke(app=app, args=["status"])
+
+        assert result.exit_code == 0
+        assert "Telemetry Status" in result.stdout
+        assert "Yes" in result.stdout  # enabled
+        assert "/var/lib/infrahub/telemetry" in result.stdout
+        assert "90" in result.stdout
+        assert "15" in result.stdout
+        assert "Acme Corp" in result.stdout
+        assert "medium" in result.stdout
+
+    def test_status_disabled(self, httpx_mock: HTTPXMock) -> None:
+        status_response = {
+            "enabled": False,
+            "storage_path": "/var/lib/infrahub/telemetry",
+            "retention_days": 90,
+            "files_count": 0,
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/status",
+            json=status_response,
+        )
+
+        result = runner.invoke(app=app, args=["status"])
+
+        assert result.exit_code == 0
+        assert "No" in result.stdout  # disabled
+
+    def test_status_without_license(self, httpx_mock: HTTPXMock) -> None:
+        status_response = {
+            "enabled": True,
+            "storage_path": "/var/lib/infrahub/telemetry",
+            "retention_days": 90,
+            "files_count": 5,
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/status",
+            json=status_response,
+        )
+
+        result = runner.invoke(app=app, args=["status"])
+
+        assert result.exit_code == 0
+        assert "License Information" not in result.stdout
+
+    def test_status_with_invalid_license(self, httpx_mock: HTTPXMock) -> None:
+        status_response = {
+            "enabled": True,
+            "storage_path": "/var/lib/infrahub/telemetry",
+            "retention_days": 90,
+            "files_count": 5,
+            "license": {
+                "customer_name": "Expired Corp",
+                "product_tier": "small",
+                "valid": False,
+            },
+        }
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/status",
+            json=status_response,
+        )
+
+        result = runner.invoke(app=app, args=["status"])
+
+        assert result.exit_code == 0
+        assert "Expired Corp" in result.stdout
+
+    def test_status_error_response(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            method="GET",
+            url="http://mock/api/telemetry/status",
+            status_code=500,
+            text="Internal Server Error",
+        )
+
+        result = runner.invoke(app=app, args=["status"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.stdout


### PR DESCRIPTION
## Summary

This PR adds new `infrahubctl telemetry` CLI commands to support telemetry data management in airgapped environments, as part of the Customer Metrics Tracking System PoC.

**Changes:**
- Add `infrahubctl telemetry export` - Export telemetry data from Infrahub for manual transfer to OpsMill
- Add `infrahubctl telemetry list` - List available local telemetry files on the Infrahub instance
- Add `infrahubctl telemetry status` - Show telemetry configuration and status including license information
- Auto-generate descriptive export filenames with customer name and date (e.g., `acme_corp-telemetry-export-2026-01-19.json`)

## Context

This implements Part 6 (SDK Changes) of the [Customer Metrics PoC Plan](https://github.com/opsmill/infrahub/blob/feature/customer-metrics-telemetry/docs/plans/customer-metrics-poc-plan.md), which defines a system for:

1. **License-based telemetry** - Infrahub instances with license files include customer metadata in telemetry
2. **Local storage** - Telemetry is saved locally before streaming, enabling airgapped export
3. **REST API endpoints** - Backend provides `/api/telemetry/export`, `/api/telemetry/list`, `/api/telemetry/status`
4. **CLI commands** - This PR adds the SDK CLI to consume those endpoints

The telemetry export workflow supports both:
- **Connected environments**: Automatic telemetry streaming to OpsMill
- **Airgapped environments**: Manual export via `infrahubctl telemetry export --all` for secure transfer

## Usage Examples

```bash
# Export all available telemetry data
infrahubctl telemetry export --all

# Export specific date range
infrahubctl telemetry export --from 2026-01-01 --to 2026-01-31

# Export to specific file
infrahubctl telemetry export --all --output my-export.json

# List available telemetry files
infrahubctl telemetry list

# Check telemetry status
infrahubctl telemetry status
```

## Dependencies

Requires the Infrahub backend changes from `opsmill/infrahub#feature/customer-metrics-telemetry` which implement:
- License module (`backend/infrahub/license/`)
- Telemetry local storage (`backend/infrahub/telemetry/storage.py`)
- REST API endpoints (`backend/infrahub/api/telemetry.py`)

## Test plan

- [ ] Verify `infrahubctl telemetry --help` shows all subcommands
- [ ] Test `infrahubctl telemetry export` against Infrahub with telemetry REST API
- [ ] Test `infrahubctl telemetry list` returns available files
- [ ] Test `infrahubctl telemetry status` shows configuration
- [ ] Verify auto-generated filenames include customer name and date
- [ ] Test date range filtering with `--from` and `--to` options