### PR TITLE
Add invoke command specifically for code linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,17 @@ Infrahub Python SDK - async/sync client for Infrahub infrastructure management.
 ```bash
 uv sync --all-groups --all-extras   # Install all deps
 uv run invoke format                # Format code
-uv run invoke lint                  # Lint (ruff + mypy + yamllint)
+uv run invoke lint                  # All linters (code + yamllint + documentation)
+uv run invoke lint-code             # All linters for Python code
 uv run pytest tests/unit/           # Unit tests
 uv run pytest tests/integration/    # Integration tests
 ```
 
-## Tech Stack
+## Tech stack
 
 Python 3.10-3.13, UV, pydantic >=2.0, httpx, graphql-core
 
-## Code Pattern
+## Code pattern
 
 ```python
 # Always provide both async and sync versions
@@ -27,7 +28,7 @@ node = await client.get(kind="NetworkDevice")
 await node.save()
 ```
 
-## Project Structure
+## Project structure
 
 ```text
 infrahub_sdk/
@@ -38,7 +39,7 @@ infrahub_sdk/
 └── pytest_plugin/      # Custom pytest plugin
 ```
 
-## Markdown Style
+## Markdown style
 
 When editing `.md` or `.mdx` files, run `uv run invoke lint-docs` before committing.
 
@@ -52,7 +53,7 @@ Key rules:
 
 ✅ **Always**
 
-- Run `uv run invoke format lint` before committing Python code
+- Run `uv run invoke format lint-code` before committing Python code
 - Run markdownlint before committing markdown changes
 - Follow async/sync dual pattern for new features
 - Use type hints on all function signatures
@@ -69,7 +70,7 @@ Key rules:
 - Modify generated code (protocols.py)
 - Bypass type checking without justification
 
-## Subdirectory Guides
+## Subdirectory guides
 
 - [docs/AGENTS.md](docs/AGENTS.md) - Documentation (Docusaurus)
 - [infrahub_sdk/ctl/AGENTS.md](infrahub_sdk/ctl/AGENTS.md) - CLI development

--- a/tasks.py
+++ b/tasks.py
@@ -219,6 +219,14 @@ def lint_vale(context: Context) -> None:
 
 
 @task
+def lint_code(context: Context) -> None:
+    """Run all code linters."""
+    lint_ruff(context)
+    lint_ty(context)
+    lint_mypy(context)
+
+
+@task
 def lint_docs(context: Context) -> None:
     """Run all documentation linters."""
     lint_markdownlint(context)
@@ -229,9 +237,7 @@ def lint_docs(context: Context) -> None:
 def lint_all(context: Context) -> None:
     """Run all linters."""
     lint_yaml(context)
-    lint_ruff(context)
-    lint_ty(context)
-    lint_mypy(context)
+    lint_code(context)
     lint_docs(context)
 
 


### PR DESCRIPTION
Adds a specific invoke command for all code linters. The reason for this is to prevent AI tools from constantly running yaml lint or documentation linting when we've only updated actual code.

The PR also include some minor changes to the AGENTS.md file to include the new command as well as some cleanup of headers with regards to the vale styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated linting documentation with clearer command descriptions, normalized section headings, and expanded subdirectory guides.

* **Refactor**
  * Reorganized linting task structure to consolidate code linting operations into a unified command workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->