### PR TITLE
Add task to generate JSON schema for .infrahub.yml files

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 from pathlib import Path
 from shutil import which
@@ -266,3 +267,17 @@ def generate_python_sdk(context: Context) -> None:  # noqa: ARG001
     """Generate documentation for the Python SDK."""
     _generate_infrahub_sdk_configuration_documentation()
     _generate_infrahub_sdk_template_documentation()
+
+
+@task
+def generate_repository_jsonschema(context: Context) -> None:
+    """Generate JSON schema file for repository configuration. https://github.com/opsmill/infrahub-jsonschema"""
+    from infrahub_sdk.schema.repository import InfrahubRepositoryConfig
+
+    repository_jsonschema = MAIN_DIRECTORY_PATH / "generated" / "repository-config" / "develop.json"
+
+    with context.cd(MAIN_DIRECTORY_PATH):
+        schema = json.dumps(InfrahubRepositoryConfig.model_json_schema(), indent=4)
+        repository_jsonschema.parent.mkdir(parents=True, exist_ok=True)
+        repository_jsonschema.write_text(schema)
+        print(f"Wrote to {repository_jsonschema}")


### PR DESCRIPTION
Adds an invoke task to generate the JSON schema file for `.infrahub.yml` files, these are the schema files that then gets added to the https://github.com/opsmill/infrahub-jsonschema repo for inclusion in the language server for Yaml.

Currently this task already exists within Infrahub. However that is just something that's remained since before the SDK moved to a git submodule. Creating this command here instead so it's easier to generate the file within its own context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development utility for generating repository configuration schema documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->