### PR TITLE
add libstdc++ to flake.nix to support Python dependencies that depend on compiled libraries

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,11 @@
       in
       {
         devShells.default = pkgs.mkShell {
-          buildInputs = [
-            pkgs.git
-            pkgs.gh
-            pkgs.vale
+          buildInputs = with pkgs; [
+            git
+            gh
+            vale
+            stdenv.cc.cc.lib
           ];
 
           shellHook = ''
@@ -26,6 +27,9 @@
             echo "  - gh (GitHub CLI): $(gh --version | head -n1)"
             echo "  - vale (prose linter): $(vale --version)"
           '';
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.stdenv.cc.cc.lib
+          ];
         };
       }
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to streamline package management and improve library path handling for the build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->