### PR TITLE
Add __hash__ method to object that already has __eq__

### DIFF
--- a/infrahub_sdk/recorder.py
+++ b/infrahub_sdk/recorder.py
@@ -34,6 +34,9 @@ class NoRecorder:
     def __eq__(self, other: object) -> bool:
         return isinstance(other, NoRecorder)
 
+    def __hash__(self) -> int:
+        return hash(self.__class__)
+
 
 class JSONRecorder(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_JSON_RECORDER_")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,6 @@ ignore = [
     "PLR2004", # Magic value used in comparison
     "PLR6301", # Method could be a function, class method, or static method
     "PLW0603", # Using the global statement to update `SETTINGS` is discouraged
-    "PLW1641", # Object does not implement `__hash__` method
     "RUF005",  # Consider `[*path, str(key)]` instead of concatenation
     "RUF029",  # Function is declared `async`, but doesn't `await` or use `async` features.
     "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The NoRecorder class now properly implements hash support, making instances hashable and compatible with sets and dictionaries for more flexible usage patterns.

* **Code Quality**
  * Strengthened linting rules to enforce proper implementation of hashing methods, improving code consistency and preventing related issues across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->