### PR TITLE
Prevent cascade delete from causing SDK tracking delete to fail

### DIFF
--- a/changelog/265.fixed.md
+++ b/changelog/265.fixed.md
@@ -1,0 +1,1 @@
+Allow SDK tracking feature to continue after encountering delete errors due to impacted nodes having already been deleted by cascade delete.

--- a/infrahub_sdk/query_groups.py
+++ b/infrahub_sdk/query_groups.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from .constants import InfrahubClientMode
-from .exceptions import NodeNotFoundError
+from .exceptions import GraphQLError, NodeNotFoundError
 from .utils import dict_hash
 
 if TYPE_CHECKING:
@@ -109,7 +109,13 @@ class InfrahubGroupContext(InfrahubGroupContextBase):
         if self.previous_members and self.unused_member_ids:
             for member in self.previous_members:
                 if member.id in self.unused_member_ids and member.typename:
-                    await self.client.delete(kind=member.typename, id=member.id)
+                    try:
+                        await self.client.delete(kind=member.typename, id=member.id)
+                    except GraphQLError as exc:
+                        if not exc.message or "Unable to find the node" not in exc.message:
+                            # If the node already has been deleted, skip the error as it would have been deleted
+                            # by the cascade delete of another node
+                            raise
 
     async def add_related_nodes(self, ids: list[str], update_group_context: bool | None = None) -> None:
         """


### PR DESCRIPTION
Currently there's an issue with deleting nodes using a generator and the SDK tracking feature if the impacted nodes have a schema that also uses the cascade delete feature.

For example if we have a number of devices and interfaces that should be deleted and we happen to delete one of the devices first we'd cause the backend cascade delete feature to remove all of the interfaces attached to that device. When the SDK then tries to remove such an interface we previously raised an error. The change here is that we instead catch those errors and ignore GraphQL errors if they are raised because a node was not found.

A larger refactoring could be warranted here. Both in terms of error management and enrichment from the backend but also the ability to send in a list of all of the nodes we want to delete in one transaction to the backend instead of calling a delete mutation for each entry.

Fixes #265 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SDK tracking no longer stops when cascade-deleted nodes trigger delete errors; cleanup now continues safely when affected nodes were already removed.

* **Chores**
  * Added a changelog entry documenting the cascade-delete handling fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->