### PR TITLE
New /pre-ci & /feedback commands for Claude

### DIFF
--- a/dev/commands/feedback.md
+++ b/dev/commands/feedback.md
@@ -80,6 +80,7 @@ After presenting the report, ask the user which changes they want to apply. Pres
 3. **None** — Just keep the report as reference, don't modify any files
 
 For approved changes:
+
 - Edit existing files when updating documentation
 - Create new files only when no appropriate existing file exists
 - Update `MEMORY.md` with approved memory changes

--- a/dev/commands/feedback.md
+++ b/dev/commands/feedback.md
@@ -1,0 +1,86 @@
+# Session Feedback
+
+Analyze the current session and identify what documentation or context was missing, incomplete, or incorrect. The goal is to continuously improve the project's knowledge base so future sessions are more efficient.
+
+## Step 1: Session Analysis
+
+Reflect on the work done in this session. For each area, identify friction points:
+
+1. **Exploration overhead**: What parts of the codebase did you have to discover by searching that should have been documented? (e.g., patterns, conventions, module responsibilities)
+2. **Wrong assumptions**: Did you make incorrect assumptions due to missing or misleading documentation?
+3. **Repeated patterns**: Did you discover recurring patterns or conventions that aren't documented anywhere?
+4. **Missing context**: What background knowledge would have helped you start faster? (e.g., architecture decisions, data flow, naming conventions)
+5. **Tooling gaps**: Were there commands, scripts, or workflows that you had to figure out?
+
+## Step 2: Documentation Audit
+
+For each friction point identified, determine the appropriate fix. Check the existing documentation to avoid duplicating what's already there:
+
+- `AGENTS.md` — Top-level project instructions and component map
+- `CLAUDE.md` — Entry point referencing AGENTS.md
+- `docs/AGENTS.md` — Documentation site guide
+- `infrahub_sdk/ctl/AGENTS.md` — CLI development guide
+- `infrahub_sdk/pytest_plugin/AGENTS.md` — Pytest plugin guide
+- `tests/AGENTS.md` — Testing guide
+
+Read the relevant existing files to understand what's already documented before proposing changes.
+
+## Step 3: Generate Report
+
+Present the feedback as a structured report with the following sections. Only include sections that have content — skip empty sections.
+
+### Format
+
+```markdown
+## Session Feedback Report
+
+### What I Was Working On
+<!-- Brief summary of the task(s) performed this session -->
+
+### Documentation Gaps
+<!-- Things that should be documented but aren't -->
+
+For each gap:
+- **Topic**: What's missing
+- **Where**: Which file should contain this (existing file to update, or new file to create)
+- **Why**: How this would have helped during this session
+- **Suggested content**: A draft of what should be added (be specific and actionable)
+
+### Documentation Corrections
+<!-- Things that are documented but wrong or misleading -->
+
+For each correction:
+- **File**: Path to the file
+- **Issue**: What's wrong or misleading
+- **Fix**: What it should say instead
+
+### Discovered Patterns
+<!-- Conventions or patterns found in the code that aren't documented -->
+
+For each pattern:
+- **Pattern**: Description of the convention
+- **Evidence**: Where in the code this pattern is used (file paths)
+- **Where to document**: Which AGENTS.md or guide file should capture this
+
+### Memory Updates
+<!-- Propose additions/changes to MEMORY.md for cross-session persistence -->
+
+For each update:
+- **Action**: Add / Update / Remove
+- **Content**: What to write
+- **Reason**: Why this is worth remembering across sessions
+```
+
+## Step 4: Apply Changes
+
+After presenting the report, ask the user which changes they want to apply. Present the options:
+
+1. **Apply all** — Create/update all proposed documentation files and memory
+2. **Cherry-pick** — Let the user select which changes to apply
+3. **None** — Just keep the report as reference, don't modify any files
+
+For approved changes:
+- Edit existing files when updating documentation
+- Create new files only when no appropriate existing file exists
+- Update `MEMORY.md` with approved memory changes
+- Keep all changes minimal and focused — don't over-document

--- a/dev/commands/feedback.md
+++ b/dev/commands/feedback.md
@@ -41,6 +41,7 @@ Present the feedback as a structured report with the following sections. Only in
 <!-- Things that should be documented but aren't -->
 
 For each gap:
+
 - **Topic**: What's missing
 - **Where**: Which file should contain this (existing file to update, or new file to create)
 - **Why**: How this would have helped during this conversation
@@ -50,6 +51,7 @@ For each gap:
 <!-- Things that are documented but wrong or misleading -->
 
 For each correction:
+
 - **File**: Path to the file
 - **Issue**: What's wrong or misleading
 - **Fix**: What it should say instead
@@ -58,6 +60,7 @@ For each correction:
 <!-- Conventions or patterns found in the code that aren't documented -->
 
 For each pattern:
+
 - **Pattern**: Description of the convention
 - **Evidence**: Where in the code this pattern is used (file paths)
 - **Where to document**: Which AGENTS.md or guide file should capture this
@@ -66,6 +69,7 @@ For each pattern:
 <!-- Propose additions/changes to MEMORY.md for cross-session persistence -->
 
 For each update:
+
 - **Action**: Add / Update / Remove
 - **Content**: What to write
 - **Reason**: Why this is worth remembering across sessions
