### PR TITLE
IHS-193 Add support for file upload/download for `CoreFileObject`

### DIFF
--- a/changelog/ihs193.added.md
+++ b/changelog/ihs193.added.md
@@ -1,0 +1,1 @@
+Added support for FileObject nodes with file upload and download capabilities. New methods `upload_from_path(path)` and `upload_from_bytes(content, name)` allow setting file content before saving, while `download_file(dest)` enables downloading files to memory or streaming to disk for large files.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1057,6 +1057,45 @@ class InfrahubClient(BaseClient):
             timeout=timeout or self.default_timeout,
         )
 
+    @asynccontextmanager
+    async def _get_streaming(
+        self, url: str, headers: dict | None = None, timeout: int | None = None
+    ) -> AsyncIterator[httpx.Response]:
+        """Execute a streaming HTTP GET with HTTPX.
+
+        Returns an async context manager that yields the streaming response.
+        Use this for downloading large files without loading into memory.
+
+        Raises:
+            ServerNotReachableError if we are not able to connect to the server
+            ServerNotResponsiveError if the server didn't respond before the timeout expired
+        """
+        await self.login()
+
+        headers = headers or {}
+        base_headers = copy.copy(self.headers or {})
+        headers.update(base_headers)
+
+        proxy_config: ProxyConfig = {"proxy": None, "mounts": None}
+        if self.config.proxy:
+            proxy_config["proxy"] = self.config.proxy
+        elif self.config.proxy_mounts.is_set:
+            proxy_config["mounts"] = {
+                key: httpx.AsyncHTTPTransport(proxy=value)
+                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
+            }
+
+        async with httpx.AsyncClient(**proxy_config, verify=self.config.tls_context) as client:
+            try:
+                async with client.stream(
+                    method="GET", url=url, headers=headers, timeout=timeout or self.default_timeout
+                ) as response:
+                    yield response
+            except httpx.NetworkError as exc:
+                raise ServerNotReachableError(address=self.address) from exc
+            except httpx.ReadTimeout as exc:
+                raise ServerNotResponsiveError(url=url, timeout=timeout or self.default_timeout) from exc
+
     async def _request(
         self,
         url: str,
@@ -2994,6 +3033,45 @@ class InfrahubClientSync(BaseClient):
             headers=headers,
             timeout=timeout or self.default_timeout,
         )
