### PR TITLE
Linting: Incorrect import of `pytest`; use `import pytest` instead

### DIFF
--- a/infrahub_sdk/pytest_plugin/items/check.py
+++ b/infrahub_sdk/pytest_plugin/items/check.py
@@ -12,7 +12,7 @@ from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
 
 if TYPE_CHECKING:
-    from pytest import ExceptionInfo
+    import pytest
 
     from ...checks import InfrahubCheck
     from ...schema.repository import InfrahubRepositoryConfigElement
@@ -46,7 +46,7 @@ class InfrahubCheckItem(InfrahubItem):
         self.instantiate_check()
         return asyncio.run(self.check_instance.run(data=variables))
 
-    def repr_failure(self, excinfo: ExceptionInfo, style: str | None = None) -> str:
+    def repr_failure(self, excinfo: pytest.ExceptionInfo, style: str | None = None) -> str:
         if isinstance(excinfo.value, HTTPStatusError):
             try:
                 response_content = ujson.dumps(excinfo.value.response.json(), indent=4)

--- a/infrahub_sdk/pytest_plugin/items/graphql_query.py
+++ b/infrahub_sdk/pytest_plugin/items/graphql_query.py
@@ -11,7 +11,7 @@ from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
 
 if TYPE_CHECKING:
-    from pytest import ExceptionInfo
+    import pytest
 
 
 class InfrahubGraphQLQueryItem(InfrahubItem):
@@ -25,7 +25,7 @@ class InfrahubGraphQLQueryItem(InfrahubItem):
             variables=self.test.spec.get_variables_data(),  # type: ignore[union-attr]
         )
 
-    def repr_failure(self, excinfo: ExceptionInfo, style: str | None = None) -> str:
+    def repr_failure(self, excinfo: pytest.ExceptionInfo, style: str | None = None) -> str:
         if isinstance(excinfo.value, HTTPStatusError):
             try:
                 response_content = ujson.dumps(excinfo.value.response.json(), indent=4)

--- a/infrahub_sdk/pytest_plugin/items/jinja2_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/jinja2_transform.py
@@ -16,7 +16,7 @@ from ..models import InfrahubInputOutputTest, InfrahubTestExpectedResult
 from .base import InfrahubItem
 
 if TYPE_CHECKING:
-    from pytest import ExceptionInfo
+    import pytest
 
 
 class InfrahubJinja2Item(InfrahubItem):
@@ -57,7 +57,7 @@ class InfrahubJinja2Item(InfrahubItem):
         )
         return "\n".join(differences)
 
-    def repr_failure(self, excinfo: ExceptionInfo, style: str | None = None) -> str:
+    def repr_failure(self, excinfo: pytest.ExceptionInfo, style: str | None = None) -> str:
         if isinstance(excinfo.value, HTTPStatusError):
             try:
                 response_content = ujson.dumps(excinfo.value.response.json(), indent=4, sort_keys=True)
@@ -94,7 +94,7 @@ class InfrahubJinja2TransformUnitRenderItem(InfrahubJinja2Item):
         if computed is not None and differences and self.test.expect == InfrahubTestExpectedResult.PASS:
             raise OutputMatchError(name=self.name, differences=differences)
 
-    def repr_failure(self, excinfo: ExceptionInfo, style: str | None = None) -> str:
+    def repr_failure(self, excinfo: pytest.ExceptionInfo, style: str | None = None) -> str:
         if isinstance(excinfo.value, (JinjaTemplateError)):
             return str(excinfo.value.message)
 

--- a/infrahub_sdk/pytest_plugin/items/python_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/python_transform.py
@@ -13,7 +13,7 @@ from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
 
 if TYPE_CHECKING:
-    from pytest import ExceptionInfo
+    import pytest
 
     from ...schema.repository import InfrahubRepositoryConfigElement
     from ...transforms import InfrahubTransform
@@ -48,7 +48,7 @@ class InfrahubPythonTransformItem(InfrahubItem):
         self.instantiate_transform()
         return asyncio.run(self.transform_instance.run(data=variables))
 
-    def repr_failure(self, excinfo: ExceptionInfo, style: str | None = None) -> str:
+    def repr_failure(self, excinfo: pytest.ExceptionInfo, style: str | None = None) -> str:
         if isinstance(excinfo.value, HTTPStatusError):
             try:
                 response_content = ujson.dumps(excinfo.value.response.json(), indent=4)

