### PR TITLE
add str method to JinjaTemplateError

### DIFF
--- a/infrahub_sdk/template/exceptions.py
+++ b/infrahub_sdk/template/exceptions.py
@@ -12,6 +12,9 @@ class JinjaTemplateError(Error):
     def __init__(self, message: str) -> None:
         self.message = message
 
+    def __str__(self) -> str:
+        return self.message
+
 
 class JinjaTemplateNotFoundError(JinjaTemplateError):
     def __init__(self, message: str | None, filename: str, base_template: str | None = None) -> None:

--- a/infrahub_sdk/template/exceptions.py
+++ b/infrahub_sdk/template/exceptions.py
@@ -13,7 +13,7 @@ class JinjaTemplateError(Error):
         self.message = message
 
     def __str__(self) -> str:
-        return self.message
+        return str(self.message)
 
 
 class JinjaTemplateNotFoundError(JinjaTemplateError):


### PR DESCRIPTION
add `__str__` to Jinja templates so that they can be correctly displayed when passed into `str()`

one of these errors was raised during a migration and passed into `str`, which resulted in an empty string and made troubleshooting harder than it needed to be

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template error messages now present correctly when converted to strings, improving readability in logs and user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->