@@ -78,6 +82,7 @@ After presenting the report, ask the user which changes they want to apply. Pres
 1. **Apply all** — Create/update all proposed documentation files and memory
 2. **Cherry-pick** — Let the user select which changes to apply
 3. **None** — Just keep the report as reference, don't modify any files
+
 
 For approved changes:
 

--- a/dev/commands/feedback.md
+++ b/dev/commands/feedback.md
@@ -1,10 +1,10 @@
 # Session Feedback
 
-Analyze the current session and identify what documentation or context was missing, incomplete, or incorrect. The goal is to continuously improve the project's knowledge base so future sessions are more efficient.
+Analyze this conversation and identify what documentation or context was missing, incomplete, or incorrect. The goal is to continuously improve the project's knowledge base so future conversations are more efficient.
 
 ## Step 1: Session Analysis
 
-Reflect on the work done in this session. For each area, identify friction points:
+Reflect on the work done in this conversation. For each area, identify friction points:
 
 1. **Exploration overhead**: What parts of the codebase did you have to discover by searching that should have been documented? (e.g., patterns, conventions, module responsibilities)
 2. **Wrong assumptions**: Did you make incorrect assumptions due to missing or misleading documentation?
@@ -35,7 +35,7 @@ Present the feedback as a structured report with the following sections. Only in
 ## Session Feedback Report
 
 ### What I Was Working On
-<!-- Brief summary of the task(s) performed this session -->
+<!-- Brief summary of the task(s) performed in this conversation -->
 
 ### Documentation Gaps
 <!-- Things that should be documented but aren't -->
@@ -43,7 +43,7 @@ Present the feedback as a structured report with the following sections. Only in
 For each gap:
 - **Topic**: What's missing
 - **Where**: Which file should contain this (existing file to update, or new file to create)
-- **Why**: How this would have helped during this session
+- **Why**: How this would have helped during this conversation
 - **Suggested content**: A draft of what should be added (be specific and actionable)
 
 ### Documentation Corrections

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -1,4 +1,4 @@
-Run a subset of fast CI checks locally. These are lightweight validations that catch common issues before pushing. Execute each step sequentially and stop on the first failure. Report a summary at the end.
+Run a subset of fast CI checks locally. These are lightweight validations that catch common issues before pushing. Run all steps and report a summary at the end.
 
 ## Steps
 
@@ -30,6 +30,6 @@ Run a subset of fast CI checks locally. These are lightweight validations that c
 ## Instructions
 
 - Run each step in order using the Bash tool.
-- If a step fails, stop immediately and report the failure with the relevant output.
+- If a step fails, continue with the remaining steps.
 - At the end, print a summary table of all steps with pass/fail status.
 - Do NOT commit or push anything.

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -1,0 +1,35 @@
+Run a subset of fast CI checks locally. These are lightweight validations that catch common issues before pushing. Execute each step sequentially and stop on the first failure. Report a summary at the end.
+
+## Steps
+
+1. **Format** Python code:
+   ```bash
+   uv run invoke format
+   ```
+
+2. **Lint** (YAML, Ruff, ty, mypy, markdownlint, vale):
+   ```bash
+   uv run invoke lint
+   ```
+
+3. **Python unit tests**:
+   ```bash
+   uv run pytest tests/unit/
+   ```
+
+4. **Docs unit tests** (vitest):
+   ```bash
+   cd docs && npx --no-install vitest run
+   ```
+
+5. **Validate generated documentation** (regenerate and check for drift):
+   ```bash
+   uv run invoke docs-validate
+   ```
+
+## Instructions
+
+- Run each step in order using the Bash tool.
+- If a step fails, stop immediately and report the failure with the relevant output.
+- At the end, print a summary table of all steps with pass/fail status.
+- Do NOT commit or push anything.

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -19,7 +19,7 @@ Run a subset of fast CI checks locally. These are lightweight validations that c
 
 4. **Docs unit tests** (vitest):
    ```bash
-   cd docs && npx --no-install vitest run
+   (cd docs && npx --no-install vitest run)
    ```
 
 5. **Validate generated documentation** (regenerate and check for drift):

--- a/dev/commands/pre-ci.md
+++ b/dev/commands/pre-ci.md
@@ -33,3 +33,4 @@ Run a subset of fast CI checks locally. These are lightweight validations that c
 - If a step fails, continue with the remaining steps.
 - At the end, print a summary table of all steps with pass/fail status.
 - Do NOT commit or push anything.
+


### PR DESCRIPTION
# Why
## pre-ci
To resolve issues detected by the CI, avoid back-and-forth `push` or `force-push.`

## feedback
Enhance Claude capabilities to develop alone and respecting the code conventions and software architecture.

## Goal

### pre-ci
The `/pre-ci` Claude command will launch a subset of CI checks locally.

### feedback
To identify missing documentation that would allow Claude to directly address correctly the problematics encountered during the session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added developer guidance for a local pre-CI workflow to run format, lint, Python tests, docs unit tests, and docs validation sequentially; continues after failures, produces a final pass/fail summary, and advises not to commit or push intermediate changes.
  * Added a structured session feedback process: identify friction points, perform a documentation audit, use a templated feedback report, and follow minimal, option-based steps to apply approved changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->