--- a/infrahub_sdk/pytest_plugin/loader.py
+++ b/infrahub_sdk/pytest_plugin/loader.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 import yaml
-from pytest import Item
 
 from .exceptions import InvalidResourceConfigError
 from .items import (
@@ -66,7 +65,7 @@ class InfrahubYamlFile(pytest.File):
 
         return resource_config
 
-    def collect_group(self, group: InfrahubTestGroup) -> Iterable[Item]:
+    def collect_group(self, group: InfrahubTestGroup) -> Iterable[pytest.Item]:
         """Collect all items for a group."""
         marker = MARKER_MAPPING[group.resource]
         resource_config = self.get_resource_config(group)
@@ -98,7 +97,7 @@ class InfrahubYamlFile(pytest.File):
 
             yield item
 
-    def collect(self) -> Iterable[Item]:
+    def collect(self) -> Iterable[pytest.Item]:
         raw = yaml.safe_load(self.path.open(encoding="utf-8"))
 
         if "infrahub_tests" not in raw:

--- a/infrahub_sdk/pytest_plugin/plugin.py
+++ b/infrahub_sdk/pytest_plugin/plugin.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from pytest import Collector, Config, Item, Parser, Session
-from pytest import exit as exit_test
+import pytest
 
 from .. import InfrahubClientSync
 from ..utils import is_valid_url
@@ -12,7 +11,7 @@ from .loader import InfrahubYamlFile
 from .utils import find_repository_config_file, load_repository_config
 
 
-def pytest_addoption(parser: Parser) -> None:
+def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("pytest-infrahub")
     group.addoption(
         "--infrahub-repo-config",
@@ -62,7 +61,7 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
 
-def pytest_sessionstart(session: Session) -> None:
+def pytest_sessionstart(session: pytest.Session) -> None:
     if session.config.option.infrahub_repo_config:
         session.infrahub_config_path = Path(session.config.option.infrahub_repo_config)  # type: ignore[attr-defined]
     else:
@@ -72,7 +71,7 @@ def pytest_sessionstart(session: Session) -> None:
         session.infrahub_repo_config = load_repository_config(repo_config_file=session.infrahub_config_path)  # type: ignore[attr-defined]
 
     if not is_valid_url(session.config.option.infrahub_address):
-        exit_test("Infrahub test instance address is not a valid URL", returncode=1)
+        pytest.exit("Infrahub test instance address is not a valid URL", returncode=1)
 
     client_config = {
         "address": session.config.option.infrahub_address,
@@ -89,13 +88,13 @@ def pytest_sessionstart(session: Session) -> None:
     session.infrahub_client = infrahub_client  # type: ignore[attr-defined]
 
 
-def pytest_collect_file(parent: Collector | Item, file_path: Path) -> InfrahubYamlFile | None:
+def pytest_collect_file(parent: pytest.Collector | pytest.Item, file_path: Path) -> InfrahubYamlFile | None:
     if file_path.suffix in {".yml", ".yaml"} and file_path.name.startswith("test_"):
         return InfrahubYamlFile.from_parent(parent, path=file_path)
     return None
 
 
-def pytest_configure(config: Config) -> None:
+def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "infrahub: Infrahub test")
     config.addinivalue_line("markers", "infrahub_smoke: Smoke test for an Infrahub resource")
     config.addinivalue_line("markers", "infrahub_unit: Unit test for an Infrahub resource, works without dependencies")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,6 @@ max-complexity = 17
     "ANN202",   # Missing return type annotation for private function
     "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
     "ASYNC240", # Async functions should not use pathlib.Path methods, use trio.Path or anyio.path
-    "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
 ]
 
 "infrahub_sdk/client.py" = [
@@ -350,7 +349,6 @@ max-complexity = 17
     "PT006",   # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
     "PT011",   # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
     "PT012",   # `pytest.raises()` block should contain a single simple statement
-    "PT013",   # Incorrect import of `pytest`; use `import pytest` instead
 ]
 
 

--- a/tests/integration/test_export_import.py
+++ b/tests/integration/test_export_import.py
@@ -15,8 +15,6 @@ from infrahub_sdk.transfer.importer.json import LineDelimitedJSONImporter
 from infrahub_sdk.transfer.schema_sorter import InfrahubSchemaTopologicalSorter
 
 if TYPE_CHECKING:
-    from pytest import TempPathFactory
-
     from infrahub_sdk import InfrahubClient
     from infrahub_sdk.node import InfrahubNode
     from infrahub_sdk.schema import SchemaRoot
@@ -24,7 +22,7 @@ if TYPE_CHECKING:
 
 class TestSchemaExportImportBase(TestInfrahubDockerClient, SchemaCarPerson):
     @pytest.fixture(scope="class")
-    def temporary_directory(self, tmp_path_factory: TempPathFactory) -> Path:
+    def temporary_directory(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
         return tmp_path_factory.mktemp("infrahub-integration-tests")
 
     @pytest.fixture(scope="class")
@@ -189,7 +187,7 @@ class TestSchemaExportImportBase(TestInfrahubDockerClient, SchemaCarPerson):
 
 class TestSchemaExportImportManyRelationships(TestInfrahubDockerClient, SchemaCarPerson):
     @pytest.fixture(scope="class")
-    def temporary_directory(self, tmp_path_factory: TempPathFactory) -> Path:
+    def temporary_directory(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
         return tmp_path_factory.mktemp("infrahub-integration-tests-many")
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
# Why

Reduce number of ignored linting rules.

## What changed

Use standard approach for pytest imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized pytest type references across the codebase by consolidating imports and updating type annotations to use the `pytest.*` namespace, improving consistency and maintainability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->