### PR TITLE
IHS-183: Fix typing errors for protocols

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.9
+    rev: v0.14.10
     hooks:
       # Run the linter.
       - id: ruff

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -293,7 +293,7 @@ async def report(
     git_files_changed = await check_git_files_changed(client, branch=branch_name)
 
     proposed_changes = await client.filters(
-        kind=CoreProposedChange,  # type: ignore[type-abstract]
+        kind=CoreProposedChange,
         source_branch__value=branch_name,
         include=["created_by"],
         prefetch_relationships=True,

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ..exceptions import Error
 from ..protocols_base import CoreNodeBase
@@ -11,7 +11,7 @@ from .metadata import NodeMetadata, RelationshipMetadata
 if TYPE_CHECKING:
     from ..client import InfrahubClient, InfrahubClientSync
     from ..schema import RelationshipSchemaAPI
-    from .node import InfrahubNode, InfrahubNodeSync
+    from .node import InfrahubNode, InfrahubNodeBase, InfrahubNodeSync
 
 
 class RelatedNodeBase:
@@ -34,7 +34,7 @@ class RelatedNodeBase:
         self._properties_object = PROPERTIES_OBJECT
         self._properties = self._properties_flag + self._properties_object
 
-        self._peer: InfrahubNode | InfrahubNodeSync | CoreNodeBase | None = None
+        self._peer: InfrahubNode | InfrahubNodeSync | InfrahubNodeBase | CoreNodeBase | None = None
         self._id: str | None = None
         self._hfid: list[str] | None = None
         self._display_label: str | None = None
@@ -43,8 +43,10 @@ class RelatedNodeBase:
         self._source_typename: str | None = None
         self._relationship_metadata: RelationshipMetadata | None = None
 
-        if isinstance(data, (CoreNodeBase)):
-            self._peer = data
+        # Check for InfrahubNodeBase instances using duck-typing (_schema attribute)
+        # to avoid circular imports, or CoreNodeBase instances
+        if isinstance(data, CoreNodeBase) or hasattr(data, "_schema"):
+            self._peer = cast("InfrahubNodeBase | CoreNodeBase", data)
             for prop in self._properties:
                 setattr(self, prop, None)
             self._relationship_metadata = None

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -34,7 +34,7 @@ class RelatedNodeBase:
         self._properties_object = PROPERTIES_OBJECT
         self._properties = self._properties_flag + self._properties_object
 
-        self._peer: InfrahubNode | InfrahubNodeSync | InfrahubNodeBase | CoreNodeBase | None = None
+        self._peer: InfrahubNodeBase | CoreNodeBase | None = None
         self._id: str | None = None
         self._hfid: list[str] | None = None
         self._display_label: str | None = None

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -34,7 +34,7 @@ class RelatedNodeBase:
         self._properties_object = PROPERTIES_OBJECT
         self._properties = self._properties_flag + self._properties_object
 
-        self._peer = None
+        self._peer: InfrahubNode | InfrahubNodeSync | CoreNodeBase | None = None
         self._id: str | None = None
         self._hfid: list[str] | None = None
         self._display_label: str | None = None

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -189,22 +189,22 @@ class CoreNodeBase:
     def get_human_friendly_id_as_string(self, include_kind: bool = False) -> str | None: ...
 
     def get_kind(self) -> str:
-        return ""
+        raise NotImplementedError()
 
     def get_all_kinds(self) -> list[str]:
-        return []
+        raise NotImplementedError()
 
     def get_branch(self) -> str:
-        return ""
+        raise NotImplementedError()
 
     def is_ip_prefix(self) -> bool:
-        return False
+        raise NotImplementedError()
 
     def is_ip_address(self) -> bool:
-        return False
+        raise NotImplementedError()
 
     def is_resource_pool(self) -> bool:
-        return False
+        raise NotImplementedError()
 
     def get_raw_graphql_data(self) -> dict | None: ...
 

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -171,8 +171,7 @@ class AnyAttributeOptional(Attribute):
     value: float | None
 
 
-@runtime_checkable
-class CoreNodeBase(Protocol):
+class CoreNodeBase:
     _schema: MainSchemaTypes
     _internal_id: str
     id: str  # NOTE this is incorrect, should be str | None
@@ -204,8 +203,7 @@ class CoreNodeBase(Protocol):
     def get_raw_graphql_data(self) -> dict | None: ...
 
 
-@runtime_checkable
-class CoreNode(CoreNodeBase, Protocol):
+class CoreNode(CoreNodeBase):
     async def save(
         self,
         allow_upsert: bool = False,
@@ -229,8 +227,7 @@ class CoreNode(CoreNodeBase, Protocol):
     async def remove_relationships(self, relation_to_update: str, related_nodes: list[str]) -> None: ...
 
 
-@runtime_checkable
-class CoreNodeSync(CoreNodeBase, Protocol):
+class CoreNodeSync(CoreNodeBase):
     def save(
         self,
         allow_upsert: bool = False,

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -188,17 +188,23 @@ class CoreNodeBase:
 
     def get_human_friendly_id_as_string(self, include_kind: bool = False) -> str | None: ...
 
-    def get_kind(self) -> str: ...
+    def get_kind(self) -> str:
+        return ""
 
-    def get_all_kinds(self) -> list[str]: ...
+    def get_all_kinds(self) -> list[str]:
+        return []
 
-    def get_branch(self) -> str: ...
+    def get_branch(self) -> str:
+        return ""
 
-    def is_ip_prefix(self) -> bool: ...
+    def is_ip_prefix(self) -> bool:
+        return False
 
-    def is_ip_address(self) -> bool: ...
+    def is_ip_address(self) -> bool:
+        return False
 
-    def is_resource_pool(self) -> bool: ...
+    def is_resource_pool(self) -> bool:
+        return False
 
     def get_raw_graphql_data(self) -> dict | None: ...
 

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -21,7 +21,7 @@ from ..exceptions import (
     ValidationError,
 )
 from ..graphql import Mutation
-from ..protocols_base import CoreNode, CoreNodeSync
+from ..protocols_base import CoreNodeBase
 from ..queries import SCHEMA_HASH_SYNC_STATUS
 from .main import (
     AttributeSchema,
@@ -208,7 +208,7 @@ class InfrahubSchemaBase:
         if isinstance(schema, str):
             return schema
 
-        if isinstance(schema, type) and issubclass(schema, (CoreNode, CoreNodeSync)):
+        if issubclass(schema, CoreNodeBase):
             if inspect.iscoroutinefunction(schema.save):
                 return schema.__name__
             if schema.__name__[-4:] == "Sync":

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -21,6 +21,7 @@ from ..exceptions import (
     ValidationError,
 )
 from ..graphql import Mutation
+from ..protocols_base import CoreNode, CoreNodeSync
 from ..queries import SCHEMA_HASH_SYNC_STATUS
 from .main import (
     AttributeSchema,
@@ -207,14 +208,14 @@ class InfrahubSchemaBase:
         if isinstance(schema, str):
             return schema
 
-        if hasattr(schema, "_is_runtime_protocol") and getattr(schema, "_is_runtime_protocol", None):
+        if isinstance(schema, type) and issubclass(schema, (CoreNode, CoreNodeSync)):
             if inspect.iscoroutinefunction(schema.save):
                 return schema.__name__
             if schema.__name__[-4:] == "Sync":
                 return schema.__name__[:-4]
             return schema.__name__
 
-        raise ValueError("schema must be a protocol or a string")
+        raise ValueError("schema must be a CoreNode subclass or a string")
 
     @staticmethod
     def _parse_schema_response(response: httpx.Response, branch: str) -> MutableMapping[str, Any]:

--- a/infrahub_sdk/testing/repository.py
+++ b/infrahub_sdk/testing/repository.py
@@ -98,7 +98,7 @@ class GitRepo:
     ) -> bool:
         for _ in range(retries):
             repo = await client.get(
-                kind=CoreGenericRepository,  # type: ignore[type-abstract]
+                kind=CoreGenericRepository,
                 name__value=self.name,
                 branch=branch or self.initial_branch,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ invalid-assignment = "ignore"
 pretty = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
-disable_error_code = ["empty-body"]
 
 [[tool.mypy.overrides]]
 module = "infrahub_sdk.ctl.check"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ invalid-assignment = "ignore"
 pretty = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
+disable_error_code = ["empty-body"]
 
 [[tool.mypy.overrides]]
 module = "infrahub_sdk.ctl.check"


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub-sdk-python/issues/697

Replace protocols with concrete classes to address `type-abstract` mypy errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Ruff linting tool from v0.11.9 to v0.14.10

* **Refactor**
  * Strengthened and expanded type annotations across the SDK for clearer type checking and IDE support
  * Removed type-suppression directives to surface compile-time type issues
  * Converted several protocol-like bases to concrete bases with default behaviors and adjusted schema validation messaging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->