### PR TITLE
Avoid + operator to concatenate collections

### DIFF
--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -147,7 +147,7 @@ class InfrahubNodeBase:
         if not hfid:
             return None
         if include_kind:
-            hfid = [self.get_kind()] + hfid
+            hfid = [self.get_kind(), *hfid]
         return "__".join(hfid)
 
     @property
@@ -203,7 +203,7 @@ class InfrahubNodeBase:
 
     def get_all_kinds(self) -> list[str]:
         if inherit_from := getattr(self._schema, "inherit_from", None):
-            return [self._schema.kind] + inherit_from
+            return [self._schema.kind, *inherit_from]
         return [self._schema.kind]
 
     def is_ip_prefix(self) -> bool:

--- a/infrahub_sdk/protocols_generator/generator.py
+++ b/infrahub_sdk/protocols_generator/generator.py
@@ -59,13 +59,13 @@ class CodeGenerator:
             not in {"TYPE_CHECKING", "CoreNode", "Optional", "Protocol", "Union", "annotations", "runtime_checkable"}
         ]
 
-        self.sorted_generics = self._sort_and_filter_models(self.generics, filters=["CoreNode"] + self.base_protocols)
-        self.sorted_nodes = self._sort_and_filter_models(self.nodes, filters=["CoreNode"] + self.base_protocols)
+        self.sorted_generics = self._sort_and_filter_models(self.generics, filters=["CoreNode", *self.base_protocols])
+        self.sorted_nodes = self._sort_and_filter_models(self.nodes, filters=["CoreNode", *self.base_protocols])
         self.sorted_profiles = self._sort_and_filter_models(
-            self.profiles, filters=["CoreProfile"] + self.base_protocols
+            self.profiles, filters=["CoreProfile", *self.base_protocols]
         )
         self.sorted_templates = self._sort_and_filter_models(
-            self.templates, filters=["CoreObjectTemplate"] + self.base_protocols
+            self.templates, filters=["CoreObjectTemplate", *self.base_protocols]
         )
 
     def render(self, sync: bool = True) -> str:

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -265,7 +265,7 @@ class InfrahubObjectFileData(BaseModel):
 
         # First validate if all mandatory fields are present
         errors.extend(
-            ObjectValidationError(position=position + [element], message=f"{element} is mandatory")
+            ObjectValidationError(position=[*position, element], message=f"{element} is mandatory")
             for element in schema.mandatory_input_names
             if not any([element in data, element in context])
         )
@@ -275,7 +275,7 @@ class InfrahubObjectFileData(BaseModel):
             if key not in schema.attribute_names and key not in schema.relationship_names:
                 errors.append(
                     ObjectValidationError(
-                        position=position + [key],
+                        position=[*position, key],
                         message=f"{key} is not a valid attribute or relationship for {schema.kind}",
                     )
                 )
@@ -283,7 +283,7 @@ class InfrahubObjectFileData(BaseModel):
             if key in schema.attribute_names and not isinstance(value, (str, int, float, bool, list, dict)):
                 errors.append(
                     ObjectValidationError(
-                        position=position + [key],
+                        position=[*position, key],
                         message=f"{key} must be a string, int, float, bool, list, or dict",
                     )
                 )
@@ -295,7 +295,7 @@ class InfrahubObjectFileData(BaseModel):
                 if not rel_info.is_valid:
                     errors.append(
                         ObjectValidationError(
-                            position=position + [key],
+                            position=[*position, key],
                             message=rel_info.reason_relationship_not_valid or "Invalid relationship",
                         )
                     )
@@ -303,7 +303,7 @@ class InfrahubObjectFileData(BaseModel):
                 errors.extend(
                     await cls.validate_related_nodes(
                         client=client,
-                        position=position + [key],
+                        position=[*position, key],
                         rel_info=rel_info,
                         data=value,
                         context=context,
@@ -378,7 +378,7 @@ class InfrahubObjectFileData(BaseModel):
                 errors.extend(
                     await cls.validate_object(
                         client=client,
-                        position=position + [idx + 1],
+                        position=[*position, idx + 1],
                         schema=peer_schema,
                         data=peer_data,
                         context=context,
@@ -403,7 +403,7 @@ class InfrahubObjectFileData(BaseModel):
                 errors.extend(
                     await cls.validate_object(
                         client=client,
-                        position=position + [idx + 1],
+                        position=[*position, idx + 1],
                         schema=peer_schema,
                         data=item["data"],
                         context=context,
@@ -613,7 +613,7 @@ class InfrahubObjectFileData(BaseModel):
                     node = await cls.create_node(
                         client=client,
                         schema=peer_schema,
-                        position=position + [rel_info.name, idx + 1],
+                        position=[*position, rel_info.name, idx + 1],
                         data=peer_data,
                         context=context,
                         branch=branch,
@@ -639,7 +639,7 @@ class InfrahubObjectFileData(BaseModel):
                 node = await cls.create_node(
                     client=client,
                     schema=peer_schema,
-                    position=position + [rel_info.name, idx + 1],
+                    position=[*position, rel_info.name, idx + 1],
                     data=item["data"],
                     context=context,
                     branch=branch,

--- a/infrahub_sdk/topological_sort.py
+++ b/infrahub_sdk/topological_sort.py
@@ -61,9 +61,9 @@ def _get_cycles(dependency_dict: dict[str, Iterable[str]], path: list[str]) -> l
     cycles = []
     for next_node in next_nodes:
         if next_node in path:
-            cycles.append(path[path.index(next_node) :] + [next_node])
+            cycles.append([*path[path.index(next_node) :], next_node])
         else:
-            next_cycles = _get_cycles(dependency_dict, path + [next_node])
+            next_cycles = _get_cycles(dependency_dict, [*path, next_node])
             if next_cycles:
                 cycles += next_cycles
     return cycles

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -145,7 +145,7 @@ def deep_merge_dict(dicta: dict, dictb: dict, path: list | None = None) -> dict:
         if key in dicta:
             a_val = dicta[key]
             if isinstance(a_val, dict) and isinstance(b_val, dict):
-                deep_merge_dict(a_val, b_val, path + [str(key)])
+                deep_merge_dict(a_val, b_val, [*path, str(key)])
             elif isinstance(a_val, list) and isinstance(b_val, list):
                 # Merge lists
                 # Cannot use compare_list because list of dicts won't work (dict not hashable)
@@ -155,7 +155,7 @@ def deep_merge_dict(dicta: dict, dictb: dict, path: list | None = None) -> dict:
             elif a_val == b_val or (a_val is not None and b_val is None):
                 continue
             else:
-                raise ValueError("Conflict at %s" % ".".join(path + [str(key)]))
+                raise ValueError("Conflict at %s" % ".".join([*path, str(key)]))
         else:
             dicta[key] = b_val
     return dicta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ ignore = [
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
     "PLR6301", # Method could be a function, class method, or static method
-    "RUF005",  # Consider `[*path, str(key)]` instead of concatenation
     "RUF029",  # Function is declared `async`, but doesn't `await` or use `async` features.
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
     "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes


### PR DESCRIPTION
# Why

Minor linting fix to remove rule from exceptions

## What changed

Avoid + operator to concatenate collections and instead use a single collection, probably trivial performance gains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code style by modernizing list construction syntax across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->