+
+    @contextmanager
+    def _get_streaming(
+        self, url: str, headers: dict | None = None, timeout: int | None = None
+    ) -> Iterator[httpx.Response]:
+        """Execute a streaming HTTP GET with HTTPX.
+
+        Returns a context manager that yields the streaming response.
+        Use this for downloading large files without loading into memory.
+
+        Raises:
+            ServerNotReachableError if we are not able to connect to the server
+            ServerNotResponsiveError if the server didn't respond before the timeout expired
+        """
+        self.login()
+
+        headers = headers or {}
+        base_headers = copy.copy(self.headers or {})
+        headers.update(base_headers)
+
+        proxy_config: ProxyConfigSync = {"proxy": None, "mounts": None}
+        if self.config.proxy:
+            proxy_config["proxy"] = self.config.proxy
+        elif self.config.proxy_mounts.is_set:
+            proxy_config["mounts"] = {
+                key: httpx.HTTPTransport(proxy=value)
+                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
+            }
+
+        with httpx.Client(**proxy_config, verify=self.config.tls_context) as client:
+            try:
+                with client.stream(
+                    method="GET", url=url, headers=headers, timeout=timeout or self.default_timeout
+                ) as response:
+                    yield response
+            except httpx.NetworkError as exc:
+                raise ServerNotReachableError(address=self.address) from exc
+            except httpx.ReadTimeout as exc:
+                raise ServerNotResponsiveError(url=url, timeout=timeout or self.default_timeout) from exc
 
     @handle_relogin_sync
     def _post(

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1009,6 +1009,18 @@ class InfrahubClient(BaseClient):
 
         # TODO add a special method to execute mutation that will check if the method returned OK
 
+    def _build_proxy_config(self) -> ProxyConfig:
+        """Build proxy configuration for httpx AsyncClient."""
+        proxy_config: ProxyConfig = {"proxy": None, "mounts": None}
+        if self.config.proxy:
+            proxy_config["proxy"] = self.config.proxy
+        elif self.config.proxy_mounts.is_set:
+            proxy_config["mounts"] = {
+                key: httpx.AsyncHTTPTransport(proxy=value)
+                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
+            }
+        return proxy_config
+
     @handle_relogin
     async def _post(
         self,
@@ -1077,16 +1089,7 @@ class InfrahubClient(BaseClient):
         base_headers = copy.copy(self.headers or {})
         headers.update(base_headers)
 
-        proxy_config: ProxyConfig = {"proxy": None, "mounts": None}
-        if self.config.proxy:
-            proxy_config["proxy"] = self.config.proxy
-        elif self.config.proxy_mounts.is_set:
-            proxy_config["mounts"] = {
-                key: httpx.AsyncHTTPTransport(proxy=value)
-                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
-            }
-
-        async with httpx.AsyncClient(**proxy_config, verify=self.config.tls_context) as client:
+        async with httpx.AsyncClient(**self._build_proxy_config(), verify=self.config.tls_context) as client:
             try:
                 async with client.stream(
                     method="GET", url=url, headers=headers, timeout=timeout or self.default_timeout
@@ -1121,19 +1124,7 @@ class InfrahubClient(BaseClient):
         if payload:
             params["json"] = payload
 
-        proxy_config: ProxyConfig = {"proxy": None, "mounts": None}
-        if self.config.proxy:
-            proxy_config["proxy"] = self.config.proxy
-        elif self.config.proxy_mounts.is_set:
-            proxy_config["mounts"] = {
-                key: httpx.AsyncHTTPTransport(proxy=value)
-                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
-            }
-
-        async with httpx.AsyncClient(
-            **proxy_config,
-            verify=self.config.tls_context,
-        ) as client:
+        async with httpx.AsyncClient(**self._build_proxy_config(), verify=self.config.tls_context) as client:
             try:
                 response = await client.request(
                     method=method.value,
@@ -1963,6 +1954,18 @@ class InfrahubClientSync(BaseClient):
         return response["data"]
 
         # TODO add a special method to execute mutation that will check if the method returned OK
+
+    def _build_proxy_config(self) -> ProxyConfigSync:
+        """Build proxy configuration for httpx Client."""
+        proxy_config: ProxyConfigSync = {"proxy": None, "mounts": None}
+        if self.config.proxy:
+            proxy_config["proxy"] = self.config.proxy
+        elif self.config.proxy_mounts.is_set:
+            proxy_config["mounts"] = {
+                key: httpx.HTTPTransport(proxy=value)
+                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
+            }
+        return proxy_config
 
     def count(
         self,
@@ -3054,16 +3057,7 @@ class InfrahubClientSync(BaseClient):
         base_headers = copy.copy(self.headers or {})
         headers.update(base_headers)
 
-        proxy_config: ProxyConfigSync = {"proxy": None, "mounts": None}
-        if self.config.proxy:
-            proxy_config["proxy"] = self.config.proxy
-        elif self.config.proxy_mounts.is_set:
-            proxy_config["mounts"] = {
-                key: httpx.HTTPTransport(proxy=value)
-                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
-            }
-
-        with httpx.Client(**proxy_config, verify=self.config.tls_context) as client:
+        with httpx.Client(**self._build_proxy_config(), verify=self.config.tls_context) as client:
             try:
                 with client.stream(
                     method="GET", url=url, headers=headers, timeout=timeout or self.default_timeout
@@ -3126,20 +3120,7 @@ class InfrahubClientSync(BaseClient):
         if payload:
             params["json"] = payload
 
-        proxy_config: ProxyConfigSync = {"proxy": None, "mounts": None}
-
-        if self.config.proxy:
-            proxy_config["proxy"] = self.config.proxy
-        elif self.config.proxy_mounts.is_set:
-            proxy_config["mounts"] = {
-                key: httpx.HTTPTransport(proxy=value)
-                for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
-            }
-
-        with httpx.Client(
-            **proxy_config,
-            verify=self.config.tls_context,
-        ) as client:
+        with httpx.Client(**self._build_proxy_config(), verify=self.config.tls_context) as client:
             try:
                 response = client.request(
                     method=method.value,

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -5,7 +5,8 @@ import copy
 import logging
 import time
 import warnings
-from collections.abc import Callable, Coroutine, Mapping, MutableMapping
+from collections.abc import AsyncIterator, Callable, Coroutine, Iterator, Mapping, MutableMapping
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from functools import wraps
 from time import sleep

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -994,14 +994,13 @@ class InfrahubClient(BaseClient):
 
         # TODO add a special method to execute mutation that will check if the method returned OK
 
-    async def execute_graphql_with_file(
+    async def _execute_graphql_with_file(
         self,
         query: str,
         variables: dict | None = None,
         file_content: BinaryIO | None = None,
         file_name: str | None = None,
         branch_name: str | None = None,
-        at: str | Timestamp | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
     ) -> dict:
@@ -1016,7 +1015,6 @@ class InfrahubClient(BaseClient):
             file_content: The file content as a file-like object (BinaryIO).
             file_name: The name of the file being uploaded.
             branch_name: Name of the branch on which the mutation will be executed.
-            at: Time when the query should be executed.
             timeout: Timeout in seconds for the query.
             tracker: Optional tracker for request tracing.
 
@@ -1027,7 +1025,7 @@ class InfrahubClient(BaseClient):
             dict: The GraphQL data payload (response["data"]).
         """
         branch_name = branch_name or self.default_branch
-        url = self._graphql_url(branch_name=branch_name, at=at)
+        url = self._graphql_url(branch_name=branch_name)
 
         # Prepare variables with file placeholder
         variables = variables or {}
@@ -2052,14 +2050,13 @@ class InfrahubClientSync(BaseClient):
 
         # TODO add a special method to execute mutation that will check if the method returned OK
 
-    def execute_graphql_with_file(
+    def _execute_graphql_with_file(
         self,
         query: str,
         variables: dict | None = None,
         file_content: BinaryIO | None = None,
         file_name: str | None = None,
         branch_name: str | None = None,
-        at: str | Timestamp | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
     ) -> dict:
@@ -2074,7 +2071,6 @@ class InfrahubClientSync(BaseClient):
             file_content: The file content as a file-like object (BinaryIO).
             file_name: The name of the file being uploaded.
             branch_name: Name of the branch on which the mutation will be executed.
-            at: Time when the query should be executed.
             timeout: Timeout in seconds for the query.
             tracker: Optional tracker for request tracing.
 
@@ -2085,7 +2081,7 @@ class InfrahubClientSync(BaseClient):
             dict: The GraphQL data payload (response["data"]).
         """
         branch_name = branch_name or self.default_branch
-        url = self._graphql_url(branch_name=branch_name, at=at)
+        url = self._graphql_url(branch_name=branch_name)
 
         # Prepare variables with file placeholder
         variables = variables or {}

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -10,14 +10,7 @@ from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from functools import wraps
 from time import sleep
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    TypedDict,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TypedDict, TypeVar, overload
 from urllib.parse import urlencode
 
 import httpx
@@ -25,12 +18,7 @@ import ujson
 from typing_extensions import Self
 
 from .batch import InfrahubBatch, InfrahubBatchSync
-from .branch import (
-    MUTATION_QUERY_TASK,
-    BranchData,
-    InfrahubBranchManager,
-    InfrahubBranchManagerSync,
-)
+from .branch import MUTATION_QUERY_TASK, BranchData, InfrahubBranchManager, InfrahubBranchManagerSync
 from .config import Config
 from .constants import InfrahubClientMode
 from .convert_object_type import CONVERT_OBJECT_MUTATION, ConversionFieldInput
@@ -45,11 +33,8 @@ from .exceptions import (
     ServerNotResponsiveError,
     URLNotFoundError,
 )
-from .graphql import Mutation, Query
-from .node import (
-    InfrahubNode,
-    InfrahubNodeSync,
-)
+from .graphql import MultipartBuilder, Mutation, Query
+from .node import InfrahubNode, InfrahubNodeSync
 from .object_store import ObjectStore, ObjectStoreSync
 from .protocols_base import CoreNode, CoreNodeSync
 from .queries import QUERY_USER, get_commit_update_mutation
@@ -1009,6 +994,103 @@ class InfrahubClient(BaseClient):
 
         # TODO add a special method to execute mutation that will check if the method returned OK
 
+    async def execute_graphql_with_file(
+        self,
+        query: str,
+        variables: dict | None = None,
+        file_content: BinaryIO | None = None,
+        file_name: str | None = None,
+        branch_name: str | None = None,
+        at: str | Timestamp | None = None,
+        timeout: int | None = None,
+        tracker: str | None = None,
+    ) -> dict:
+        """Execute a GraphQL mutation with a file upload using multipart/form-data.
+
+        This method follows the GraphQL Multipart Request Spec for file uploads.
+        The file is attached to the 'file' variable in the mutation.
+
+        Args:
+            query: GraphQL mutation query that includes a $file variable of type Upload!
+            variables: Variables to pass along with the GraphQL query.
+            file_content: The file content as a file-like object (BinaryIO).
+            file_name: The name of the file being uploaded.
+            branch_name: Name of the branch on which the mutation will be executed.
+            at: Time when the query should be executed.
+            timeout: Timeout in seconds for the query.
+            tracker: Optional tracker for request tracing.
+
+        Raises:
+            GraphQLError: When the GraphQL response contains errors.
+
+        Returns:
+            dict: The GraphQL data payload (response["data"]).
+        """
+        branch_name = branch_name or self.default_branch
+        url = self._graphql_url(branch_name=branch_name, at=at)
+
+        # Prepare variables with file placeholder
+        variables = variables or {}
+        variables["file"] = None
+
+        headers = copy.copy(self.headers or {})
+        # Remove content-type header - httpx will set it for multipart
+        headers.pop("content-type", None)
+        if self.insert_tracker and tracker:
+            headers["X-Infrahub-Tracker"] = tracker
+
+        self._echo(url=url, query=query, variables=variables)
+
+        resp = await self._post_multipart(
+            url=url,
+            query=query,
+            variables=variables,
+            file_content=file_content,
+            file_name=file_name or "upload",
+            headers=headers,
+            timeout=timeout,
+        )
+
+        resp.raise_for_status()
+        response = decode_json(response=resp)
+
+        if "errors" in response:
+            raise GraphQLError(errors=response["errors"], query=query, variables=variables)
+
+        return response["data"]
+
+    @handle_relogin
+    async def _post_multipart(
+        self,
+        url: str,
+        query: str,
+        variables: dict,
+        file_content: BinaryIO | None,
+        file_name: str,
+        headers: dict | None = None,
+        timeout: int | None = None,
+    ) -> httpx.Response:
+        """Execute a HTTP POST with multipart/form-data for GraphQL file uploads.
+
+        The file_content is streamed directly from the file-like object, avoiding loading the entire file into memory for large files.
+        """
+        await self.login()
+
+        headers = headers or {}
+        base_headers = copy.copy(self.headers or {})
+        # Remove content-type from base headers - httpx will set it for multipart
+        base_headers.pop("content-type", None)
+        headers.update(base_headers)
+
+        # Build the multipart form data according to GraphQL Multipart Request Spec
+        files = MultipartBuilder.build_payload(
+            query=query, variables=variables, file_content=file_content, file_name=file_name
+        )
+
+        return await self._request_multipart(
+            url=url, headers=headers, timeout=timeout or self.default_timeout, files=files
+        )
+
     def _build_proxy_config(self) -> ProxyConfig:
         """Build proxy configuration for httpx AsyncClient."""
         proxy_config: ProxyConfig = {"proxy": None, "mounts": None}
@@ -1020,6 +1102,21 @@ class InfrahubClient(BaseClient):
                 for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
             }
         return proxy_config
+
+    async def _request_multipart(
+        self, url: str, headers: dict[str, Any], timeout: int, files: dict[str, Any]
+    ) -> httpx.Response:
+        """Execute a multipart HTTP POST request."""
+        async with httpx.AsyncClient(**self._build_proxy_config(), verify=self.config.tls_context) as client:
+            try:
+                response = await client.post(url=url, headers=headers, timeout=timeout, files=files)
+            except httpx.NetworkError as exc:
+                raise ServerNotReachableError(address=self.address) from exc
+            except httpx.ReadTimeout as exc:
+                raise ServerNotResponsiveError(url=url, timeout=timeout) from exc
+
+        self._record(response)
+        return response
 
     @handle_relogin
     async def _post(
@@ -1955,6 +2052,101 @@ class InfrahubClientSync(BaseClient):
 
         # TODO add a special method to execute mutation that will check if the method returned OK
 
+    def execute_graphql_with_file(
+        self,
+        query: str,
+        variables: dict | None = None,
+        file_content: BinaryIO | None = None,
+        file_name: str | None = None,
+        branch_name: str | None = None,
+        at: str | Timestamp | None = None,
+        timeout: int | None = None,
+        tracker: str | None = None,
+    ) -> dict:
+        """Execute a GraphQL mutation with a file upload using multipart/form-data.
+
+        This method follows the GraphQL Multipart Request Spec for file uploads.
+        The file is attached to the 'file' variable in the mutation.
+
+        Args:
+            query: GraphQL mutation query that includes a $file variable of type Upload!
+            variables: Variables to pass along with the GraphQL query.
+            file_content: The file content as a file-like object (BinaryIO).
+            file_name: The name of the file being uploaded.
+            branch_name: Name of the branch on which the mutation will be executed.
+            at: Time when the query should be executed.
+            timeout: Timeout in seconds for the query.
+            tracker: Optional tracker for request tracing.
+
+        Raises:
+            GraphQLError: When the GraphQL response contains errors.
+
+        Returns:
+            dict: The GraphQL data payload (response["data"]).
+        """
+        branch_name = branch_name or self.default_branch
+        url = self._graphql_url(branch_name=branch_name, at=at)
+
+        # Prepare variables with file placeholder
+        variables = variables or {}
+        variables["file"] = None
+
+        headers = copy.copy(self.headers or {})
+        # Remove content-type header - httpx will set it for multipart
+        headers.pop("content-type", None)
+        if self.insert_tracker and tracker:
+            headers["X-Infrahub-Tracker"] = tracker
+
+        self._echo(url=url, query=query, variables=variables)
+
+        resp = self._post_multipart(
+            url=url,
+            query=query,
+            variables=variables,
+            file_content=file_content,
+            file_name=file_name or "upload",
+            headers=headers,
+            timeout=timeout,
+        )
+
+        resp.raise_for_status()
+        response = decode_json(response=resp)
+
+        if "errors" in response:
+            raise GraphQLError(errors=response["errors"], query=query, variables=variables)
+
+        return response["data"]
+
+    @handle_relogin_sync
+    def _post_multipart(
+        self,
+        url: str,
+        query: str,
+        variables: dict,
+        file_content: BinaryIO | None,
+        file_name: str,
+        headers: dict | None = None,
+        timeout: int | None = None,
+    ) -> httpx.Response:
+        """Execute a HTTP POST with multipart/form-data for GraphQL file uploads.
+
+        The file_content is streamed directly from the file-like object, avoiding loading the entire file into memory for large files.
+        """
+        self.login()
+
+        headers = headers or {}
+        base_headers = copy.copy(self.headers or {})
+        # Remove content-type from base headers - httpx will set it for multipart
+        base_headers.pop("content-type", None)
+        headers.update(base_headers)
+
+        # Build the multipart form data according to GraphQL Multipart Request Spec
+        files = MultipartBuilder.build_payload(
+            query=query, variables=variables, file_content=file_content, file_name=file_name
+        )
+
+        return self._request_multipart(url=url, headers=headers, timeout=timeout or self.default_timeout, files=files)
+
     def _build_proxy_config(self) -> ProxyConfigSync:
         """Build proxy configuration for httpx Client."""
         proxy_config: ProxyConfigSync = {"proxy": None, "mounts": None}
@@ -1966,6 +2158,21 @@ class InfrahubClientSync(BaseClient):
                 for key, value in self.config.proxy_mounts.model_dump(by_alias=True).items()
             }
         return proxy_config
+
+    def _request_multipart(
+        self, url: str, headers: dict[str, Any], timeout: int, files: dict[str, Any]
+    ) -> httpx.Response:
+        """Execute a multipart HTTP POST request."""
+        with httpx.Client(**self._build_proxy_config(), verify=self.config.tls_context) as client:
+            try:
+                response = client.post(url=url, headers=headers, timeout=timeout, files=files)
+            except httpx.NetworkError as exc:
+                raise ServerNotReachableError(address=self.address) from exc
+            except httpx.ReadTimeout as exc:
+                raise ServerNotResponsiveError(url=url, timeout=timeout) from exc
+
+        self._record(response)
+        return response
 
     def count(
         self,

--- a/infrahub_sdk/ctl/branch.py
+++ b/infrahub_sdk/ctl/branch.py
@@ -119,8 +119,8 @@ def generate_proposed_change_tables(proposed_changes: list[CoreProposedChange]) 
         proposed_change_table.add_row("Name", pc.name.value)
         proposed_change_table.add_row("State", str(pc.state.value))
         proposed_change_table.add_row("Is draft", "Yes" if pc.is_draft.value else "No")
-        proposed_change_table.add_row("Created by", pc.created_by.peer.name.value)  # type: ignore[union-attr]
-        proposed_change_table.add_row("Created at", format_timestamp(str(pc.created_by.updated_at)))
+        proposed_change_table.add_row("Created by", pc.created_by.peer.name.value)  # type: ignore[attr-defined]
+        proposed_change_table.add_row("Created at", format_timestamp(str(pc.created_by.updated_at)))  # type: ignore[attr-defined]
         proposed_change_table.add_row("Approvals", str(len(pc.approved_by.peers)))
         proposed_change_table.add_row("Rejections", str(len(pc.rejected_by.peers)))
 

--- a/infrahub_sdk/file_handler.py
+++ b/infrahub_sdk/file_handler.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, cast, overload
 
+import anyio
 import httpx
 
 from .exceptions import AuthenticationError, NodeNotFoundError, ServerNotReachableError
@@ -27,8 +28,44 @@ class FileHandlerBase:
     """
 
     @staticmethod
-    def prepare_upload(content: bytes | Path | BinaryIO | None, name: str | None = None) -> PreparedFile:
-        """Prepare file content for upload.
+    async def prepare_upload(content: bytes | Path | BinaryIO | None, name: str | None = None) -> PreparedFile:
+        """Prepare file content for upload (async version).
+
+        Converts various content types to a consistent BinaryIO interface for streaming uploads.
+        For Path inputs, opens the file handle in a thread pool to avoid blocking the event loop.
+        The actual file reading is streamed by httpx during the HTTP request.
+
+        Args:
+            content: The file content as bytes, a Path to a file, or a file-like object.
+                     Can be None if no file is set.
+            name: Optional filename. If not provided and content is a Path,
+                  the filename will be derived from the path.
+
+        Returns:
+            A PreparedFile containing the file object, filename, and whether it should be closed.
+        """
+        if content is None:
+            return PreparedFile(file_object=None, filename=None, should_close=False)
+
+        if name is None and isinstance(content, Path):
+            name = content.name
+
+        filename = name or "uploaded_file"
+
+        if isinstance(content, bytes):
+            return PreparedFile(file_object=BytesIO(content), filename=filename, should_close=False)
+        if isinstance(content, Path):
+            # Open file in thread pool to avoid blocking the event loop
+            # Returns a sync file handle that httpx can stream from in chunks
+            file_obj = await anyio.to_thread.run_sync(content.open, "rb")
+            return PreparedFile(file_object=cast("BinaryIO", file_obj), filename=filename, should_close=True)
+
+        # At this point, content must be a BinaryIO (file-like object)
+        return PreparedFile(file_object=cast("BinaryIO", content), filename=filename, should_close=False)
+
+    @staticmethod
+    def prepare_upload_sync(content: bytes | Path | BinaryIO | None, name: str | None = None) -> PreparedFile:
+        """Prepare file content for upload (sync version).
 
         Converts various content types to a consistent BinaryIO interface for streaming uploads.
 
@@ -196,9 +233,9 @@ class FileHandler(FileHandlerBase):
                     self.handle_error_response(exc=exc)
 
                 bytes_written = 0
-                with dest.open("wb") as f:
-                    async for chunk in resp.aiter_bytes(chunk_size=8192):
-                        f.write(chunk)
+                async with await anyio.Path(dest).open("wb") as f:
+                    async for chunk in resp.aiter_bytes(chunk_size=65536):
+                        await f.write(chunk)
                         bytes_written += len(chunk)
                 return bytes_written
         except ServerNotReachableError:
@@ -302,7 +339,7 @@ class FileHandlerSync(FileHandlerBase):
 
                 bytes_written = 0
                 with dest.open("wb") as f:
-                    for chunk in resp.iter_bytes(chunk_size=8192):
+                    for chunk in resp.iter_bytes(chunk_size=65536):
                         f.write(chunk)
                         bytes_written += len(chunk)
                 return bytes_written

--- a/infrahub_sdk/file_handler.py
+++ b/infrahub_sdk/file_handler.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING, BinaryIO, cast, overload
+
+import httpx
+
+from .exceptions import AuthenticationError, NodeNotFoundError, ServerNotReachableError
+
+if TYPE_CHECKING:
+    from .client import InfrahubClient, InfrahubClientSync
+
+
+@dataclass
+class PreparedFile:
+    file_object: BinaryIO | None
+    filename: str | None
+    should_close: bool
+
+
+class FileHandlerBase:
+    """Base class for file handling operations.
+
+    Provides common functionality for both async and sync file handlers, including upload preparation and error handling.
+    """
+
+    @staticmethod
+    def prepare_upload(content: bytes | Path | BinaryIO | None, name: str | None = None) -> PreparedFile:
+        """Prepare file content for upload.
+
+        Converts various content types to a consistent BinaryIO interface for streaming uploads.
+
+        Args:
+            content: The file content as bytes, a Path to a file, or a file-like object.
+                     Can be None if no file is set.
+            name: Optional filename. If not provided and content is a Path,
+                  the filename will be derived from the path.
+
+        Returns:
+            A PreparedFile containing the file object, filename, and whether it should be closed.
+        """
+        if content is None:
+            return PreparedFile(file_object=None, filename=None, should_close=False)
+
+        if name is None and isinstance(content, Path):
+            name = content.name
+
+        filename = name or "uploaded_file"
+
+        if isinstance(content, bytes):
+            return PreparedFile(file_object=BytesIO(content), filename=filename, should_close=False)
+        if isinstance(content, Path):
+            return PreparedFile(file_object=content.open("rb"), filename=filename, should_close=True)
+
+        # At this point, content must be a BinaryIO (file-like object)
+        return PreparedFile(file_object=cast("BinaryIO", content), filename=filename, should_close=False)
+
+    @staticmethod
+    def handle_error_response(exc: httpx.HTTPStatusError) -> None:
+        """Handle HTTP error responses for file operations.
+
+        Args:
+            exc: The HTTP status error from httpx.
+
+        Raises:
+            AuthenticationError: If authentication fails (401/403).
+            NodeNotFoundError: If the file/node is not found (404).
+            httpx.HTTPStatusError: For other HTTP errors.
+        """
+        if exc.response.status_code in {401, 403}:
+            response = exc.response.json()
+            errors = response.get("errors", [])
+            messages = [error.get("message") for error in errors]
+            raise AuthenticationError(" | ".join(messages)) from exc
+        if exc.response.status_code == 404:
+            response = exc.response.json()
+            detail = response.get("detail", "File not found")
+            raise NodeNotFoundError(node_type="FileObject", identifier=detail) from exc
+        raise exc
+
+    @staticmethod
+    def handle_response(resp: httpx.Response) -> bytes:
+        """Handle the HTTP response and return file content as bytes.
+
+        Args:
+            resp: The HTTP response from httpx.
+
+        Returns:
+            The file content as bytes.
+
+        Raises:
+            AuthenticationError: If authentication fails.
+            NodeNotFoundError: If the file is not found.
+        """
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            FileHandlerBase.handle_error_response(exc=exc)
+        return resp.content
+
+
+class FileHandler(FileHandlerBase):
+    """Async file handler for download operations.
+
+    Handles file downloads with support for streaming to disk
+    for memory-efficient handling of large files.
+    """
+
+    def __init__(self, client: InfrahubClient) -> None:
+        """Initialize the async file handler.
+
+        Args:
+            client: The async Infrahub client instance.
+        """
+        self._client = client
+
+    def _build_url(self, node_id: str, branch: str | None) -> str:
+        """Build the download URL for a file.
+
+        Args:
+            node_id: The ID of the FileObject node.
+            branch: Optional branch name.
+
+        Returns:
+            The complete URL for downloading the file.
+        """
+        url = f"{self._client.address}/api/storage/files/{node_id}"
+        if branch:
+            url = f"{url}?branch={branch}"
+        return url
+
+    @overload
+    async def download(self, node_id: str, branch: str | None) -> bytes: ...
+
+    @overload
+    async def download(self, node_id: str, branch: str | None, dest: Path) -> int: ...
+
+    @overload
+    async def download(self, node_id: str, branch: str | None, dest: None) -> bytes: ...
+
+    async def download(self, node_id: str, branch: str | None, dest: Path | None = None) -> bytes | int:
+        """Download file content from a FileObject node.
+
+        Args:
+            node_id: The ID of the FileObject node.
+            branch: Optional branch name. Uses client default if not provided.
+            dest: Optional destination path. If provided, streams to disk.
+
+        Returns:
+            If dest is None: The file content as bytes.
+            If dest is provided: The number of bytes written.
+
+        Raises:
+            ServerNotReachableError: If the server is not reachable.
+            AuthenticationError: If authentication fails.
+            NodeNotFoundError: If the node/file is not found.
+        """
+        effective_branch = branch or self._client.default_branch
+        url = self._build_url(node_id=node_id, branch=effective_branch)
+
+        if dest is not None:
+            return await self._stream_to_file(url=url, dest=dest)
+
+        try:
+            resp = await self._client._get(url=url)
+        except ServerNotReachableError:
+            self._client.log.error(f"Unable to connect to {self._client.address}")
+            raise
+
+        return self.handle_response(resp=resp)
+
+    async def _stream_to_file(self, url: str, dest: Path) -> int:
+        """Stream download directly to a file without loading into memory.
+
+        Args:
+            url: The URL to download from.
+            dest: The destination path to write to.
+
+        Returns:
+            The number of bytes written to the file.
+
+        Raises:
+            ServerNotReachableError: If the server is not reachable.
+            AuthenticationError: If authentication fails.
+            NodeNotFoundError: If the file is not found.
+        """
+        try:
+            async with self._client._get_streaming(url=url) as resp:
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    # Need to read the response body for error details
+                    await resp.aread()
+                    self.handle_error_response(exc=exc)
+
+                bytes_written = 0
+                with dest.open("wb") as f:
+                    async for chunk in resp.aiter_bytes(chunk_size=8192):
+                        f.write(chunk)
+                        bytes_written += len(chunk)
+                return bytes_written
+        except ServerNotReachableError:
+            self._client.log.error(f"Unable to connect to {self._client.address}")
+            raise
+
+
+class FileHandlerSync(FileHandlerBase):
+    """Sync file handler for download operations.
+
+    Handles file downloads with support for streaming to disk
+    for memory-efficient handling of large files.
+    """
+
+    def __init__(self, client: InfrahubClientSync) -> None:
+        """Initialize the sync file handler.
+
+        Args:
+            client: The sync Infrahub client instance.
+        """
+        self._client = client
+
+    def _build_url(self, node_id: str, branch: str | None) -> str:
+        """Build the download URL for a file.
+
+        Args:
+            node_id: The ID of the FileObject node.
+            branch: Optional branch name.
+
+        Returns:
+            The complete URL for downloading the file.
+        """
+        url = f"{self._client.address}/api/storage/files/{node_id}"
+        if branch:
+            url = f"{url}?branch={branch}"
+        return url
+
+    @overload
+    def download(self, node_id: str, branch: str | None) -> bytes: ...
+
+    @overload
+    def download(self, node_id: str, branch: str | None, dest: Path) -> int: ...
+
+    @overload
+    def download(self, node_id: str, branch: str | None, dest: None) -> bytes: ...
+
+    def download(self, node_id: str, branch: str | None, dest: Path | None = None) -> bytes | int:
+        """Download file content from a FileObject node.
+
+        Args:
+            node_id: The ID of the FileObject node.
+            branch: Optional branch name. Uses client default if not provided.
+            dest: Optional destination path. If provided, streams to disk.
+
+        Returns:
+            If dest is None: The file content as bytes.
+            If dest is provided: The number of bytes written.
+
+        Raises:
+            ServerNotReachableError: If the server is not reachable.
+            AuthenticationError: If authentication fails.
+            NodeNotFoundError: If the node/file is not found.
+        """
+        effective_branch = branch or self._client.default_branch
+        url = self._build_url(node_id=node_id, branch=effective_branch)
+
+        if dest is not None:
+            return self._stream_to_file(url=url, dest=dest)
+
+        try:
+            resp = self._client._get(url=url)
+        except ServerNotReachableError:
+            self._client.log.error(f"Unable to connect to {self._client.address}")
+            raise
+
+        return self.handle_response(resp=resp)
+
+    def _stream_to_file(self, url: str, dest: Path) -> int:
+        """Stream download directly to a file without loading into memory.
+
+        Args:
+            url: The URL to download from.
+            dest: The destination path to write to.
+
+        Returns:
+            The number of bytes written to the file.
+
+        Raises:
+            ServerNotReachableError: If the server is not reachable.
+            AuthenticationError: If authentication fails.
+            NodeNotFoundError: If the file is not found.
+        """
+        try:
+            with self._client._get_streaming(url=url) as resp:
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    # Need to read the response body for error details
+                    resp.read()
+                    self.handle_error_response(exc=exc)
+
+                bytes_written = 0
+                with dest.open("wb") as f:
+                    for chunk in resp.iter_bytes(chunk_size=8192):
+                        f.write(chunk)
+                        bytes_written += len(chunk)
+                return bytes_written
+        except ServerNotReachableError:
+            self._client.log.error(f"Unable to connect to {self._client.address}")
+            raise

--- a/infrahub_sdk/graphql/__init__.py
+++ b/infrahub_sdk/graphql/__init__.py
@@ -1,9 +1,11 @@
 from .constants import VARIABLE_TYPE_MAPPING
+from .multipart import MultipartBuilder
 from .query import Mutation, Query
 from .renderers import render_input_block, render_query_block, render_variables_to_string
 
 __all__ = [
     "VARIABLE_TYPE_MAPPING",
+    "MultipartBuilder",
     "Mutation",
     "Query",
     "render_input_block",

--- a/infrahub_sdk/graphql/constants.py
+++ b/infrahub_sdk/graphql/constants.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from pathlib import Path
+from typing import BinaryIO
 
 VARIABLE_TYPE_MAPPING = (
     (str, "String!"),
@@ -11,4 +13,7 @@ VARIABLE_TYPE_MAPPING = (
     (bool | None, "Boolean"),
     (datetime, "DateTime!"),
     (datetime | None, "DateTime"),
+    (bytes, "Upload!"),
+    (Path, "Upload!"),
+    (BinaryIO, "Upload!"),
 )

--- a/infrahub_sdk/graphql/multipart.py
+++ b/infrahub_sdk/graphql/multipart.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import ujson
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
+
+
+class MultipartBuilder:
+    """Builds multipart form data payloads for GraphQL file uploads.
+
+    This class implements the GraphQL Multipart Request Spec for uploading files via GraphQL mutations. The spec defines a standard way to send files
+    alongside GraphQL operations using multipart/form-data.
+
+    The payload structure follows the spec:
+    - operations: JSON containing the GraphQL query and variables
+    - map: JSON mapping file keys to variable paths
+    - 0, 1, ...: The actual file contents
+
+    Example payload:
+        {
+            "operations": '{"query": "mutation($file: Upload!) {...}", "variables": {"file": null}}',
+            "map": '{"0": ["variables.file"]}',
+            "0": (filename, file_content)
+        }
+    """
+
+    @staticmethod
+    def build_operations(query: str, variables: dict[str, Any]) -> str:
+        """Build the operations JSON string.
+
+        Args:
+            query: The GraphQL query string.
+            variables: The variables dict (file variable should be null).
+
+        Returns:
+            JSON string containing the query and variables.
+        """
+        return ujson.dumps({"query": query, "variables": variables})
+
+    @staticmethod
+    def build_file_map(file_key: str = "0", variable_path: str = "variables.file") -> str:
+        """Build the file map JSON string.
+
+        Args:
+            file_key: The key used for the file in the multipart payload.
+            variable_path: The path to the file variable in the GraphQL variables.
+
+        Returns:
+            JSON string mapping the file key to the variable path.
+        """
+        return ujson.dumps({file_key: [variable_path]})
+
+    @staticmethod
+    def build_payload(
+        query: str,
+        variables: dict[str, Any],
+        file_content: BinaryIO | None = None,
+        file_name: str = "upload",
+    ) -> dict[str, Any]:
+        """Build the complete multipart form data payload.
+
+        Constructs the payload according to the GraphQL Multipart Request Spec. The returned dict can be passed directly to httpx as the `files`
+        parameter.
+
+        Args:
+            query: The GraphQL query string containing $file: Upload! variable.
+            variables: The variables dict. The 'file' key will be set to null.
+            file_content: The file content as a file-like object (BinaryIO).
+                          If None, only the operations and map will be included.
+            file_name: The filename to use for the upload.
+
+        Returns:
+            A dict suitable for httpx's `files` parameter in a POST request.
+
+        Example:
+            >>> builder = MultipartBuilder()
+            >>> payload = builder.build_payload(
+            ...     query="mutation($file: Upload!) { upload(file: $file) { id } }",
+            ...     variables={"other": "value"},
+            ...     file_content=open("file.pdf", "rb"),
+            ...     file_name="document.pdf",
+            ... )
+            >>> # payload can be passed to httpx.post(..., files=payload)
+        """
+        # Ensure file variable is null (spec requirement)
+        variables = {**variables, "file": None}
+
+        operations = MultipartBuilder.build_operations(query=query, variables=variables)
+        file_map = MultipartBuilder.build_file_map()
+
+        files: dict[str, Any] = {"operations": (None, operations), "map": (None, file_map)}
+
+        if file_content is not None:
+            # httpx streams from file-like objects automatically
+            files["0"] = (file_name, file_content)
+
+        return files

--- a/infrahub_sdk/graphql/renderers.py
+++ b/infrahub_sdk/graphql/renderers.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from pathlib import Path
+from typing import Any, BinaryIO
 
 from pydantic import BaseModel
 
@@ -88,7 +89,7 @@ def convert_to_graphql_as_string(value: Any, convert_enum: bool = False) -> str:
     return str(value)
 
 
-GRAPHQL_VARIABLE_TYPES = type[str | int | float | bool | datetime | None]
+GRAPHQL_VARIABLE_TYPES = type[str | int | float | bool | datetime | bytes | Path | BinaryIO | None]
 
 
 def render_variables_to_string(data: dict[str, GRAPHQL_VARIABLE_TYPES]) -> str:

--- a/infrahub_sdk/node/constants.py
+++ b/infrahub_sdk/node/constants.py
@@ -27,6 +27,9 @@ ARTIFACT_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE = (
 ARTIFACT_DEFINITION_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE = (
     "calling generate is only supported for CoreArtifactDefinition nodes"
 )
+FILE_DOWNLOAD_FEATURE_NOT_SUPPORTED_MESSAGE = (
+    "calling download_file is only supported for nodes that inherit from CoreFileObject"
+)
 
 HIERARCHY_FETCH_FEATURE_NOT_SUPPORTED_MESSAGE = "Hierarchical fields are not supported for this node."
 

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 from ..constants import InfrahubClientMode
 from ..exceptions import FeatureNotSupportedError, NodeNotFoundError, ResourceNotDefinedError, SchemaNotFoundError
+from ..file_handler import FileHandler, FileHandlerBase, FileHandlerSync, PreparedFile
 from ..graphql import Mutation, Query
 from ..schema import (
     GenericSchemaAPI,
@@ -21,6 +23,7 @@ from .constants import (
     ARTIFACT_DEFINITION_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE,
     ARTIFACT_FETCH_FEATURE_NOT_SUPPORTED_MESSAGE,
     ARTIFACT_GENERATE_FEATURE_NOT_SUPPORTED_MESSAGE,
+    FILE_DOWNLOAD_FEATURE_NOT_SUPPORTED_MESSAGE,
     PROPERTIES_OBJECT,
 )
 from .metadata import NodeMetadata
@@ -68,10 +71,15 @@ class InfrahubNodeBase:
         # GenericSchemaAPI doesn't have inherit_from, so we need to check the type first
         if isinstance(schema, GenericSchemaAPI):
             self._artifact_support = False
+            self._file_object_support = False
         else:
             inherit_from = getattr(schema, "inherit_from", None) or []
             self._artifact_support = "CoreArtifactTarget" in inherit_from
+            self._file_object_support = "CoreFileObject" in inherit_from
         self._artifact_definition_support = schema.kind == "CoreArtifactDefinition"
+
+        self._file_content: bytes | Path | BinaryIO | None = None
+        self._file_name: str | None = None
 
         # Check if this node is hierarchical (supports parent/children and ancestors/descendants)
         if not isinstance(schema, (ProfileSchemaAPI, GenericSchemaAPI, TemplateSchemaAPI)):
@@ -213,6 +221,61 @@ class InfrahubNodeBase:
     def is_resource_pool(self) -> bool:
         return hasattr(self._schema, "inherit_from") and "CoreResourcePool" in self._schema.inherit_from  # type: ignore[union-attr]
 
+    def is_file_object(self) -> bool:
+        """Check if this node inherits from CoreFileObject and supports file uploads."""
+        return self._file_object_support
+
+    def set_file(self, content: bytes | Path | BinaryIO, name: str | None = None) -> None:
+        """Set file content to be uploaded when saving this FileObject node.
+
+        The content can be provided in several forms for flexibility:
+        - bytes: The file content directly in memory
+        - Path: A path to a file on disk (will be streamed during upload)
+        - BinaryIO: An open file-like object (will be streamed during upload)
+
+        Using Path or BinaryIO is recommended for large files to avoid loading
+        the entire file into memory.
+
+        Args:
+            content: The file content as bytes, a Path to a file, or a file-like object.
+            name: Optional filename. If not provided and content is a Path, the filename
+                  will be derived from the path. Otherwise, a default name will be used.
+
+        Raises:
+            FeatureNotSupportedError: If this node doesn't inherit from CoreFileObject.
+
+        Examples:
+            # Using bytes (for small files)
+            node.set_file(content=b"file content", name="example.txt")
+
+            # Using Path (recommended for large files)
+            node.set_file(content=Path("/path/to/large_file.pdf"))
+
+            # Using file-like object
+            with open("/path/to/file.bin", "rb") as f:
+                node.set_file(content=f, name="file.bin")
+        """
+        if not self._file_object_support:
+            raise FeatureNotSupportedError(
+                f"File upload is not supported for {self._schema.kind}. Only nodes inheriting from CoreFileObject support file uploads."
+            )
+        self._file_content = content
+
+        # Derive filename from Path if not provided
+        if name is None and isinstance(content, Path):
+            name = content.name
+
+        self._file_name = name
+
+    def clear_file(self) -> None:
+        """Clear any pending file content."""
+        self._file_content = None
+        self._file_name = None
+
+    def _get_file_for_upload(self) -> PreparedFile:
+        """Get the file content as a file-like object for upload."""
+        return FileHandlerBase.prepare_upload(content=self._file_content, name=self._file_name)
+
     def get_raw_graphql_data(self) -> dict | None:
         return self._data
 
@@ -300,6 +363,11 @@ class InfrahubNodeBase:
         mutation_payload = {"data": data}
         if context_data := self._get_request_context(request_context=request_context):
             mutation_payload["context"] = context_data
+
+        # Add file variable for FileObject nodes with pending file content
+        if self._file_object_support and self._file_content is not None:
+            data["file"] = "$file"
+            mutation_variables["file"] = bytes
 
         return {
             "data": mutation_payload,
@@ -426,6 +494,10 @@ class InfrahubNodeBase:
         if not self._artifact_definition_support:
             raise FeatureNotSupportedError(message)
 
+    def _validate_file_object_support(self, message: str) -> None:
+        if not self._file_object_support:
+            raise FeatureNotSupportedError(message)
+
     def generate_query_data_init(
         self,
         filters: dict[str, Any] | None = None,
@@ -515,6 +587,7 @@ class InfrahubNode(InfrahubNodeBase):
             data: Optional data to initialize the node.
         """
         self._client = client
+        self._file_handler = FileHandler(client=client)
 
         # Extract node_metadata before extracting node data (node_metadata is sibling to node in edges)
         node_metadata_data: dict | None = None
@@ -702,6 +775,41 @@ class InfrahubNode(InfrahubNodeBase):
 
         artifact = await self._client.get(kind="CoreArtifact", name__value=name, object__ids=[self.id])
         return await self._client.object_store.get(identifier=artifact._get_attribute(name="storage_id").value)
+
+    async def download_file(self, dest: Path | None = None) -> bytes | int:
+        """Download the file content from this FileObject node.
+
+        This method is only available for nodes that inherit from CoreFileObject.
+        The node must have been saved (have an id) before calling this method.
+
+        Args:
+            dest: Optional destination path. If provided, the file will be streamed
+                  directly to this path (memory-efficient for large files) and the
+                  number of bytes written will be returned. If not provided, the
+                  file content will be returned as bytes.
+
+        Returns:
+            If dest is None: The file content as bytes.
+            If dest is provided: The number of bytes written to the file.
+
+        Raises:
+            FeatureNotSupportedError: If this node doesn't inherit from CoreFileObject.
+            ValueError: If the node hasn't been saved yet or file not found.
+            AuthenticationError: If authentication fails.
+
+        Examples:
+            # Download to memory
+            content = await contract.download_file()
+
+            # Stream to file (memory-efficient for large files)
+            bytes_written = await contract.download_file(dest=Path("/tmp/contract.pdf"))
+        """
+        self._validate_file_object_support(message=FILE_DOWNLOAD_FEATURE_NOT_SUPPORTED_MESSAGE)
+
+        if not self.id:
+            raise ValueError("Cannot download file for a node that hasn't been saved yet.")
+
+        return await self._file_handler.download(node_id=self.id, branch=self._branch, dest=dest)
 
     async def delete(self, timeout: int | None = None, request_context: RequestContext | None = None) -> None:
         input_data = {"data": {"id": self.id}}
@@ -1049,19 +1157,39 @@ class InfrahubNode(InfrahubNodeBase):
             input_data = self._generate_input_data(exclude_hfid=True, request_context=request_context)
             mutation_name = f"{self._schema.kind}Create"
             tracker = f"mutation-{str(self._schema.kind).lower()}-create"
+
         query = Mutation(
             mutation=mutation_name,
             input_data=input_data["data"],
             query=mutation_query,
             variables=input_data["mutation_variables"],
         )
-        response = await self._client.execute_graphql(
-            query=query.render(),
-            branch_name=self._branch,
-            tracker=tracker,
-            variables=input_data["variables"],
-            timeout=timeout,
-        )
+
+        if "file" in input_data["mutation_variables"]:
+            prepared = self._get_file_for_upload()
+            try:
+                response = await self._client.execute_graphql_with_file(
+                    query=query.render(),
+                    variables=input_data["variables"],
+                    file_content=prepared.file_object,
+                    file_name=prepared.filename,
+                    branch_name=self._branch,
+                    tracker=tracker,
+                    timeout=timeout,
+                )
+            finally:
+                if prepared.should_close and prepared.file_object:
+                    prepared.file_object.close()
+            # Clear the file content after successful upload
+            self.clear_file()
+        else:
+            response = await self._client.execute_graphql(
+                query=query.render(),
+                branch_name=self._branch,
+                tracker=tracker,
+                variables=input_data["variables"],
+                timeout=timeout,
+            )
         await self._process_mutation_result(mutation_name=mutation_name, response=response, timeout=timeout)
 
     async def update(
@@ -1070,6 +1198,7 @@ class InfrahubNode(InfrahubNodeBase):
         input_data = self._generate_input_data(exclude_unmodified=not do_full_update, request_context=request_context)
         mutation_query = self._generate_mutation_query()
         mutation_name = f"{self._schema.kind}Update"
+        tracker = f"mutation-{str(self._schema.kind).lower()}-update"
 
         query = Mutation(
             mutation=mutation_name,
@@ -1077,13 +1206,32 @@ class InfrahubNode(InfrahubNodeBase):
             query=mutation_query,
             variables=input_data["mutation_variables"],
         )
-        response = await self._client.execute_graphql(
-            query=query.render(),
-            branch_name=self._branch,
-            timeout=timeout,
-            tracker=f"mutation-{str(self._schema.kind).lower()}-update",
-            variables=input_data["variables"],
-        )
+
+        if "file" in input_data["mutation_variables"]:
+            prepared = self._get_file_for_upload()
+            try:
+                response = await self._client.execute_graphql_with_file(
+                    query=query.render(),
+                    variables=input_data["variables"],
+                    file_content=prepared.file_object,
+                    file_name=prepared.filename,
+                    branch_name=self._branch,
+                    tracker=tracker,
+                    timeout=timeout,
+                )
+            finally:
+                if prepared.should_close and prepared.file_object:
+                    prepared.file_object.close()
+            # Clear the file content after successful upload
+            self.clear_file()
+        else:
+            response = await self._client.execute_graphql(
+                query=query.render(),
+                branch_name=self._branch,
+                timeout=timeout,
+                tracker=tracker,
+                variables=input_data["variables"],
+            )
         await self._process_mutation_result(mutation_name=mutation_name, response=response, timeout=timeout)
 
     async def _process_relationships(
@@ -1323,6 +1471,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
             data (Optional[dict]): Optional data to initialize the node.
         """
         self._client = client
+        self._file_handler = FileHandlerSync(client=client)
 
         # Extract node_metadata before extracting node data (node_metadata is sibling to node in edges)
         node_metadata_data: dict | None = None
@@ -1511,6 +1660,41 @@ class InfrahubNodeSync(InfrahubNodeBase):
         self._validate_artifact_support(ARTIFACT_FETCH_FEATURE_NOT_SUPPORTED_MESSAGE)
         artifact = self._client.get(kind="CoreArtifact", name__value=name, object__ids=[self.id])
         return self._client.object_store.get(identifier=artifact._get_attribute(name="storage_id").value)
+
+    def download_file(self, dest: Path | None = None) -> bytes | int:
+        """Download the file content from this FileObject node.
+
+        This method is only available for nodes that inherit from CoreFileObject.
+        The node must have been saved (have an id) before calling this method.
+
+        Args:
+            dest: Optional destination path. If provided, the file will be streamed
+                  directly to this path (memory-efficient for large files) and the
+                  number of bytes written will be returned. If not provided, the
+                  file content will be returned as bytes.
+
+        Returns:
+            If dest is None: The file content as bytes.
+            If dest is provided: The number of bytes written to the file.
+
+        Raises:
+            FeatureNotSupportedError: If this node doesn't inherit from CoreFileObject.
+            ValueError: If the node hasn't been saved yet or file not found.
+            AuthenticationError: If authentication fails.
+
+        Examples:
+            # Download to memory
+            content = contract.download_file()
+
+            # Stream to file (memory-efficient for large files)
+            bytes_written = contract.download_file(dest=Path("/tmp/contract.pdf"))
+        """
+        self._validate_file_object_support(message=FILE_DOWNLOAD_FEATURE_NOT_SUPPORTED_MESSAGE)
+
+        if not self.id:
+            raise ValueError("Cannot download file for a node that hasn't been saved yet.")
+
+        return self._file_handler.download(node_id=self.id, branch=self._branch, dest=dest)
 
     def delete(self, timeout: int | None = None, request_context: RequestContext | None = None) -> None:
         input_data = {"data": {"id": self.id}}
@@ -1855,6 +2039,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
             input_data = self._generate_input_data(exclude_hfid=True, request_context=request_context)
             mutation_name = f"{self._schema.kind}Create"
             tracker = f"mutation-{str(self._schema.kind).lower()}-create"
+
         query = Mutation(
             mutation=mutation_name,
             input_data=input_data["data"],
@@ -1862,13 +2047,31 @@ class InfrahubNodeSync(InfrahubNodeBase):
             variables=input_data["mutation_variables"],
         )
 
-        response = self._client.execute_graphql(
-            query=query.render(),
-            branch_name=self._branch,
-            tracker=tracker,
-            variables=input_data["variables"],
-            timeout=timeout,
-        )
+        if "file" in input_data["mutation_variables"]:
+            prepared = self._get_file_for_upload()
+            try:
+                response = self._client.execute_graphql_with_file(
+                    query=query.render(),
+                    variables=input_data["variables"],
+                    file_content=prepared.file_object,
+                    file_name=prepared.filename,
+                    branch_name=self._branch,
+                    tracker=tracker,
+                    timeout=timeout,
+                )
+            finally:
+                if prepared.should_close and prepared.file_object:
+                    prepared.file_object.close()
+            # Clear the file content after successful upload
+            self.clear_file()
+        else:
+            response = self._client.execute_graphql(
+                query=query.render(),
+                branch_name=self._branch,
+                tracker=tracker,
+                variables=input_data["variables"],
+                timeout=timeout,
+            )
         self._process_mutation_result(mutation_name=mutation_name, response=response, timeout=timeout)
 
     def update(
@@ -1877,6 +2080,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         input_data = self._generate_input_data(exclude_unmodified=not do_full_update, request_context=request_context)
         mutation_query = self._generate_mutation_query()
         mutation_name = f"{self._schema.kind}Update"
+        tracker = f"mutation-{str(self._schema.kind).lower()}-update"
 
         query = Mutation(
             mutation=mutation_name,
@@ -1885,13 +2089,31 @@ class InfrahubNodeSync(InfrahubNodeBase):
             variables=input_data["mutation_variables"],
         )
 
-        response = self._client.execute_graphql(
-            query=query.render(),
-            branch_name=self._branch,
-            tracker=f"mutation-{str(self._schema.kind).lower()}-update",
-            variables=input_data["variables"],
-            timeout=timeout,
-        )
+        if "file" in input_data["mutation_variables"]:
+            prepared = self._get_file_for_upload()
+            try:
+                response = self._client.execute_graphql_with_file(
+                    query=query.render(),
+                    variables=input_data["variables"],
+                    file_content=prepared.file_object,
+                    file_name=prepared.filename,
+                    branch_name=self._branch,
+                    tracker=tracker,
+                    timeout=timeout,
+                )
+            finally:
+                if prepared.should_close and prepared.file_object:
+                    prepared.file_object.close()
+            # Clear the file content after successful upload
+            self.clear_file()
+        else:
+            response = self._client.execute_graphql(
+                query=query.render(),
+                branch_name=self._branch,
+                tracker=tracker,
+                variables=input_data["variables"],
+                timeout=timeout,
+            )
         self._process_mutation_result(mutation_name=mutation_name, response=response, timeout=timeout)
 
     def _process_relationships(

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -225,46 +225,53 @@ class InfrahubNodeBase:
         """Check if this node inherits from CoreFileObject and supports file uploads."""
         return self._file_object_support
 
-    def set_file(self, content: bytes | Path | BinaryIO, name: str | None = None) -> None:
-        """Set file content to be uploaded when saving this FileObject node.
+    def select_file_for_upload(self, path: Path) -> None:
+        """Select a file from disk to be uploaded when saving this FileObject node.
 
-        The content can be provided in several forms for flexibility:
-        - bytes: The file content directly in memory
-        - Path: A path to a file on disk (will be streamed during upload)
-        - BinaryIO: An open file-like object (will be streamed during upload)
-
-        Using Path or BinaryIO is recommended for large files to avoid loading
-        the entire file into memory.
+        The file will be streamed during upload, avoiding loading the entire file into memory.
 
         Args:
-            content: The file content as bytes, a Path to a file, or a file-like object.
-            name: Optional filename. If not provided and content is a Path, the filename
-                  will be derived from the path. Otherwise, a default name will be used.
+            path: Path to the file on disk.
+
+        Raises:
+            FeatureNotSupportedError: If this node doesn't inherit from CoreFileObject.
+
+        Example:
+            node.select_file_for_upload(path=Path("/path/to/large_file.pdf"))
+        """
+        if not self._file_object_support:
+            raise FeatureNotSupportedError(
+                f"File upload is not supported for {self._schema.kind}. Only nodes inheriting from CoreFileObject support file uploads."
+            )
+        self._file_content = path
+        self._file_name = path.name
+
+    def select_content_for_upload(self, content: bytes | BinaryIO, name: str) -> None:
+        """Select content to be uploaded when saving this FileObject node.
+
+        The content can be provided as bytes or a file-like object.
+        Using BinaryIO is recommended for large content to stream during upload.
+
+        Args:
+            content: The file content as bytes or a file-like object.
+            name: The filename to use for the uploaded file.
 
         Raises:
             FeatureNotSupportedError: If this node doesn't inherit from CoreFileObject.
 
         Examples:
             # Using bytes (for small files)
-            node.set_file(content=b"file content", name="example.txt")
+            node.select_content_for_upload(content=b"file content", name="example.txt")
 
-            # Using Path (recommended for large files)
-            node.set_file(content=Path("/path/to/large_file.pdf"))
-
-            # Using file-like object
+            # Using file-like object (for large files)
             with open("/path/to/file.bin", "rb") as f:
-                node.set_file(content=f, name="file.bin")
+                node.select_content_for_upload(content=f, name="file.bin")
         """
         if not self._file_object_support:
             raise FeatureNotSupportedError(
                 f"File upload is not supported for {self._schema.kind}. Only nodes inheriting from CoreFileObject support file uploads."
             )
         self._file_content = content
-
-        # Derive filename from Path if not provided
-        if name is None and isinstance(content, Path):
-            name = content.name
-
         self._file_name = name
 
     def clear_file(self) -> None:

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -360,7 +360,7 @@ class InfrahubNodeBase:
         elif self.hfid is not None and not exclude_hfid:
             data["hfid"] = self.hfid
 
-        mutation_payload = {"data": data}
+        mutation_payload: dict[str, Any] = {"data": data}
         if context_data := self._get_request_context(request_context=request_context):
             mutation_payload["context"] = context_data
 

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -225,8 +225,8 @@ class InfrahubNodeBase:
         """Check if this node inherits from CoreFileObject and supports file uploads."""
         return self._file_object_support
 
-    def select_file_for_upload(self, path: Path) -> None:
-        """Select a file from disk to be uploaded when saving this FileObject node.
+    def upload_from_path(self, path: Path) -> None:
+        """Set a file from disk to be uploaded when saving this FileObject node.
 
         The file will be streamed during upload, avoiding loading the entire file into memory.
 
@@ -237,7 +237,7 @@ class InfrahubNodeBase:
             FeatureNotSupportedError: If this node doesn't inherit from CoreFileObject.
 
         Example:
-            node.select_file_for_upload(path=Path("/path/to/large_file.pdf"))
+            node.upload_from_path(path=Path("/path/to/large_file.pdf"))
         """
         if not self._file_object_support:
             raise FeatureNotSupportedError(
@@ -246,8 +246,8 @@ class InfrahubNodeBase:
         self._file_content = path
         self._file_name = path.name
 
-    def select_content_for_upload(self, content: bytes | BinaryIO, name: str) -> None:
-        """Select content to be uploaded when saving this FileObject node.
+    def upload_from_bytes(self, content: bytes | BinaryIO, name: str) -> None:
+        """Set content to be uploaded when saving this FileObject node.
 
         The content can be provided as bytes or a file-like object.
         Using BinaryIO is recommended for large content to stream during upload.
@@ -261,11 +261,11 @@ class InfrahubNodeBase:
 
         Examples:
             # Using bytes (for small files)
-            node.select_content_for_upload(content=b"file content", name="example.txt")
+            node.upload_from_bytes(content=b"file content", name="example.txt")
 
             # Using file-like object (for large files)
             with open("/path/to/file.bin", "rb") as f:
-                node.select_content_for_upload(content=f, name="file.bin")
+                node.upload_from_bytes(content=f, name="file.bin")
         """
         if not self._file_object_support:
             raise FeatureNotSupportedError(
@@ -1159,7 +1159,7 @@ class InfrahubNode(InfrahubNodeBase):
     ) -> None:
         if self._file_object_support and self._file_content is None:
             raise ValueError(
-                f"Cannot create {self._schema.kind} without file content. Use select_file_for_upload() or select_content_for_upload() to provide "
+                f"Cannot create {self._schema.kind} without file content. Use upload_from_path() or upload_from_bytes() to provide "
                 "file content before saving."
             )
 
@@ -2049,7 +2049,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
     ) -> None:
         if self._file_object_support and self._file_content is None:
             raise ValueError(
-                f"Cannot create {self._schema.kind} without file content. Use select_file_for_upload() or select_content_for_upload() to provide "
+                f"Cannot create {self._schema.kind} without file content. Use upload_from_path() or upload_from_bytes() to provide "
                 "file content before saving."
             )
 

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1146,6 +1146,11 @@ class InfrahubNode(InfrahubNodeBase):
     async def create(
         self, allow_upsert: bool = False, timeout: int | None = None, request_context: RequestContext | None = None
     ) -> None:
+        if self._file_object_support and self._file_content is None:
+            raise ValueError(
+                f"Cannot create {self._schema.kind} without file content. Use set_file() to provide file content before saving."
+            )
+
         mutation_query = self._generate_mutation_query()
 
         # Upserting means we may want to create, meaning payload contains all mandatory fields required for a creation,
@@ -2030,6 +2035,11 @@ class InfrahubNodeSync(InfrahubNodeBase):
     def create(
         self, allow_upsert: bool = False, timeout: int | None = None, request_context: RequestContext | None = None
     ) -> None:
+        if self._file_object_support and self._file_content is None:
+            raise ValueError(
+                f"Cannot create {self._schema.kind} without file content. Use set_file() to provide file content before saving."
+            )
+
         mutation_query = self._generate_mutation_query()
 
         if allow_upsert:

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -365,8 +365,9 @@ class InfrahubNodeBase:
             mutation_payload["context"] = context_data
 
         # Add file variable for FileObject nodes with pending file content
+        # file is a mutation argument at the same level as data, not inside data
         if self._file_object_support and self._file_content is not None:
-            data["file"] = "$file"
+            mutation_payload["file"] = "$file"
             mutation_variables["file"] = bytes
 
         return {

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -272,9 +272,13 @@ class InfrahubNodeBase:
         self._file_content = None
         self._file_name = None
 
-    def _get_file_for_upload(self) -> PreparedFile:
-        """Get the file content as a file-like object for upload."""
-        return FileHandlerBase.prepare_upload(content=self._file_content, name=self._file_name)
+    async def _get_file_for_upload(self) -> PreparedFile:
+        """Get the file content as a file-like object for upload (async version)."""
+        return await FileHandlerBase.prepare_upload(content=self._file_content, name=self._file_name)
+
+    def _get_file_for_upload_sync(self) -> PreparedFile:
+        """Get the file content as a file-like object for upload (sync version)."""
+        return FileHandlerBase.prepare_upload_sync(content=self._file_content, name=self._file_name)
 
     def get_raw_graphql_data(self) -> dict | None:
         return self._data
@@ -1172,7 +1176,7 @@ class InfrahubNode(InfrahubNodeBase):
         )
 
         if "file" in input_data["mutation_variables"]:
-            prepared = self._get_file_for_upload()
+            prepared = await self._get_file_for_upload()
             try:
                 response = await self._client.execute_graphql_with_file(
                     query=query.render(),
@@ -1214,7 +1218,7 @@ class InfrahubNode(InfrahubNodeBase):
         )
 
         if "file" in input_data["mutation_variables"]:
-            prepared = self._get_file_for_upload()
+            prepared = await self._get_file_for_upload()
             try:
                 response = await self._client.execute_graphql_with_file(
                     query=query.render(),
@@ -2059,7 +2063,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         )
 
         if "file" in input_data["mutation_variables"]:
-            prepared = self._get_file_for_upload()
+            prepared = self._get_file_for_upload_sync()
             try:
                 response = self._client.execute_graphql_with_file(
                     query=query.render(),
@@ -2101,7 +2105,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         )
 
         if "file" in input_data["mutation_variables"]:
-            prepared = self._get_file_for_upload()
+            prepared = self._get_file_for_upload_sync()
             try:
                 response = self._client.execute_graphql_with_file(
                     query=query.render(),

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -68,14 +68,10 @@ class InfrahubNodeBase:
         self._attributes = [item.name for item in self._schema.attributes]
         self._relationships = [item.name for item in self._schema.relationships]
 
-        # GenericSchemaAPI doesn't have inherit_from, so we need to check the type first
-        if isinstance(schema, GenericSchemaAPI):
-            self._artifact_support = False
-            self._file_object_support = False
-        else:
-            inherit_from = getattr(schema, "inherit_from", None) or []
-            self._artifact_support = "CoreArtifactTarget" in inherit_from
-            self._file_object_support = "CoreFileObject" in inherit_from
+        # GenericSchemaAPI doesn't have inherit_from
+        inherit_from: list[str] = getattr(schema, "inherit_from", None) or []
+        self._artifact_support = "CoreArtifactTarget" in inherit_from
+        self._file_object_support = "CoreFileObject" in inherit_from
         self._artifact_definition_support = schema.kind == "CoreArtifactDefinition"
 
         self._file_content: bytes | Path | BinaryIO | None = None

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1159,7 +1159,8 @@ class InfrahubNode(InfrahubNodeBase):
     ) -> None:
         if self._file_object_support and self._file_content is None:
             raise ValueError(
-                f"Cannot create {self._schema.kind} without file content. Use set_file() to provide file content before saving."
+                f"Cannot create {self._schema.kind} without file content. Use select_file_for_upload() or select_content_for_upload() to provide "
+                "file content before saving."
             )
 
         mutation_query = self._generate_mutation_query()
@@ -2048,7 +2049,8 @@ class InfrahubNodeSync(InfrahubNodeBase):
     ) -> None:
         if self._file_object_support and self._file_content is None:
             raise ValueError(
-                f"Cannot create {self._schema.kind} without file content. Use set_file() to provide file content before saving."
+                f"Cannot create {self._schema.kind} without file content. Use select_file_for_upload() or select_content_for_upload() to provide "
+                "file content before saving."
             )
 
         mutation_query = self._generate_mutation_query()

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1186,7 +1186,7 @@ class InfrahubNode(InfrahubNodeBase):
         if "file" in input_data["mutation_variables"]:
             prepared = await self._get_file_for_upload()
             try:
-                response = await self._client.execute_graphql_with_file(
+                response = await self._client._execute_graphql_with_file(
                     query=query.render(),
                     variables=input_data["variables"],
                     file_content=prepared.file_object,
@@ -1228,7 +1228,7 @@ class InfrahubNode(InfrahubNodeBase):
         if "file" in input_data["mutation_variables"]:
             prepared = await self._get_file_for_upload()
             try:
-                response = await self._client.execute_graphql_with_file(
+                response = await self._client._execute_graphql_with_file(
                     query=query.render(),
                     variables=input_data["variables"],
                     file_content=prepared.file_object,
@@ -2074,7 +2074,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         if "file" in input_data["mutation_variables"]:
             prepared = self._get_file_for_upload_sync()
             try:
-                response = self._client.execute_graphql_with_file(
+                response = self._client._execute_graphql_with_file(
                     query=query.render(),
                     variables=input_data["variables"],
                     file_content=prepared.file_object,
@@ -2116,7 +2116,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         if "file" in input_data["mutation_variables"]:
             prepared = self._get_file_for_upload_sync()
             try:
-                response = self._client.execute_graphql_with_file(
+                response = self._client._execute_graphql_with_file(
                     query=query.render(),
                     variables=input_data["variables"],
                     file_content=prepared.file_object,

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
         StringOptional,
     )
 
-# pylint: disable=too-many-ancestors
 
 # ---------------------------------------------
 # ASYNC
@@ -106,6 +105,14 @@ class CoreCredential(CoreNode):
     name: String
     label: StringOptional
     description: StringOptional
+
+
+class CoreFileObject(CoreNode):
+    file_name: String
+    checksum: String
+    file_size: Integer
+    file_type: String
+    storage_id: String
 
 
 class CoreGenericAccount(CoreNode):
@@ -227,6 +234,7 @@ class CoreValidator(CoreNode):
 class CoreWebhook(CoreNode):
     name: String
     event_type: Enum
+    active: Boolean
     branch_scope: Dropdown
     node_kind: StringOptional
     description: StringOptional
@@ -499,7 +507,6 @@ class CoreProposedChange(CoreTaskTarget):
     approved_by: RelationshipManager
     rejected_by: RelationshipManager
     reviewers: RelationshipManager
-    created_by: RelatedNode
     comments: RelationshipManager
     threads: RelationshipManager
     validations: RelationshipManager
@@ -665,6 +672,14 @@ class CoreCredentialSync(CoreNodeSync):
     description: StringOptional
 
 
+class CoreFileObjectSync(CoreNodeSync):
+    file_name: String
+    checksum: String
+    file_size: Integer
+    file_type: String
+    storage_id: String
+
+
 class CoreGenericAccountSync(CoreNodeSync):
     name: String
     password: HashedPassword
@@ -784,6 +799,7 @@ class CoreValidatorSync(CoreNodeSync):
 class CoreWebhookSync(CoreNodeSync):
     name: String
     event_type: Enum
+    active: Boolean
     branch_scope: Dropdown
     node_kind: StringOptional
     description: StringOptional
@@ -1056,7 +1072,6 @@ class CoreProposedChangeSync(CoreTaskTargetSync):
     approved_by: RelationshipManagerSync
     rejected_by: RelationshipManagerSync
     reviewers: RelationshipManagerSync
-    created_by: RelatedNodeSync
     comments: RelationshipManagerSync
     threads: RelationshipManagerSync
     validations: RelationshipManagerSync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,10 @@ max-complexity = 17
     "PT013",   # Incorrect import of `pytest`; use `import pytest` instead
 ]
 
+"tests/unit/sdk/test_file_handler.py" = [
+    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
+]
+
 # tests/integration/
 "tests/integration/test_infrahub_client.py" = ["PLR0904"]
 "tests/integration/test_infrahub_client_sync.py" = ["PLR0904"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,7 @@ max-complexity = 17
     # Review and change the below later                                                              #
     ##################################################################################################
     "PLR0912", # Too many branches
+    "PLR0904", # Too many public methods
 ]
 
 "infrahub_sdk/node/related_node.py" = [
@@ -351,7 +352,13 @@ max-complexity = 17
     "PT013",   # Incorrect import of `pytest`; use `import pytest` instead
 ]
 
+"tests/unit/sdk/test_node.py" = [
+    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
+]
 "tests/unit/sdk/test_file_handler.py" = [
+    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
+]
+"tests/unit/sdk/test_file_object.py" = [
     "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,15 +352,6 @@ max-complexity = 17
     "PT013",   # Incorrect import of `pytest`; use `import pytest` instead
 ]
 
-"tests/unit/sdk/test_node.py" = [
-    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
-]
-"tests/unit/sdk/test_file_handler.py" = [
-    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
-]
-"tests/unit/sdk/test_file_object.py" = [
-    "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
-]
 
 # tests/integration/
 "tests/integration/test_infrahub_client.py" = ["PLR0904"]

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -2645,3 +2645,49 @@ async def nested_device_with_interfaces_schema() -> NodeSchemaAPI:
         ],
     }
     return NodeSchema(**data).convert_api()
+
+
+@pytest.fixture
+async def file_object_schema() -> NodeSchemaAPI:
+    """Schema for a node that inherits from CoreFileObject."""
+    data = {
+        "name": "CircuitContract",
+        "namespace": "Network",
+        "label": "Circuit Contract",
+        "default_filter": "file_name__value",
+        "inherit_from": ["CoreFileObject"],
+        "order_by": ["file_name__value"],
+        "display_labels": ["file_name__value"],
+        "attributes": [
+            # Simulate inherited attributes from CoreFileObject
+            {"name": "file_name", "kind": "Text", "read_only": True, "optional": False},
+            {"name": "checksum", "kind": "Text", "read_only": True, "optional": False},
+            {"name": "file_size", "kind": "Number", "read_only": True, "optional": False},
+            {"name": "file_type", "kind": "Text", "read_only": True, "optional": False},
+            {"name": "storage_id", "kind": "Text", "read_only": True, "optional": False},
+            {"name": "contract_start", "kind": "DateTime", "optional": False},
+            {"name": "contract_end", "kind": "DateTime", "optional": False},
+        ],
+        "relationships": [],
+    }
+    return NodeSchema(**data).convert_api()
+
+
+@pytest.fixture
+async def non_file_object_schema() -> NodeSchemaAPI:
+    """Schema for a regular node that does not inherit from CoreFileObject."""
+    data = {
+        "name": "Device",
+        "namespace": "Infra",
+        "label": "Device",
+        "default_filter": "name__value",
+        "inherit_from": [],
+        "order_by": ["name__value"],
+        "display_labels": ["name__value"],
+        "attributes": [
+            {"name": "name", "kind": "Text", "unique": True},
+            {"name": "description", "kind": "Text", "optional": True},
+        ],
+        "relationships": [],
+    }
+    return NodeSchema(**data).convert_api()

--- a/tests/unit/sdk/graphql/test_multipart.py
+++ b/tests/unit/sdk/graphql/test_multipart.py
@@ -1,0 +1,177 @@
+"""Unit tests for MultipartBuilder class."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import ujson
+
+from infrahub_sdk.graphql import MultipartBuilder
+
+
+def test_build_operations_simple() -> None:
+    """Test building operations with simple query and variables."""
+    query = "mutation($file: Upload!) { upload(file: $file) { id } }"
+    variables = {"other": "value"}
+
+    result = MultipartBuilder.build_operations(query=query, variables=variables)
+
+    parsed = ujson.loads(result)
+    assert parsed["query"] == query
+    assert parsed["variables"] == variables
+
+
+def test_build_operations_empty_variables() -> None:
+    """Test building operations with empty variables."""
+    query = "mutation { doSomething { id } }"
+    variables: dict[str, str] = {}
+
+    result = MultipartBuilder.build_operations(query=query, variables=variables)
+
+    parsed = ujson.loads(result)
+    assert parsed["query"] == query
+    assert parsed["variables"] == {}
+
+
+def test_build_operations_complex_variables() -> None:
+    """Test building operations with nested variables."""
+    query = "mutation($input: CreateInput!) { create(input: $input) { id } }"
+    variables = {"input": {"name": "test", "nested": {"value": 123}, "list": [1, 2, 3]}}
+
+    result = MultipartBuilder.build_operations(query=query, variables=variables)
+
+    parsed = ujson.loads(result)
+    assert parsed["variables"]["input"]["name"] == "test"
+    assert parsed["variables"]["input"]["nested"]["value"] == 123
+    assert parsed["variables"]["input"]["list"] == [1, 2, 3]
+
+
+def test_build_file_map_defaults() -> None:
+    """Test building file map with default values."""
+    result = MultipartBuilder.build_file_map()
+
+    parsed = ujson.loads(result)
+    assert parsed == {"0": ["variables.file"]}
+
+
+def test_build_file_map_custom_key() -> None:
+    """Test building file map with custom file key."""
+    result = MultipartBuilder.build_file_map(file_key="1")
+
+    parsed = ujson.loads(result)
+    assert parsed == {"1": ["variables.file"]}
+
+
+def test_build_file_map_custom_path() -> None:
+    """Test building file map with custom variable path."""
+    result = MultipartBuilder.build_file_map(variable_path="variables.input.document")
+
+    parsed = ujson.loads(result)
+    assert parsed == {"0": ["variables.input.document"]}
+
+
+def test_build_file_map_both_custom() -> None:
+    """Test building file map with both custom values."""
+    result = MultipartBuilder.build_file_map(file_key="attachment", variable_path="variables.attachment")
+
+    parsed = ujson.loads(result)
+    assert parsed == {"attachment": ["variables.attachment"]}
+
+
+def test_build_payload_with_file() -> None:
+    """Test building complete payload with file content."""
+    query = "mutation($file: Upload!) { upload(file: $file) { id } }"
+    variables = {"other": "value"}
+    file_content = BytesIO(b"test file content")
+    file_name = "document.pdf"
+
+    result = MultipartBuilder.build_payload(
+        query=query, variables=variables, file_content=file_content, file_name=file_name
+    )
+
+    # Check operations
+    assert "operations" in result
+    assert result["operations"][0] is None  # No filename for operations
+    operations_json = ujson.loads(result["operations"][1])
+    assert operations_json["query"] == query
+    assert operations_json["variables"]["other"] == "value"
+    assert operations_json["variables"]["file"] is None  # File var should be null
+
+    # Check map
+    assert "map" in result
+    assert result["map"][0] is None
+    map_json = ujson.loads(result["map"][1])
+    assert map_json == {"0": ["variables.file"]}
+
+    # Check file
+    assert "0" in result
+    assert result["0"][0] == file_name
+    assert result["0"][1] is file_content
+
+
+def test_build_payload_without_file() -> None:
+    """Test building payload without file content."""
+    query = "mutation($file: Upload!) { upload(file: $file) { id } }"
+    variables = {"other": "value"}
+
+    result = MultipartBuilder.build_payload(query=query, variables=variables, file_content=None, file_name="unused.txt")
+
+    # Should have operations and map
+    assert "operations" in result
+    assert "map" in result
+
+    # Should NOT have file key
+    assert "0" not in result
+
+
+def test_build_payload_sets_file_var_to_null() -> None:
+    """Test that build_payload sets file variable to null per spec."""
+    query = "mutation($file: Upload!) { upload(file: $file) { id } }"
+    variables = {"file": "should_be_overwritten", "other": "value"}
+    file_content = BytesIO(b"content")
+
+    result = MultipartBuilder.build_payload(
+        query=query, variables=variables, file_content=file_content, file_name="test.txt"
+    )
+
+    operations_json = ujson.loads(result["operations"][1])
+    assert operations_json["variables"]["file"] is None
+    assert operations_json["variables"]["other"] == "value"
+
+
+def test_build_payload_default_filename() -> None:
+    """Test that default filename is used when not specified."""
+    query = "mutation($file: Upload!) { upload(file: $file) { id } }"
+    file_content = BytesIO(b"content")
+
+    result = MultipartBuilder.build_payload(
+        query=query,
+        variables={},
+        file_content=file_content,
+    )
+
+    assert result["0"][0] == "upload"
+
+
+def test_build_payload_preserves_existing_variables() -> None:
+    """Test that existing variables are preserved in the payload."""
+    query = "mutation($file: Upload!, $nodeId: ID!) { upload(file: $file, node: $nodeId) { id } }"
+    variables = {
+        "nodeId": "node-123",
+        "description": "A test file",
+        "nested": {"key": "value"},
+    }
+    file_content = BytesIO(b"content")
+
+    result = MultipartBuilder.build_payload(
+        query=query,
+        variables=variables,
+        file_content=file_content,
+        file_name="test.txt",
+    )
+
+    operations_json = ujson.loads(result["operations"][1])
+    assert operations_json["variables"]["nodeId"] == "node-123"
+    assert operations_json["variables"]["description"] == "A test file"
+    assert operations_json["variables"]["nested"] == {"key": "value"}
+    assert operations_json["variables"]["file"] is None  # file is null per spec

--- a/tests/unit/sdk/test_file_handler.py
+++ b/tests/unit/sdk/test_file_handler.py
@@ -47,11 +47,11 @@ def test_prepare_upload_with_bytes_default_name() -> None:
 
 def test_prepare_upload_with_path() -> None:
     """Test preparing upload with Path content."""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
         tmp.write(b"test content from file")
+        tmp.flush()
         tmp_path = Path(tmp.name)
 
-    try:
         prepared = FileHandlerBase.prepare_upload(content=tmp_path)
 
         assert prepared.file_object is not None
@@ -59,24 +59,20 @@ def test_prepare_upload_with_path() -> None:
         assert prepared.should_close is True
         assert prepared.file_object.read() == b"test content from file"
         prepared.file_object.close()
-    finally:
-        tmp_path.unlink()
 
 
 def test_prepare_upload_with_path_custom_name() -> None:
     """Test preparing upload with Path content and custom name."""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
         tmp.write(b"test content")
+        tmp.flush()
         tmp_path = Path(tmp.name)
 
-    try:
         prepared = FileHandlerBase.prepare_upload(content=tmp_path, name="custom_name.txt")
 
         assert prepared.filename == "custom_name.txt"
         assert prepared.file_object
         prepared.file_object.close()
-    finally:
-        tmp_path.unlink()
 
 
 def test_prepare_upload_with_binary_io() -> None:
@@ -201,10 +197,9 @@ async def test_file_handler_download_to_disk(
     """Test streaming file download to disk via FileHandler."""
     client = getattr(clients, client_type)
 
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        dest_path = Path(tmp.name)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest_path = Path(tmpdir) / "downloaded.bin"
 
-    try:
         if client_type == "standard":
             handler = FileHandler(client=client)
             bytes_written = await handler.download(node_id="stream-node", branch="main", dest=dest_path)
@@ -214,8 +209,6 @@ async def test_file_handler_download_to_disk(
 
         assert bytes_written == len(FILE_CONTENT_BYTES)
         assert await anyio.Path(dest_path).read_bytes() == FILE_CONTENT_BYTES
-    finally:
-        await anyio.Path(dest_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_file_handler.py
+++ b/tests/unit/sdk/test_file_handler.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import anyio
 import httpx
 import pytest
 
@@ -212,9 +213,9 @@ async def test_file_handler_download_to_disk(
             bytes_written = handler.download(node_id="stream-node", branch="main", dest=dest_path)
 
         assert bytes_written == len(FILE_CONTENT_BYTES)
-        assert dest_path.read_bytes() == FILE_CONTENT_BYTES
+        assert await anyio.Path(dest_path).read_bytes() == FILE_CONTENT_BYTES
     finally:
-        dest_path.unlink()
+        await anyio.Path(dest_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_file_handler.py
+++ b/tests/unit/sdk/test_file_handler.py
@@ -22,10 +22,10 @@ FILE_CONTENT_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR..."
 NODE_ID = "test-node-123"
 
 
-def test_prepare_upload_with_bytes() -> None:
-    """Test preparing upload with bytes content."""
+async def test_prepare_upload_with_bytes() -> None:
+    """Test preparing upload with bytes content (async)."""
     content = b"test file content"
-    prepared = FileHandlerBase.prepare_upload(content=content, name="test.txt")
+    prepared = await FileHandlerBase.prepare_upload(content=content, name="test.txt")
 
     assert isinstance(prepared, PreparedFile)
     assert prepared.file_object is not None
@@ -35,24 +35,24 @@ def test_prepare_upload_with_bytes() -> None:
     assert prepared.file_object.read() == content
 
 
-def test_prepare_upload_with_bytes_default_name() -> None:
-    """Test preparing upload with bytes content and no name."""
+async def test_prepare_upload_with_bytes_default_name() -> None:
+    """Test preparing upload with bytes content and no name (async)."""
     content = b"test file content"
-    prepared = FileHandlerBase.prepare_upload(content=content)
+    prepared = await FileHandlerBase.prepare_upload(content=content)
 
     assert prepared.file_object is not None
     assert prepared.filename == "uploaded_file"
     assert prepared.should_close is False
 
 
-def test_prepare_upload_with_path() -> None:
-    """Test preparing upload with Path content."""
+async def test_prepare_upload_with_path() -> None:
+    """Test preparing upload with Path content (async, opens in thread pool)."""
     with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
         tmp.write(b"test content from file")
         tmp.flush()
         tmp_path = Path(tmp.name)
 
-        prepared = FileHandlerBase.prepare_upload(content=tmp_path)
+        prepared = await FileHandlerBase.prepare_upload(content=tmp_path)
 
         assert prepared.file_object is not None
         assert prepared.filename == tmp_path.name
@@ -61,33 +61,105 @@ def test_prepare_upload_with_path() -> None:
         prepared.file_object.close()
 
 
-def test_prepare_upload_with_path_custom_name() -> None:
-    """Test preparing upload with Path content and custom name."""
+async def test_prepare_upload_with_path_custom_name() -> None:
+    """Test preparing upload with Path content and custom name (async)."""
     with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
         tmp.write(b"test content")
         tmp.flush()
         tmp_path = Path(tmp.name)
 
-        prepared = FileHandlerBase.prepare_upload(content=tmp_path, name="custom_name.txt")
+        prepared = await FileHandlerBase.prepare_upload(content=tmp_path, name="custom_name.txt")
 
         assert prepared.filename == "custom_name.txt"
         assert prepared.file_object
         prepared.file_object.close()
 
 
-def test_prepare_upload_with_binary_io() -> None:
-    """Test preparing upload with BinaryIO content."""
+async def test_prepare_upload_with_binary_io() -> None:
+    """Test preparing upload with BinaryIO content (async)."""
     content = BytesIO(b"binary io content")
-    prepared = FileHandlerBase.prepare_upload(content=content, name="binary.bin")
+    prepared = await FileHandlerBase.prepare_upload(content=content, name="binary.bin")
 
     assert prepared.file_object is content
     assert prepared.filename == "binary.bin"
     assert prepared.should_close is False
 
 
-def test_prepare_upload_with_none() -> None:
-    """Test preparing upload with None content."""
-    prepared = FileHandlerBase.prepare_upload(content=None)
+async def test_prepare_upload_with_none() -> None:
+    """Test preparing upload with None content (async)."""
+    prepared = await FileHandlerBase.prepare_upload(content=None)
+
+    assert prepared.file_object is None
+    assert prepared.filename is None
+    assert prepared.should_close is False
+
+
+def test_prepare_upload_sync_with_bytes() -> None:
+    """Test preparing upload with bytes content (sync)."""
+    content = b"test file content"
+    prepared = FileHandlerBase.prepare_upload_sync(content=content, name="test.txt")
+
+    assert isinstance(prepared, PreparedFile)
+    assert prepared.file_object is not None
+    assert isinstance(prepared.file_object, BytesIO)
+    assert prepared.filename == "test.txt"
+    assert prepared.should_close is False
+    assert prepared.file_object.read() == content
+
+
+def test_prepare_upload_sync_with_bytes_default_name() -> None:
+    """Test preparing upload with bytes content and no name (sync)."""
+    content = b"test file content"
+    prepared = FileHandlerBase.prepare_upload_sync(content=content)
+
+    assert prepared.file_object is not None
+    assert prepared.filename == "uploaded_file"
+    assert prepared.should_close is False
+
+
+def test_prepare_upload_sync_with_path() -> None:
+    """Test preparing upload with Path content (sync)."""
+    with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
+        tmp.write(b"test content from file")
+        tmp.flush()
+        tmp_path = Path(tmp.name)
+
+        prepared = FileHandlerBase.prepare_upload_sync(content=tmp_path)
+
+        assert prepared.file_object is not None
+        assert prepared.filename == tmp_path.name
+        assert prepared.should_close is True
+        assert prepared.file_object.read() == b"test content from file"
+        prepared.file_object.close()
+
+
+def test_prepare_upload_sync_with_path_custom_name() -> None:
+    """Test preparing upload with Path content and custom name (sync)."""
+    with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
+        tmp.write(b"test content")
+        tmp.flush()
+        tmp_path = Path(tmp.name)
+
+        prepared = FileHandlerBase.prepare_upload_sync(content=tmp_path, name="custom_name.txt")
+
+        assert prepared.filename == "custom_name.txt"
+        assert prepared.file_object
+        prepared.file_object.close()
+
+
+def test_prepare_upload_sync_with_binary_io() -> None:
+    """Test preparing upload with BinaryIO content (sync)."""
+    content = BytesIO(b"binary io content")
+    prepared = FileHandlerBase.prepare_upload_sync(content=content, name="binary.bin")
+
+    assert prepared.file_object is content
+    assert prepared.filename == "binary.bin"
+    assert prepared.should_close is False
+
+
+def test_prepare_upload_sync_with_none() -> None:
+    """Test preparing upload with None content (sync)."""
+    prepared = FileHandlerBase.prepare_upload_sync(content=None)
 
     assert prepared.file_object is None
     assert prepared.filename is None

--- a/tests/unit/sdk/test_file_handler.py
+++ b/tests/unit/sdk/test_file_handler.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from infrahub_sdk.exceptions import AuthenticationError, NodeNotFoundError
+from infrahub_sdk.file_handler import FileHandler, FileHandlerBase, FileHandlerSync, PreparedFile
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+    from tests.unit.sdk.conftest import BothClients
+
+
+FILE_CONTENT_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR..."
+NODE_ID = "test-node-123"
+
+
+def test_prepare_upload_with_bytes() -> None:
+    """Test preparing upload with bytes content."""
+    content = b"test file content"
+    prepared = FileHandlerBase.prepare_upload(content=content, name="test.txt")
+
+    assert isinstance(prepared, PreparedFile)
+    assert prepared.file_object is not None
+    assert isinstance(prepared.file_object, BytesIO)
+    assert prepared.filename == "test.txt"
+    assert prepared.should_close is False
+    assert prepared.file_object.read() == content
+
+
+def test_prepare_upload_with_bytes_default_name() -> None:
+    """Test preparing upload with bytes content and no name."""
+    content = b"test file content"
+    prepared = FileHandlerBase.prepare_upload(content=content)
+
+    assert prepared.file_object is not None
+    assert prepared.filename == "uploaded_file"
+    assert prepared.should_close is False
+
+
+def test_prepare_upload_with_path() -> None:
+    """Test preparing upload with Path content."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as tmp:
+        tmp.write(b"test content from file")
+        tmp_path = Path(tmp.name)
+
+    try:
+        prepared = FileHandlerBase.prepare_upload(content=tmp_path)
+
+        assert prepared.file_object is not None
+        assert prepared.filename == tmp_path.name
+        assert prepared.should_close is True
+        assert prepared.file_object.read() == b"test content from file"
+        prepared.file_object.close()
+    finally:
+        tmp_path.unlink()
+
+
+def test_prepare_upload_with_path_custom_name() -> None:
+    """Test preparing upload with Path content and custom name."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as tmp:
+        tmp.write(b"test content")
+        tmp_path = Path(tmp.name)
+
+    try:
+        prepared = FileHandlerBase.prepare_upload(content=tmp_path, name="custom_name.txt")
+
+        assert prepared.filename == "custom_name.txt"
+        assert prepared.file_object
+        prepared.file_object.close()
+    finally:
+        tmp_path.unlink()
+
+
+def test_prepare_upload_with_binary_io() -> None:
+    """Test preparing upload with BinaryIO content."""
+    content = BytesIO(b"binary io content")
+    prepared = FileHandlerBase.prepare_upload(content=content, name="binary.bin")
+
+    assert prepared.file_object is content
+    assert prepared.filename == "binary.bin"
+    assert prepared.should_close is False
+
+
+def test_prepare_upload_with_none() -> None:
+    """Test preparing upload with None content."""
+    prepared = FileHandlerBase.prepare_upload(content=None)
+
+    assert prepared.file_object is None
+    assert prepared.filename is None
+    assert prepared.should_close is False
+
+
+def test_handle_error_response_401() -> None:
+    """Test handling 401 authentication error."""
+    response = httpx.Response(status_code=401, json={"errors": [{"message": "Invalid token"}]})
+    exc = httpx.HTTPStatusError(message="Unauthorized", request=httpx.Request("GET", "http://test"), response=response)
+
+    with pytest.raises(AuthenticationError) as excinfo:
+        FileHandlerBase.handle_error_response(exc=exc)
+
+    assert "Invalid token" in str(excinfo.value)
+
+
+def test_handle_error_response_403() -> None:
+    """Test handling 403 forbidden error."""
+    response = httpx.Response(status_code=403, json={"errors": [{"message": "Access denied"}]})
+    exc = httpx.HTTPStatusError(message="Forbidden", request=httpx.Request("GET", "http://test"), response=response)
+
+    with pytest.raises(AuthenticationError) as excinfo:
+        FileHandlerBase.handle_error_response(exc=exc)
+
+    assert "Access denied" in str(excinfo.value)
+
+
+def test_handle_error_response_404() -> None:
+    """Test handling 404 not found error."""
+    response = httpx.Response(status_code=404, json={"detail": "File not found with ID abc123"})
+    exc = httpx.HTTPStatusError(message="Not Found", request=httpx.Request("GET", "http://test"), response=response)
+
+    with pytest.raises(NodeNotFoundError) as excinfo:
+        FileHandlerBase.handle_error_response(exc=exc)
+
+    assert "File not found with ID abc123" in str(excinfo.value)
+
+
+def test_handle_error_response_500() -> None:
+    """Test handling 500 server error (re-raises)."""
+    response = httpx.Response(status_code=500, json={"error": "Internal server error"})
+    exc = httpx.HTTPStatusError(message="Server Error", request=httpx.Request("GET", "http://test"), response=response)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        FileHandlerBase.handle_error_response(exc=exc)
+
+
+def test_handle_response_success() -> None:
+    """Test handling successful response."""
+    request = httpx.Request("GET", "http://test")
+    response = httpx.Response(status_code=200, content=FILE_CONTENT_BYTES, request=request)
+
+    result = FileHandlerBase.handle_response(resp=response)
+
+    assert result == FILE_CONTENT_BYTES
+
+
+@pytest.fixture
+def mock_download_success(httpx_mock: HTTPXMock) -> HTTPXMock:
+    """Mock successful file download."""
+    httpx_mock.add_response(
+        method="GET",
+        url="http://mock/api/storage/files/test-node-123?branch=main",
+        content=FILE_CONTENT_BYTES,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    return httpx_mock
+
+
+@pytest.fixture
+def mock_download_stream(httpx_mock: HTTPXMock) -> HTTPXMock:
+    """Mock successful streaming file download."""
+    httpx_mock.add_response(
+        method="GET",
+        url="http://mock/api/storage/files/stream-node?branch=main",
+        content=FILE_CONTENT_BYTES,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    return httpx_mock
+
+
+client_types = ["standard", "sync"]
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_file_handler_download_to_memory(
+    client_type: str, clients: BothClients, mock_download_success: HTTPXMock
+) -> None:
+    """Test downloading file to memory via FileHandler."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        handler = FileHandler(client=client)
+        content = await handler.download(node_id=NODE_ID, branch="main")
+    else:
+        handler = FileHandlerSync(client=client)
+        content = handler.download(node_id=NODE_ID, branch="main")
+
+    assert content == FILE_CONTENT_BYTES
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_file_handler_download_to_disk(
+    client_type: str, clients: BothClients, mock_download_stream: HTTPXMock
+) -> None:
+    """Test streaming file download to disk via FileHandler."""
+    client = getattr(clients, client_type)
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        dest_path = Path(tmp.name)
+
+    try:
+        if client_type == "standard":
+            handler = FileHandler(client=client)
+            bytes_written = await handler.download(node_id="stream-node", branch="main", dest=dest_path)
+        else:
+            handler = FileHandlerSync(client=client)
+            bytes_written = handler.download(node_id="stream-node", branch="main", dest=dest_path)
+
+        assert bytes_written == len(FILE_CONTENT_BYTES)
+        assert dest_path.read_bytes() == FILE_CONTENT_BYTES
+    finally:
+        dest_path.unlink()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_file_handler_build_url_with_branch(client_type: str, clients: BothClients) -> None:
+    """Test URL building with branch parameter."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        handler = FileHandler(client=client)
+    else:
+        handler = FileHandlerSync(client=client)
+
+    url = handler._build_url(node_id="node-123", branch="feature-branch")
+    assert url == "http://mock/api/storage/files/node-123?branch=feature-branch"
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_file_handler_build_url_without_branch(client_type: str, clients: BothClients) -> None:
+    """Test URL building without branch parameter."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        handler = FileHandler(client=client)
+    else:
+        handler = FileHandlerSync(client=client)
+
+    url = handler._build_url(node_id="node-456", branch=None)
+    assert url == "http://mock/api/storage/files/node-456"

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -89,7 +89,7 @@ async def test_node_create_with_file_uses_multipart(
 
     node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
     node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
-    node.set_file(content=FILE_CONTENT, name=FILE_NAME)
+    node.select_content_for_upload(content=FILE_CONTENT, name=FILE_NAME)
 
     if isinstance(node, InfrahubNode):
         await node.save()
@@ -121,7 +121,7 @@ async def test_node_update_with_file_uses_multipart(
     node._existing = True
     node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
     node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
-    node.set_file(content=FILE_CONTENT, name=FILE_NAME)
+    node.select_content_for_upload(content=FILE_CONTENT, name=FILE_NAME)
 
     if isinstance(node, InfrahubNode):
         await node.save()
@@ -173,7 +173,7 @@ async def test_node_save_clears_file_after_upload(
     node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
     node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
 
-    node.set_file(content=FILE_CONTENT, name=FILE_NAME)
+    node.select_content_for_upload(content=FILE_CONTENT, name=FILE_NAME)
     assert node._file_content is not None
     assert node._file_name is not None
 

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -10,9 +10,121 @@ from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
 from infrahub_sdk.schema import NodeSchemaAPI
 from tests.unit.sdk.conftest import BothClients
 
+pytestmark = pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+
 client_types = ["standard", "sync"]
 
-FILE_CONTENT_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR..."
+FILE_CONTENT = b"Test file content"
+FILE_NAME = "contract.pdf"
+FILE_MIME_TYPE = "application/pdf"
+
+
+@pytest.fixture
+def mock_node_save_with_file(httpx_mock: HTTPXMock) -> HTTPXMock:
+    """Mock the HTTP response for node.save() with file upload."""
+    httpx_mock.add_response(
+        method="POST",
+        json={
+            "data": {
+                "NetworkCircuitContractCreate": {
+                    "ok": True,
+                    "object": {
+                        "id": "new-file-node-123",
+                        "display_label": FILE_NAME,
+                        "file_name": {"value": FILE_NAME},
+                        "checksum": {"value": "abc123checksum"},
+                        "file_size": {"value": len(FILE_CONTENT)},
+                        "file_type": {"value": FILE_MIME_TYPE},
+                        "storage_id": {"value": "storage-xyz-789"},
+                        "contract_start": {"value": "2024-01-01T00:00:00Z"},
+                        "contract_end": {"value": "2024-12-31T23:59:59Z"},
+                    },
+                }
+            }
+        },
+        is_reusable=True,
+    )
+    return httpx_mock
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_save_with_file_uses_multipart(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_save_with_file: HTTPXMock
+) -> None:
+    """Test that node.save() with file content sends a multipart request."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+
+    node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
+    node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
+    node.set_file(content=FILE_CONTENT, name=FILE_NAME)
+
+    if isinstance(node, InfrahubNode):
+        await node.save()
+    else:
+        node.save()
+
+    requests = mock_node_save_with_file.get_requests()
+    assert len(requests) == 1
+    assert requests[0].headers.get("x-infrahub-tracker") == "mutation-networkcircuitcontract-create"
+    assert requests[0].headers.get("content-type").startswith("multipart/form-data;")
+    assert b"Content-Disposition: form-data" in requests[0].content
+    assert f'filename="{FILE_NAME}"'.encode() in requests[0].content
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_create_file_object_without_file_raises(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that creating a FileObject node without file content raises an error."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+
+    node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
+    node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
+
+    with pytest.raises(ValueError, match=r"Cannot create .* without file content"):
+        if isinstance(node, InfrahubNode):
+            await node.save()
+        else:
+            node.save()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_save_clears_file_after_upload(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_save_with_file: HTTPXMock
+) -> None:
+    """Test that file content is cleared after successful save."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+
+    node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
+    node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
+
+    node.set_file(content=FILE_CONTENT, name=FILE_NAME)
+    assert node._file_content is not None
+    assert node._file_name is not None
+
+    if isinstance(node, InfrahubNode):
+        await node.save()
+    else:
+        node.save()
+
+    # File content should be cleared after save
+    assert node._file_content is None
+    assert node._file_name is None
 
 
 @pytest.fixture
@@ -20,8 +132,8 @@ def mock_download_file(httpx_mock: HTTPXMock) -> HTTPXMock:
     httpx_mock.add_response(
         method="GET",
         url="http://mock/api/storage/files/file-node-123?branch=main",
-        content=FILE_CONTENT_BYTES,
-        headers={"Content-Type": "image/png", "Content-Disposition": 'attachment; filename="test.png"'},
+        content=FILE_CONTENT,
+        headers={"Content-Type": FILE_MIME_TYPE, "Content-Disposition": f'attachment; filename="{FILE_NAME}"'},
     )
     return httpx_mock
 
@@ -44,7 +156,7 @@ async def test_node_download_file(
     else:
         content = node.download_file()
 
-    assert content == FILE_CONTENT_BYTES
+    assert content == FILE_CONTENT
 
 
 @pytest.fixture
@@ -52,8 +164,8 @@ def mock_download_file_to_disk(httpx_mock: HTTPXMock) -> HTTPXMock:
     httpx_mock.add_response(
         method="GET",
         url="http://mock/api/storage/files/file-node-stream?branch=main",
-        content=FILE_CONTENT_BYTES,
-        headers={"Content-Type": "image/png", "Content-Disposition": 'attachment; filename="test.png"'},
+        content=FILE_CONTENT,
+        headers={"Content-Type": FILE_MIME_TYPE, "Content-Disposition": f'attachment; filename="{FILE_NAME}"'},
     )
     return httpx_mock
 
@@ -79,8 +191,8 @@ async def test_node_download_file_to_disk(
         else:
             bytes_written = node.download_file(dest=dest_path)
 
-        assert bytes_written == len(FILE_CONTENT_BYTES)
-        assert await anyio.Path(dest_path).read_bytes() == FILE_CONTENT_BYTES
+        assert bytes_written == len(FILE_CONTENT)
+        assert await anyio.Path(dest_path).read_bytes() == FILE_CONTENT
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -20,8 +20,8 @@ FILE_MIME_TYPE = "application/pdf"
 
 
 @pytest.fixture
-def mock_node_save_with_file(httpx_mock: HTTPXMock) -> HTTPXMock:
-    """Mock the HTTP response for node.save() with file upload."""
+def mock_node_create_with_file(httpx_mock: HTTPXMock) -> HTTPXMock:
+    """Mock the HTTP response for node create with file upload."""
     httpx_mock.add_response(
         method="POST",
         json={
@@ -47,11 +47,39 @@ def mock_node_save_with_file(httpx_mock: HTTPXMock) -> HTTPXMock:
     return httpx_mock
 
 
+@pytest.fixture
+def mock_node_update_with_file(httpx_mock: HTTPXMock) -> HTTPXMock:
+    """Mock the HTTP response for node update with file upload."""
+    httpx_mock.add_response(
+        method="POST",
+        json={
+            "data": {
+                "NetworkCircuitContractUpdate": {
+                    "ok": True,
+                    "object": {
+                        "id": "existing-file-node-456",
+                        "display_label": FILE_NAME,
+                        "file_name": {"value": FILE_NAME},
+                        "checksum": {"value": "updated123checksum"},
+                        "file_size": {"value": len(FILE_CONTENT)},
+                        "file_type": {"value": FILE_MIME_TYPE},
+                        "storage_id": {"value": "storage-updated-789"},
+                        "contract_start": {"value": "2024-01-01T00:00:00Z"},
+                        "contract_end": {"value": "2024-12-31T23:59:59Z"},
+                    },
+                }
+            }
+        },
+        is_reusable=True,
+    )
+    return httpx_mock
+
+
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_save_with_file_uses_multipart(
-    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_save_with_file: HTTPXMock
+async def test_node_create_with_file_uses_multipart(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_create_with_file: HTTPXMock
 ) -> None:
-    """Test that node.save() with file content sends a multipart request."""
+    """Test that node.save() for create with file content sends a multipart request."""
     client = getattr(clients, client_type)
 
     if client_type == "standard":
@@ -68,9 +96,41 @@ async def test_node_save_with_file_uses_multipart(
     else:
         node.save()
 
-    requests = mock_node_save_with_file.get_requests()
+    requests = mock_node_create_with_file.get_requests()
     assert len(requests) == 1
     assert requests[0].headers.get("x-infrahub-tracker") == "mutation-networkcircuitcontract-create"
+    assert requests[0].headers.get("content-type").startswith("multipart/form-data;")
+    assert b"Content-Disposition: form-data" in requests[0].content
+    assert f'filename="{FILE_NAME}"'.encode() in requests[0].content
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_update_with_file_uses_multipart(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_update_with_file: HTTPXMock
+) -> None:
+    """Test that node.save() for update with file content sends a multipart request."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+
+    # Simulate an existing node
+    node.id = "existing-file-node-456"
+    node._existing = True
+    node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
+    node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
+    node.set_file(content=FILE_CONTENT, name=FILE_NAME)
+
+    if isinstance(node, InfrahubNode):
+        await node.save()
+    else:
+        node.save()
+
+    requests = mock_node_update_with_file.get_requests()
+    assert len(requests) == 1
+    assert requests[0].headers.get("x-infrahub-tracker") == "mutation-networkcircuitcontract-update"
     assert requests[0].headers.get("content-type").startswith("multipart/form-data;")
     assert b"Content-Disposition: form-data" in requests[0].content
     assert f'filename="{FILE_NAME}"'.encode() in requests[0].content
@@ -100,7 +160,7 @@ async def test_node_create_file_object_without_file_raises(
 
 @pytest.mark.parametrize("client_type", client_types)
 async def test_node_save_clears_file_after_upload(
-    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_save_with_file: HTTPXMock
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_node_create_with_file: HTTPXMock
 ) -> None:
     """Test that file content is cleared after successful save."""
     client = getattr(clients, client_type)

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -71,10 +71,9 @@ async def test_node_download_file_to_disk(
         node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
 
     node.id = "file-node-stream"
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        dest_path = Path(tmp.name)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest_path = Path(tmpdir) / "downloaded.bin"
 
-    try:
         if isinstance(node, InfrahubNode):
             bytes_written = await node.download_file(dest=dest_path)
         else:
@@ -82,8 +81,6 @@ async def test_node_download_file_to_disk(
 
         assert bytes_written == len(FILE_CONTENT_BYTES)
         assert await anyio.Path(dest_path).read_bytes() == FILE_CONTENT_BYTES
-    finally:
-        await anyio.Path(dest_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -1,0 +1,125 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from infrahub_sdk.exceptions import FeatureNotSupportedError
+from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
+from infrahub_sdk.schema import NodeSchemaAPI
+from tests.unit.sdk.conftest import BothClients
+
+client_types = ["standard", "sync"]
+
+FILE_CONTENT_BYTES = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR..."
+
+
+@pytest.fixture
+def mock_download_file(httpx_mock: HTTPXMock) -> HTTPXMock:
+    httpx_mock.add_response(
+        method="GET",
+        url="http://mock/api/storage/files/file-node-123?branch=main",
+        content=FILE_CONTENT_BYTES,
+        headers={"Content-Type": "image/png", "Content-Disposition": 'attachment; filename="test.png"'},
+    )
+    return httpx_mock
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_download_file(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_download_file: HTTPXMock
+) -> None:
+    """Test downloading a file from a FileObject node."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+
+    node.id = "file-node-123"
+    if isinstance(node, InfrahubNode):
+        content = await node.download_file()
+    else:
+        content = node.download_file()
+
+    assert content == FILE_CONTENT_BYTES
+
+
+@pytest.fixture
+def mock_download_file_to_disk(httpx_mock: HTTPXMock) -> HTTPXMock:
+    httpx_mock.add_response(
+        method="GET",
+        url="http://mock/api/storage/files/file-node-stream?branch=main",
+        content=FILE_CONTENT_BYTES,
+        headers={"Content-Type": "image/png", "Content-Disposition": 'attachment; filename="test.png"'},
+    )
+    return httpx_mock
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_download_file_to_disk(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI, mock_download_file_to_disk: HTTPXMock
+) -> None:
+    """Test downloading a file from a FileObject node directly to disk."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+
+    node.id = "file-node-stream"
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        dest_path = Path(tmp.name)
+
+    try:
+        if isinstance(node, InfrahubNode):
+            bytes_written = await node.download_file(dest=dest_path)
+        else:
+            bytes_written = node.download_file(dest=dest_path)
+
+        assert bytes_written == len(FILE_CONTENT_BYTES)
+        assert dest_path.read_bytes() == FILE_CONTENT_BYTES
+    finally:
+        dest_path.unlink()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_download_file_not_file_object_raises(
+    client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that download_file raises error on non-FileObject nodes."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=non_file_object_schema, branch="main")
+        with pytest.raises(
+            FeatureNotSupportedError,
+            match=r"calling download_file is only supported for nodes that inherit from CoreFileObject",
+        ):
+            await node.download_file()
+    else:
+        node = InfrahubNodeSync(client=client, schema=non_file_object_schema, branch="main")
+        with pytest.raises(
+            FeatureNotSupportedError,
+            match=r"calling download_file is only supported for nodes that inherit from CoreFileObject",
+        ):
+            node.download_file()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_download_file_unsaved_node_raises(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that download_file raises error on unsaved nodes."""
+    client = getattr(clients, client_type)
+
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=file_object_schema, branch="main")
+        with pytest.raises(ValueError, match=r"Cannot download file for a node that hasn't been saved yet"):
+            await node.download_file()
+    else:
+        node = InfrahubNodeSync(client=client, schema=file_object_schema, branch="main")
+        with pytest.raises(ValueError, match=r"Cannot download file for a node that hasn't been saved yet"):
+            node.download_file()

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -1,6 +1,7 @@
 import tempfile
 from pathlib import Path
 
+import anyio
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -80,9 +81,9 @@ async def test_node_download_file_to_disk(
             bytes_written = node.download_file(dest=dest_path)
 
         assert bytes_written == len(FILE_CONTENT_BYTES)
-        assert dest_path.read_bytes() == FILE_CONTENT_BYTES
+        assert await anyio.Path(dest_path).read_bytes() == FILE_CONTENT_BYTES
     finally:
-        dest_path.unlink()
+        await anyio.Path(dest_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_file_object.py
+++ b/tests/unit/sdk/test_file_object.py
@@ -89,7 +89,7 @@ async def test_node_create_with_file_uses_multipart(
 
     node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
     node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
-    node.select_content_for_upload(content=FILE_CONTENT, name=FILE_NAME)
+    node.upload_from_bytes(content=FILE_CONTENT, name=FILE_NAME)
 
     if isinstance(node, InfrahubNode):
         await node.save()
@@ -121,7 +121,7 @@ async def test_node_update_with_file_uses_multipart(
     node._existing = True
     node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
     node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
-    node.select_content_for_upload(content=FILE_CONTENT, name=FILE_NAME)
+    node.upload_from_bytes(content=FILE_CONTENT, name=FILE_NAME)
 
     if isinstance(node, InfrahubNode):
         await node.save()
@@ -173,7 +173,7 @@ async def test_node_save_clears_file_after_upload(
     node.contract_start.value = "2024-01-01T00:00:00Z"  # type: ignore[union-attr]
     node.contract_end.value = "2024-12-31T23:59:59Z"  # type: ignore[union-attr]
 
-    node.select_content_for_upload(content=FILE_CONTENT, name=FILE_NAME)
+    node.upload_from_bytes(content=FILE_CONTENT, name=FILE_NAME)
     assert node._file_content is not None
     assert node._file_name is not None
 

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -3303,27 +3303,27 @@ async def test_node_is_file_object_false(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_set_file_on_file_object(
+async def test_node_select_content_for_upload_with_bytes(
     client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that set_file works on FileObject nodes."""
+    """Test that select_content_for_upload works with bytes on FileObject nodes."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
     file_content = b"PDF content here"
-    node.set_file(content=file_content, name="contract.pdf")
+    node.select_content_for_upload(content=file_content, name="contract.pdf")
 
     assert node._file_content == file_content
     assert node._file_name == "contract.pdf"
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_set_file_with_path(
+async def test_node_select_file_for_upload(
     client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that set_file works with a Path object."""
+    """Test that select_file_for_upload works with a Path object."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
     else:
@@ -3335,16 +3335,16 @@ async def test_node_set_file_with_path(
         tmp.flush()
         tmp_path = Path(tmp.name)
 
-        node.set_file(content=tmp_path)
+        node.select_file_for_upload(path=tmp_path)
         assert node._file_content == tmp_path
         assert node._file_name == tmp_path.name
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_set_file_with_binary_io(
+async def test_node_select_content_for_upload_with_binary_io(
     client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that set_file works with a BinaryIO object."""
+    """Test that select_content_for_upload works with a BinaryIO object."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
     else:
@@ -3353,25 +3353,38 @@ async def test_node_set_file_with_binary_io(
     file_content = b"Content from BinaryIO"
     file_obj = BytesIO(file_content)
 
-    node.set_file(content=file_obj, name="uploaded.pdf")
+    node.select_content_for_upload(content=file_obj, name="uploaded.pdf")
 
     assert node._file_content == file_obj
     assert node._file_name == "uploaded.pdf"
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_set_file_on_non_file_object_raises(
+async def test_node_select_content_for_upload_on_non_file_object_raises(
     client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that set_file raises FeatureNotSupportedError on non-FileObject nodes."""
-
+    """Test that select_content_for_upload raises FeatureNotSupportedError on non-FileObject nodes."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=non_file_object_schema, branch="main")
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=non_file_object_schema, branch="main")
 
     with pytest.raises(FeatureNotSupportedError, match=r"File upload is not supported"):
-        node.set_file(content=b"some content", name="file.txt")
+        node.select_content_for_upload(content=b"some content", name="file.txt")
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_select_file_for_upload_on_non_file_object_raises(
+    client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that select_file_for_upload raises FeatureNotSupportedError on non-FileObject nodes."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=non_file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=non_file_object_schema, branch="main")
+
+    with pytest.raises(FeatureNotSupportedError, match=r"File upload is not supported"):
+        node.select_file_for_upload(path=Path("/some/file.txt"))
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -3385,7 +3398,7 @@ async def test_node_clear_file(client_type: str, clients: BothClients, file_obje
     file_content = b"Test content"
     file_name = "file.txt"
 
-    node.set_file(content=file_content, name=file_name)
+    node.select_content_for_upload(content=file_content, name=file_name)
     assert node._file_content == file_content
     assert node._file_name == file_name
 
@@ -3406,7 +3419,7 @@ async def test_node_get_file_for_upload_bytes(
 
     file_content = b"Test content"
     file_name = "test.txt"
-    node.set_file(content=file_content, name=file_name)
+    node.select_content_for_upload(content=file_content, name=file_name)
 
     if isinstance(node, InfrahubNode):
         prepared = await node._get_file_for_upload()
@@ -3435,7 +3448,7 @@ async def test_node_get_file_for_upload_path(
         tmp.flush()
         tmp_path = Path(tmp.name)
 
-        node.set_file(content=tmp_path)
+        node.select_file_for_upload(path=tmp_path)
 
         if isinstance(node, InfrahubNode):
             prepared = await node._get_file_for_upload()
@@ -3462,7 +3475,7 @@ async def test_node_get_file_for_upload_binary_io(
     file_content = b"Content from BinaryIO"
     file_name = "test.bin"
     file_obj_input = BytesIO(file_content)
-    node.set_file(content=file_obj_input, name=file_name)
+    node.select_content_for_upload(content=file_obj_input, name=file_name)
 
     if isinstance(node, InfrahubNode):
         prepared = await node._get_file_for_upload()
@@ -3504,7 +3517,7 @@ async def test_node_generate_input_data_with_file(
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
-    node.set_file(content=b"test content", name="test.txt")
+    node.select_content_for_upload(content=b"test content", name="test.txt")
 
     input_data = node._generate_input_data()
 

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -3303,27 +3303,25 @@ async def test_node_is_file_object_false(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_select_content_for_upload_with_bytes(
+async def test_node_upload_from_bytes_with_bytes(
     client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that select_content_for_upload works with bytes on FileObject nodes."""
+    """Test that upload_from_bytes works with bytes on FileObject nodes."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
     file_content = b"PDF content here"
-    node.select_content_for_upload(content=file_content, name="contract.pdf")
+    node.upload_from_bytes(content=file_content, name="contract.pdf")
 
     assert node._file_content == file_content
     assert node._file_name == "contract.pdf"
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_select_file_for_upload(
-    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
-) -> None:
-    """Test that select_file_for_upload works with a Path object."""
+async def test_node_upload_from_path(client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI) -> None:
+    """Test that upload_from_path works with a Path object."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
     else:
@@ -3335,16 +3333,16 @@ async def test_node_select_file_for_upload(
         tmp.flush()
         tmp_path = Path(tmp.name)
 
-        node.select_file_for_upload(path=tmp_path)
+        node.upload_from_path(path=tmp_path)
         assert node._file_content == tmp_path
         assert node._file_name == tmp_path.name
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_select_content_for_upload_with_binary_io(
+async def test_node_upload_from_bytes_with_binary_io(
     client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that select_content_for_upload works with a BinaryIO object."""
+    """Test that upload_from_bytes works with a BinaryIO object."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
     else:
@@ -3353,38 +3351,38 @@ async def test_node_select_content_for_upload_with_binary_io(
     file_content = b"Content from BinaryIO"
     file_obj = BytesIO(file_content)
 
-    node.select_content_for_upload(content=file_obj, name="uploaded.pdf")
+    node.upload_from_bytes(content=file_obj, name="uploaded.pdf")
 
     assert node._file_content == file_obj
     assert node._file_name == "uploaded.pdf"
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_select_content_for_upload_on_non_file_object_raises(
+async def test_node_upload_from_bytes_on_non_file_object_raises(
     client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that select_content_for_upload raises FeatureNotSupportedError on non-FileObject nodes."""
+    """Test that upload_from_bytes raises FeatureNotSupportedError on non-FileObject nodes."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=non_file_object_schema, branch="main")
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=non_file_object_schema, branch="main")
 
     with pytest.raises(FeatureNotSupportedError, match=r"File upload is not supported"):
-        node.select_content_for_upload(content=b"some content", name="file.txt")
+        node.upload_from_bytes(content=b"some content", name="file.txt")
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_node_select_file_for_upload_on_non_file_object_raises(
+async def test_node_upload_from_path_on_non_file_object_raises(
     client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
 ) -> None:
-    """Test that select_file_for_upload raises FeatureNotSupportedError on non-FileObject nodes."""
+    """Test that upload_from_path raises FeatureNotSupportedError on non-FileObject nodes."""
     if client_type == "standard":
         node = InfrahubNode(client=clients.standard, schema=non_file_object_schema, branch="main")
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=non_file_object_schema, branch="main")
 
     with pytest.raises(FeatureNotSupportedError, match=r"File upload is not supported"):
-        node.select_file_for_upload(path=Path("/some/file.txt"))
+        node.upload_from_path(path=Path("/some/file.txt"))
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -3398,7 +3396,7 @@ async def test_node_clear_file(client_type: str, clients: BothClients, file_obje
     file_content = b"Test content"
     file_name = "file.txt"
 
-    node.select_content_for_upload(content=file_content, name=file_name)
+    node.upload_from_bytes(content=file_content, name=file_name)
     assert node._file_content == file_content
     assert node._file_name == file_name
 
@@ -3419,7 +3417,7 @@ async def test_node_get_file_for_upload_bytes(
 
     file_content = b"Test content"
     file_name = "test.txt"
-    node.select_content_for_upload(content=file_content, name=file_name)
+    node.upload_from_bytes(content=file_content, name=file_name)
 
     if isinstance(node, InfrahubNode):
         prepared = await node._get_file_for_upload()
@@ -3448,7 +3446,7 @@ async def test_node_get_file_for_upload_path(
         tmp.flush()
         tmp_path = Path(tmp.name)
 
-        node.select_file_for_upload(path=tmp_path)
+        node.upload_from_path(path=tmp_path)
 
         if isinstance(node, InfrahubNode):
             prepared = await node._get_file_for_upload()
@@ -3475,7 +3473,7 @@ async def test_node_get_file_for_upload_binary_io(
     file_content = b"Content from BinaryIO"
     file_name = "test.bin"
     file_obj_input = BytesIO(file_content)
-    node.select_content_for_upload(content=file_obj_input, name=file_name)
+    node.upload_from_bytes(content=file_obj_input, name=file_name)
 
     if isinstance(node, InfrahubNode):
         prepared = await node._get_file_for_upload()
@@ -3517,7 +3515,7 @@ async def test_node_generate_input_data_with_file(
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
-    node.select_content_for_upload(content=b"test content", name="test.txt")
+    node.upload_from_bytes(content=b"test content", name="test.txt")
 
     input_data = node._generate_input_data()
 

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -7,7 +7,6 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import anyio
 import pytest
 
 from infrahub_sdk.exceptions import FeatureNotSupportedError, NodeNotFoundError
@@ -3331,16 +3330,14 @@ async def test_node_set_file_with_path(
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
     file_content = b"Content from file path"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
         tmp.write(file_content)
+        tmp.flush()
         tmp_path = Path(tmp.name)
 
-    try:
         node.set_file(content=tmp_path)
         assert node._file_content == tmp_path
         assert node._file_name == tmp_path.name
-    finally:
-        await anyio.Path(tmp_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -3430,11 +3427,11 @@ async def test_node_get_file_for_upload_path(
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
     file_content = b"Content from path"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
         tmp.write(file_content)
+        tmp.flush()
         tmp_path = Path(tmp.name)
 
-    try:
         node.set_file(content=tmp_path)
 
         prepared = node._get_file_for_upload()
@@ -3444,8 +3441,6 @@ async def test_node_get_file_for_upload_path(
         assert prepared.should_close  # Path files should be closed after upload
         assert prepared.file_object.read() == file_content
         prepared.file_object.close()
-    finally:
-        await anyio.Path(tmp_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -3485,3 +3480,24 @@ async def test_node_get_file_for_upload_none(
     assert prepared.file_object is None
     assert prepared.filename is None
     assert not prepared.should_close
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_generate_input_data_with_file(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test _generate_input_data places file at mutation level, not inside data."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    node.set_file(content=b"test content", name="test.txt")
+
+    input_data = node._generate_input_data()
+
+    assert "file" in input_data["data"], "file should be at mutation payload level"
+    assert input_data["data"]["file"] == "$file"
+    assert "file" not in input_data["data"]["data"], "file should not be inside nested data dict"
+    assert "file" in input_data["mutation_variables"]
+    assert input_data["mutation_variables"]["file"] is bytes

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import anyio
 import pytest
 
 from infrahub_sdk.exceptions import FeatureNotSupportedError, NodeNotFoundError
@@ -3339,7 +3340,7 @@ async def test_node_set_file_with_path(
         assert node._file_content == tmp_path
         assert node._file_name == tmp_path.name
     finally:
-        tmp_path.unlink()
+        await anyio.Path(tmp_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -3444,7 +3445,7 @@ async def test_node_get_file_for_upload_path(
         assert prepared.file_object.read() == file_content
         prepared.file_object.close()
     finally:
-        tmp_path.unlink()
+        await anyio.Path(tmp_path).unlink()
 
 
 @pytest.mark.parametrize("client_type", client_types)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -3408,7 +3408,10 @@ async def test_node_get_file_for_upload_bytes(
     file_name = "test.txt"
     node.set_file(content=file_content, name=file_name)
 
-    prepared = node._get_file_for_upload()
+    if isinstance(node, InfrahubNode):
+        prepared = await node._get_file_for_upload()
+    else:
+        prepared = node._get_file_for_upload_sync()
 
     assert prepared.file_object
     assert prepared.filename == file_name
@@ -3434,7 +3437,10 @@ async def test_node_get_file_for_upload_path(
 
         node.set_file(content=tmp_path)
 
-        prepared = node._get_file_for_upload()
+        if isinstance(node, InfrahubNode):
+            prepared = await node._get_file_for_upload()
+        else:
+            prepared = node._get_file_for_upload_sync()
 
         assert prepared.file_object
         assert prepared.filename == tmp_path.name
@@ -3458,7 +3464,10 @@ async def test_node_get_file_for_upload_binary_io(
     file_obj_input = BytesIO(file_content)
     node.set_file(content=file_obj_input, name=file_name)
 
-    prepared = node._get_file_for_upload()
+    if isinstance(node, InfrahubNode):
+        prepared = await node._get_file_for_upload()
+    else:
+        prepared = node._get_file_for_upload_sync()
 
     assert prepared.file_object is file_obj_input  # Should be the same object
     assert prepared.filename == file_name
@@ -3475,7 +3484,10 @@ async def test_node_get_file_for_upload_none(
     else:
         node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
 
-    prepared = node._get_file_for_upload()
+    if isinstance(node, InfrahubNode):
+        prepared = await node._get_file_for_upload()
+    else:
+        prepared = node._get_file_for_upload_sync()
 
     assert prepared.file_object is None
     assert prepared.filename is None

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import inspect
 import ipaddress
+import tempfile
+from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub_sdk.exceptions import NodeNotFoundError
+from infrahub_sdk.exceptions import FeatureNotSupportedError, NodeNotFoundError
 from infrahub_sdk.node import (
     InfrahubNode,
     InfrahubNodeBase,
@@ -3271,3 +3274,213 @@ def test_relationship_manager_generate_query_data_without_include_metadata() -> 
     assert "count" in data
     assert "edges" in data
     assert "node" in data["edges"]
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_is_file_object_true(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that is_file_object returns True for nodes inheriting from CoreFileObject."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    assert node.is_file_object()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_is_file_object_false(
+    client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that is_file_object returns False for regular nodes."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=non_file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=non_file_object_schema, branch="main")
+
+    assert not node.is_file_object()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_set_file_on_file_object(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that set_file works on FileObject nodes."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"PDF content here"
+    node.set_file(content=file_content, name="contract.pdf")
+
+    assert node._file_content == file_content
+    assert node._file_name == "contract.pdf"
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_set_file_with_path(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that set_file works with a Path object."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"Content from file path"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(file_content)
+        tmp_path = Path(tmp.name)
+
+    try:
+        node.set_file(content=tmp_path)
+        assert node._file_content == tmp_path
+        assert node._file_name == tmp_path.name
+    finally:
+        tmp_path.unlink()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_set_file_with_binary_io(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that set_file works with a BinaryIO object."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"Content from BinaryIO"
+    file_obj = BytesIO(file_content)
+
+    node.set_file(content=file_obj, name="uploaded.pdf")
+
+    assert node._file_content == file_obj
+    assert node._file_name == "uploaded.pdf"
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_set_file_on_non_file_object_raises(
+    client_type: str, clients: BothClients, non_file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test that set_file raises FeatureNotSupportedError on non-FileObject nodes."""
+
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=non_file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=non_file_object_schema, branch="main")
+
+    with pytest.raises(FeatureNotSupportedError, match=r"File upload is not supported"):
+        node.set_file(content=b"some content", name="file.txt")
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_clear_file(client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI) -> None:
+    """Test that clear_file removes pending file content."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"Test content"
+    file_name = "file.txt"
+
+    node.set_file(content=file_content, name=file_name)
+    assert node._file_content == file_content
+    assert node._file_name == file_name
+
+    node.clear_file()
+    assert node._file_content is None
+    assert node._file_name is None
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_get_file_for_upload_bytes(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test _get_file_for_upload with bytes returns PreparedFile with BytesIO."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"Test content"
+    file_name = "test.txt"
+    node.set_file(content=file_content, name=file_name)
+
+    prepared = node._get_file_for_upload()
+
+    assert prepared.file_object
+    assert prepared.filename == file_name
+    assert not prepared.should_close
+    assert prepared.file_object.read() == file_content
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_get_file_for_upload_path(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test _get_file_for_upload with Path returns PreparedFile with opened file handle."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"Content from path"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(file_content)
+        tmp_path = Path(tmp.name)
+
+    try:
+        node.set_file(content=tmp_path)
+
+        prepared = node._get_file_for_upload()
+
+        assert prepared.file_object
+        assert prepared.filename == tmp_path.name
+        assert prepared.should_close  # Path files should be closed after upload
+        assert prepared.file_object.read() == file_content
+        prepared.file_object.close()
+    finally:
+        tmp_path.unlink()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_get_file_for_upload_binary_io(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test _get_file_for_upload with BinaryIO returns PreparedFile with the same object."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    file_content = b"Content from BinaryIO"
+    file_name = "test.bin"
+    file_obj_input = BytesIO(file_content)
+    node.set_file(content=file_obj_input, name=file_name)
+
+    prepared = node._get_file_for_upload()
+
+    assert prepared.file_object is file_obj_input  # Should be the same object
+    assert prepared.filename == file_name
+    assert not prepared.should_close  # BinaryIO provided by user shouldn't be closed
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_get_file_for_upload_none(
+    client_type: str, clients: BothClients, file_object_schema: NodeSchemaAPI
+) -> None:
+    """Test _get_file_for_upload with no file set returns PreparedFile with None values."""
+    if client_type == "standard":
+        node = InfrahubNode(client=clients.standard, schema=file_object_schema, branch="main")
+    else:
+        node = InfrahubNodeSync(client=clients.sync, schema=file_object_schema, branch="main")
+
+    prepared = node._get_file_for_upload()
+
+    assert prepared.file_object is None
+    assert prepared.filename is None
+    assert not prepared.should_close


### PR DESCRIPTION
This change adds support to create, update and retrieve nodes which schemas implement `CoreFileObject`.

The proposed user exposed API follows these key points:
- `node.upload_from_path(path)` to select a file from disk for upload (streams during upload)
- `node.upload_from_bytes(content, name)` to set content for upload (supports bytes or BinaryIO)
- `node.download_file(dest)`  to download a file to memory or stream to disk

Being able to stream a file to disk or from a disk is important in order to support large files and to avoid them being loaded completely into memory (which would be problematic for +1GB files in general).

The choice of using `upload_from_path` and `upload_from_bytes` is to prevent a collision with a potential attribute or relationship called `file` in the schema. That is also the reason why the `file` GraphQL parameter is outside the `data` one instead of inside it.

Here we introduce a couple of components to try to make our code SOLID (it's not much for now, but it's honest work):
- `FileHandler` / `FileHandlerSync` dedicated classes for file I/O operations
- `MultipartBuilder` GraphQL Multipart Request Spec payload building

It sure won't make our code SOLID but it won't add to the burden for now.

So given the user who loaded a schema, using our SDK will look like:

####  Upload a file when creating a node

```python
from pathlib import Path
from infrahub_sdk import InfrahubClientSync

client = InfrahubClientSync()

contract = client.create(
    kind="NetworkCircuitContract", contract_start="2026-01-01", contract_end="2026-12-31"
)

# Option 1: Select file from disk (will be streamed during upload)
contract.upload_from_path(path=Path("/tmp/contract.pdf"))

# Option 2: Upload from memory (for small files or dynamically generated content)
contract.upload_from_bytes(content=b"file content", name="contract.pdf")

# Save as usual
contract.save()
```

#### Download a file from a node

```python
from pathlib import Path

contract = client.get(kind="NetworkCircuitContract", id="abc123")

# Download to memory (suitable for small files)
content = contract.download_file()

# Or stream directly to disk (suitable for large files)
bytes_written = contract.download_file(dest=Path("/tmp/downloaded.pdf"))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GraphQL multipart file upload support and node-level file attach/clear APIs.
  * File download for file-like nodes (in-memory or streamed to disk).
  * Streaming GET responses and improved proxy/config handling for network requests.

* **Tests**
  * Comprehensive unit tests for multipart uploads, file preparation, downloads/streaming, and node file workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->