### PR TITLE
feat: IHS-190 (part of IFC-2162) Add namespace restriction parameter to generic schemas

### DIFF
--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -289,7 +289,9 @@ class GenericSchemaAPI(BaseSchema, BaseSchemaAttrRelAPI):
     """A Generic can be either an Interface or a Union depending if there are some Attributes or Relationships defined."""
 
     hash: str | None = None
+    hierarchical: bool | None = None
     used_by: list[str] = Field(default_factory=list)
+    restricted_namespaces: list[str] | None = None
 
 
 class BaseNodeSchema(BaseSchema):

--- a/tests/fixtures/models/valid_generic_schema.json
+++ b/tests/fixtures/models/valid_generic_schema.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0",
+    "generics": [
+        {
+            "name": "Animal",
+            "namespace": "Testing",
+            "attributes": [
+                {
+                    "name": "name",
+                    "kind": "Text"
+                }
+            ],
+            "restricted_namespaces": ["Dog"]
+        }
+    ],
+    "nodes": [
+        {
+            "name": "Dog",
+            "namespace": "Dog",
+            "inherit_from": ["TestingAnimal"],
+            "attributes": [
+                {
+                    "name": "breed",
+                    "kind": "Text",
+                    "optional": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/unit/ctl/test_schema_app.py
+++ b/tests/unit/ctl/test_schema_app.py
@@ -128,3 +128,48 @@ def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock) -> None:
         fixture_file.read_text(encoding="utf-8"),
     )
     assert content_json == {"schemas": [fixture_file_content]}
+
+
+def test_load_valid_generic_schema(httpx_mock: HTTPXMock) -> None:
+    """A test which ensures that a generic schema is correctly loaded when loaded from infrahubctl command"""
+
+    # Arrange
+    fixture_file = get_fixtures_dir() / "models" / "valid_generic_schema.json"
+
+    httpx_mock.add_response(
+        method="POST",
+        url="http://mock/api/schema/load?branch=main",
+        status_code=200,
+        json={
+            "hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+            "previous_hash": "d3f7f4e7161f0ae6538a01d5a42dc661",
+            "diff": {
+                "added": {
+                    "TestingAnimal": {"added": {}, "changed": {}, "removed": {}},
+                    "DogDog": {"added": {}, "changed": {}, "removed": {}},
+                },
+                "changed": {},
+                "removed": {},
+            },
+            "schema_updated": True,
+        },
+    )
+
+    # Act
+    result = runner.invoke(app=app, args=["load", str(fixture_file)])
+
+    # Assert
+    assert result.exit_code == 0
+    assert f"schema '{fixture_file}' loaded successfully" in remove_ansi_color(result.stdout.replace("\n", ""))
+
+    content = httpx_mock.get_requests()[0].content.decode("utf8")
+    content_json = yaml.safe_load(content)
+    fixture_file_content = yaml.safe_load(
+        fixture_file.read_text(encoding="utf-8"),
+    )
+    assert content_json == {"schemas": [fixture_file_content]}
+
+    # Verify restricted_namespaces is present in the payload sent to the API
+    sent_generics = content_json["schemas"][0]["generics"]
+    assert len(sent_generics) == 1
+    assert sent_generics[0]["restricted_namespaces"] == ["Dog"]

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock
@@ -482,3 +483,56 @@ def test_schema_base__get_schema_name__returns_correct_schema_name_for_protocols
     assert InfrahubSchemaBase._get_schema_name(schema=BuiltinIPAddressSync) == "BuiltinIPAddress"
     assert InfrahubSchemaBase._get_schema_name(schema=BuiltinIPAddress) == "BuiltinIPAddress"
     assert InfrahubSchemaBase._get_schema_name(schema="BuiltinIPAddress") == "BuiltinIPAddress"
+
+
+async def test_schema_load_rejected_when_node_namespace_violates_generic_restricted_namespaces(
+    client: InfrahubClient, httpx_mock: HTTPXMock
+) -> None:
+    """Validate that loading a schema with a node whose namespace violates the generic's restricted_namespaces
+    is rejected. One test is already testing the API internal behavior
+    tests.integration.schema_lifecycle.test_restricted_namespaces_validation.
+    TestRestrictedNamespacesValidation.test_change_restriction_should_fail"""
+    # Arrange
+    schema_payload = {
+        "version": "1.0",
+        "generics": [
+            {
+                "name": "Animal",
+                "namespace": "Testing",
+                "attributes": [{"name": "name", "kind": "Text"}],
+                "restricted_namespaces": ["Dog"],
+            }
+        ],
+        "nodes": [
+            {
+                "name": "Cat",
+                "namespace": "Cat",
+                "inherit_from": ["TestingAnimal"],
+                "attributes": [{"name": "breed", "kind": "Text", "optional": True}],
+            }
+        ],
+    }
+
+    error_message = (
+        "Generic node 'TestingAnimal' has restricted namespaces: ['Dog']. "
+        "The node 'CatCat' does not comply with this restriction as its namespace is 'Cat'."
+    )
+
+    httpx_mock.add_response(
+        method="POST",
+        url="http://mock/api/schema/load?branch=main",
+        status_code=422,
+        json={
+            "data": None,
+            "errors": [{"message": error_message, "extensions": {"code": 422}}],
+        },
+    )
+
+    # Act
+    response = await client.schema.load(schemas=[schema_payload])
+
+    # Assert
+    assert response.errors
+    error_message = response.errors["errors"][0]["message"]
+    assert re.search(r"(?s)restricted namespaces(?=.*Dog)(?=.*Cat)", error_message)
+    assert not response.schema_updated

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -1,5 +1,4 @@
 import inspect
-import re
 from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock
@@ -485,38 +484,11 @@ def test_schema_base__get_schema_name__returns_correct_schema_name_for_protocols
     assert InfrahubSchemaBase._get_schema_name(schema="BuiltinIPAddress") == "BuiltinIPAddress"
 
 
-async def test_schema_load_rejected_when_node_namespace_violates_generic_restricted_namespaces(
-    client: InfrahubClient, httpx_mock: HTTPXMock
-) -> None:
-    """Validate that loading a schema with a node whose namespace violates the generic's restricted_namespaces
-    is rejected. One test is already testing the API internal behavior
-    tests.integration.schema_lifecycle.test_restricted_namespaces_validation.
-    TestRestrictedNamespacesValidation.test_change_restriction_should_fail"""
+async def test_schema_load_surfaces_api_error_on_422(client: InfrahubClient, httpx_mock: HTTPXMock) -> None:
+    """Validate that schema.load surfaces API error responses to the caller."""
     # Arrange
-    schema_payload = {
-        "version": "1.0",
-        "generics": [
-            {
-                "name": "Animal",
-                "namespace": "Testing",
-                "attributes": [{"name": "name", "kind": "Text"}],
-                "restricted_namespaces": ["Dog"],
-            }
-        ],
-        "nodes": [
-            {
-                "name": "Cat",
-                "namespace": "Cat",
-                "inherit_from": ["TestingAnimal"],
-                "attributes": [{"name": "breed", "kind": "Text", "optional": True}],
-            }
-        ],
-    }
-
-    error_message = (
-        "Generic node 'TestingAnimal' has restricted namespaces: ['Dog']. "
-        "The node 'CatCat' does not comply with this restriction as its namespace is 'Cat'."
-    )
+    schema_payload = {"version": "1.0", "nodes": [{"name": "Dummy", "namespace": "Test"}]}
+    api_error_message = "Something went wrong on the server side."
 
     httpx_mock.add_response(
         method="POST",
@@ -524,7 +496,7 @@ async def test_schema_load_rejected_when_node_namespace_violates_generic_restric
         status_code=422,
         json={
             "data": None,
-            "errors": [{"message": error_message, "extensions": {"code": 422}}],
+            "errors": [{"message": api_error_message, "extensions": {"code": 422}}],
         },
     )
 
@@ -533,6 +505,5 @@ async def test_schema_load_rejected_when_node_namespace_violates_generic_restric
 
     # Assert
     assert response.errors
-    error_message = response.errors["errors"][0]["message"]
-    assert re.search(r"(?s)restricted namespaces(?=.*Dog)(?=.*Cat)", error_message)
+    assert response.errors["errors"][0]["message"] == api_error_message
     assert not response.schema_updated


### PR DESCRIPTION
To understand the global feature, see this PR: https://github.com/opsmill/infrahub/pull/8319

This PR is about updating `infrahub_sdk.schema.main.GenericSchemaAPI` with the new generic schema parameter "restricted_namespaces".

### Goal
See https://github.com/opsmill/infrahub/pull/8319

### Non-goals
Added another missing attribute to `infrahub_sdk.schema.main.GenericSchemaAPI`: hierarchical. This attribute was already into the internal Infrahub generic schema model.

### What changed
Generic schemas into SDK API.

### How-to review
This PR is quite small: commit by commit, in the chronological order.

### How to test

**Automated back-end tests:**

`uv run pytest tests/unit/ctl/test_schema_app.py tests/unit/sdk/test_schema.py
`
- new test loading a generic schema through infrahubctl command, Infrahub API is mocked
- new test ensuring that a schema not following the namespace restriction rule is rejected with the correct error message when loaded from python-sdk utilities. Infrahub API is mocked.

**Application testing scenarios:**

- Load a valid generic schema from SDK API using the new attribute "restricted_namespaces".
- Load an invalid schema from SDK API not following the namespace restriction rule.

### Impact & rollout
Deployment notes: safe to deploy

Closes IHS-190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "hierarchical" and "restricted namespaces" configuration options to the schema API.

* **Tests**
  * Added tests for loading generic schemas that include namespace restrictions.
  * Added tests to surface API error handling when schema load requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->