### PR TITLE
use CoreNodeBase in get_schema_name

### DIFF
--- a/infrahub_sdk/store.py
+++ b/infrahub_sdk/store.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import inspect
 import warnings
 from typing import TYPE_CHECKING, Literal, overload
+
+from infrahub_sdk.protocols_base import CoreNodeBase
 
 from .exceptions import NodeInvalidError, NodeNotFoundError
 from .node.parsers import parse_human_friendly_id
@@ -16,8 +19,15 @@ def get_schema_name(schema: type[SchemaType | SchemaTypeSync] | str | None = Non
     if isinstance(schema, str):
         return schema
 
-    if hasattr(schema, "_is_runtime_protocol") and schema._is_runtime_protocol:  # type: ignore[union-attr]
-        return schema.__name__  # type: ignore[union-attr]
+    if schema is None:
+        return None
+
+    if issubclass(schema, CoreNodeBase):
+        if inspect.iscoroutinefunction(schema.save):
+            return schema.__name__
+        if schema.__name__[-4:] == "Sync":
+            return schema.__name__[:-4]
+        return schema.__name__
 
     return None
 
@@ -100,6 +110,8 @@ class NodeStoreBranch:
                 identifier={"key": [key] if isinstance(key, str) else key},
                 message=f"Found a node of a different kind instead of {kind} for key {key!r} in the store ({self.branch_name})",
             )
+
+        breakpoint()
 
         raise NodeNotFoundError(
             identifier={"key": [key] if isinstance(key, str) else key},

--- a/infrahub_sdk/store.py
+++ b/infrahub_sdk/store.py
@@ -111,8 +111,6 @@ class NodeStoreBranch:
                 message=f"Found a node of a different kind instead of {kind} for key {key!r} in the store ({self.branch_name})",
             )
 
-        breakpoint()
-
         raise NodeNotFoundError(
             identifier={"key": [key] if isinstance(key, str) else key},
             message=f"Unable to find the node {key!r} in the store ({self.branch_name})",

--- a/tests/unit/sdk/test_store.py
+++ b/tests/unit/sdk/test_store.py
@@ -6,7 +6,7 @@ import pytest
 
 from infrahub_sdk.exceptions import NodeInvalidError, NodeNotFoundError
 from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
-from infrahub_sdk.protocols import BuiltinIPPrefix
+from infrahub_sdk.protocols import BuiltinIPAddressSync, BuiltinIPPrefix
 from infrahub_sdk.store import NodeStore, NodeStoreSync, get_schema_name
 
 if TYPE_CHECKING:
@@ -162,3 +162,4 @@ def test_node_store_get_with_hfid(
 
 def test_store_get_schema_name() -> None:
     assert get_schema_name(schema=BuiltinIPPrefix) == BuiltinIPPrefix.__name__
+    assert get_schema_name(schema=BuiltinIPAddressSync) == BuiltinIPAddressSync.__name__[:-4]

--- a/tests/unit/sdk/test_store.py
+++ b/tests/unit/sdk/test_store.py
@@ -6,7 +6,8 @@ import pytest
 
 from infrahub_sdk.exceptions import NodeInvalidError, NodeNotFoundError
 from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
-from infrahub_sdk.store import NodeStore, NodeStoreSync
+from infrahub_sdk.protocols import BuiltinIPPrefix
+from infrahub_sdk.store import NodeStore, NodeStoreSync, get_schema_name
 
 if TYPE_CHECKING:
     from infrahub_sdk.schema import NodeSchemaAPI
@@ -157,3 +158,7 @@ def test_node_store_get_with_hfid(
         store.get(kind="BuiltinLocation", key="anotherkey")
     with pytest.raises(NodeNotFoundError):
         store.get(key="anotherkey")
+
+
+def test_store_get_schema_name() -> None:
+    assert get_schema_name(schema=BuiltinIPPrefix) == BuiltinIPPrefix.__name__


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema name handling: returns None for absent inputs, normalizes names for specialized node types, and trims trailing "Sync" suffix where applicable.

* **Tests**
  * Added unit tests covering the updated schema name resolution behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->