### PR TITLE
IHS-206 API Documentation Collapsible sections containing method overloads

### DIFF
--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -19,6 +19,9 @@ GraphQL Client to interact with Infrahub.
 get(self, kind: type[SchemaType], raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaType | None
 ```
 
+<details>
+<summary>Show 6 other overloads</summary>
+
 #### `get`
 
 ```python
@@ -55,11 +58,21 @@ get(self, kind: str, raise_when_missing: bool = ..., at: Timestamp | None = ...,
 get(self, kind: str | type[SchemaType], raise_when_missing: bool = True, at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, id: str | None = None, hfid: list[str] | None = None, include: list[str] | None = None, exclude: list[str] | None = None, populate_store: bool = True, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, include_metadata: bool = False, **kwargs: Any) -> InfrahubNode | SchemaType | None
 ```
 
+</details>
 #### `delete`
 
 ```python
 delete(self, kind: str | type[SchemaType], id: str, branch: str | None = None) -> None
 ```
+
+#### `create`
+
+```python
+create(self, kind: str | type[SchemaType], data: dict | None = None, branch: str | None = None, timeout: int | None = None, **kwargs: Any) -> InfrahubNode | SchemaType
+```
+
+<details>
+<summary>Show 2 other overloads</summary>
 
 #### `create`
 
@@ -73,12 +86,7 @@ create(self, kind: str, data: dict | None = ..., branch: str | None = ..., **kwa
 create(self, kind: type[SchemaType], data: dict | None = ..., branch: str | None = ..., **kwargs: Any) -> SchemaType
 ```
 
-#### `create`
-
-```python
-create(self, kind: str | type[SchemaType], data: dict | None = None, branch: str | None = None, timeout: int | None = None, **kwargs: Any) -> InfrahubNode | SchemaType
-```
-
+</details>
 #### `get_version`
 
 ```python
@@ -117,6 +125,9 @@ Return the number of nodes of a given kind.
 all(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ...) -> list[SchemaType]
 ```
 
+<details>
+<summary>Show 2 other overloads</summary>
+
 #### `all`
 
 ```python
@@ -152,11 +163,15 @@ Retrieve all nodes of a given kind
 
 - list\[InfrahubNode]: List of Nodes
 
+</details>
 #### `filters`
 
 ```python
 filters(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., **kwargs: Any) -> list[SchemaType]
 ```
+
+<details>
+<summary>Show 2 other overloads</summary>
 
 #### `filters`
 
@@ -195,6 +210,7 @@ Retrieve nodes of a given kind based on provided filters.
 
 - list\[InfrahubNodeSync]: List of Nodes that match the given filters.
 
+</details>
 #### `clone`
 
 ```python
@@ -277,6 +293,9 @@ Returns None if no diff exists.
 allocate_next_ip_address(self, resource_pool: CoreNode, kind: type[SchemaType], identifier: str | None = ..., prefix_length: int | None = ..., address_type: str | None = ..., data: dict[str, Any] | None = ..., branch: str | None = ..., timeout: int | None = ..., tracker: str | None = ..., raise_for_error: Literal[True] = True) -> SchemaType
 ```
 
+<details>
+<summary>Show 6 other overloads</summary>
+
 #### `allocate_next_ip_address`
 
 ```python
@@ -330,11 +349,15 @@ Allocate a new IP address by using the provided resource pool.
 Returns:
     InfrahubNode: Node corresponding to the allocated resource.
 
+</details>
 #### `allocate_next_ip_prefix`
 
 ```python
 allocate_next_ip_prefix(self, resource_pool: CoreNode, kind: type[SchemaType], identifier: str | None = ..., prefix_length: int | None = ..., member_type: str | None = ..., prefix_type: str | None = ..., data: dict[str, Any] | None = ..., branch: str | None = ..., timeout: int | None = ..., tracker: str | None = ..., raise_for_error: Literal[True] = True) -> SchemaType
 ```
+
+<details>
+<summary>Show 6 other overloads</summary>
 
 #### `allocate_next_ip_prefix`
 
@@ -390,6 +413,7 @@ Allocate a new IP prefix by using the provided resource pool.
 Returns:
     InfrahubNode: Node corresponding to the allocated resource.
 
+</details>
 #### `create_batch`
 
 ```python
@@ -429,6 +453,9 @@ for more information.
 get(self, kind: type[SchemaTypeSync], raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaTypeSync | None
 ```
 
+<details>
+<summary>Show 6 other overloads</summary>
+
 #### `get`
 
 ```python
@@ -465,11 +492,21 @@ get(self, kind: str, raise_when_missing: bool = ..., at: Timestamp | None = ...,
 get(self, kind: str | type[SchemaTypeSync], raise_when_missing: bool = True, at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, id: str | None = None, hfid: list[str] | None = None, include: list[str] | None = None, exclude: list[str] | None = None, populate_store: bool = True, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, include_metadata: bool = False, **kwargs: Any) -> InfrahubNodeSync | SchemaTypeSync | None
 ```
 
+</details>
 #### `delete`
 
 ```python
 delete(self, kind: str | type[SchemaTypeSync], id: str, branch: str | None = None) -> None
 ```
+
+#### `create`
+
+```python
+create(self, kind: str | type[SchemaTypeSync], data: dict | None = None, branch: str | None = None, timeout: int | None = None, **kwargs: Any) -> InfrahubNodeSync | SchemaTypeSync
+```
+
+<details>
+<summary>Show 2 other overloads</summary>
 
 #### `create`
 
@@ -483,12 +520,7 @@ create(self, kind: str, data: dict | None = ..., branch: str | None = ..., **kwa
 create(self, kind: type[SchemaTypeSync], data: dict | None = ..., branch: str | None = ..., **kwargs: Any) -> SchemaTypeSync
 ```
 
-#### `create`
-
-```python
-create(self, kind: str | type[SchemaTypeSync], data: dict | None = None, branch: str | None = None, timeout: int | None = None, **kwargs: Any) -> InfrahubNodeSync | SchemaTypeSync
-```
-
+</details>
 #### `get_version`
 
 ```python
@@ -564,6 +596,9 @@ Return the number of nodes of a given kind.
 all(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ...) -> list[SchemaTypeSync]
 ```
 
+<details>
+<summary>Show 2 other overloads</summary>
+
 #### `all`
 
 ```python
@@ -599,11 +634,15 @@ Retrieve all nodes of a given kind
 
 - list\[InfrahubNodeSync]: List of Nodes
 
+</details>
 #### `filters`
 
 ```python
 filters(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., **kwargs: Any) -> list[SchemaTypeSync]
 ```
+
+<details>
+<summary>Show 2 other overloads</summary>
 
 #### `filters`
 
@@ -642,6 +681,7 @@ Retrieve nodes of a given kind based on provided filters.
 
 - list\[InfrahubNodeSync]: List of Nodes that match the given filters.
 
+</details>
 #### `create_batch`
 
 ```python
@@ -692,6 +732,9 @@ Returns None if no diff exists.
 ```python
 allocate_next_ip_address(self, resource_pool: CoreNodeSync, kind: type[SchemaTypeSync], identifier: str | None = ..., prefix_length: int | None = ..., address_type: str | None = ..., data: dict[str, Any] | None = ..., branch: str | None = ..., timeout: int | None = ..., tracker: str | None = ..., raise_for_error: Literal[True] = True) -> SchemaTypeSync
 ```
+
+<details>
+<summary>Show 6 other overloads</summary>
 
 #### `allocate_next_ip_address`
 
@@ -746,11 +789,15 @@ Allocate a new IP address by using the provided resource pool.
 Returns:
     InfrahubNodeSync: Node corresponding to the allocated resource.
 
+</details>
 #### `allocate_next_ip_prefix`
 
 ```python
 allocate_next_ip_prefix(self, resource_pool: CoreNodeSync, kind: type[SchemaTypeSync], identifier: str | None = ..., prefix_length: int | None = ..., member_type: str | None = ..., prefix_type: str | None = ..., data: dict[str, Any] | None = ..., branch: str | None = ..., timeout: int | None = ..., tracker: str | None = ..., raise_for_error: Literal[True] = True) -> SchemaTypeSync
 ```
+
+<details>
+<summary>Show 6 other overloads</summary>
 
 #### `allocate_next_ip_prefix`
 
@@ -806,6 +853,7 @@ Allocate a new IP prefix by using the provided resource pool.
 Returns:
     InfrahubNodeSync: Node corresponding to the allocated resource.
 
+</details>
 #### `repository_update_commit`
 
 ```python
@@ -852,15 +900,19 @@ Base class for InfrahubClient and InfrahubClientSync
 #### `request_context`
 
 ```python
-request_context(self) -> RequestContext | None
+request_context(self, request_context: RequestContext) -> None
 ```
+
+<details>
+<summary>Show 1 other overload</summary>
 
 #### `request_context`
 
 ```python
-request_context(self, request_context: RequestContext) -> None
+request_context(self) -> RequestContext | None
 ```
 
+</details>
 #### `start_tracking`
 
 ```python

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -900,19 +900,15 @@ Base class for InfrahubClient and InfrahubClientSync
 #### `request_context`
 
 ```python
-request_context(self, request_context: RequestContext) -> None
+request_context(self) -> RequestContext | None
 ```
-
-<details>
-<summary>Show 1 other overload</summary>
 
 #### `request_context`
 
 ```python
-request_context(self) -> RequestContext | None
+request_context(self, request_context: RequestContext) -> None
 ```
 
-</details>
 #### `start_tracking`
 
 ```python

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
@@ -16,16 +16,11 @@ Represents an attribute of a Node, including its schema, value, and properties.
 #### `value`
 
 ```python
-value(self, value: Any) -> None
+value(self) -> Any
 ```
-
-<details>
-<summary>Show 1 other overload</summary>
 
 #### `value`
 
 ```python
-value(self) -> Any
+value(self, value: Any) -> None
 ```
-
-</details>

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
@@ -16,11 +16,16 @@ Represents an attribute of a Node, including its schema, value, and properties.
 #### `value`
 
 ```python
-value(self) -> Any
+value(self, value: Any) -> None
 ```
+
+<details>
+<summary>Show 1 other overload</summary>
 
 #### `value`
 
 ```python
-value(self, value: Any) -> None
+value(self) -> Any
 ```
+
+</details>

--- a/docs/docs_generation/content_gen_methods/__init__.py
+++ b/docs/docs_generation/content_gen_methods/__init__.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from docs.docs_generation.content_gen_methods.command.command import ACommand
 from docs.docs_generation.content_gen_methods.command.typer_command import TyperGroupCommand, TyperSingleCommand
 from docs.docs_generation.content_gen_methods.mdx.mdx_code_doc import ACodeDocumentation, MdxCodeDocumentation
+from docs.docs_generation.content_gen_methods.mdx.mdx_collapsed_overload_code_doc import (
+    CollapsedOverloadCodeDocumentation,
+)
 from docs.docs_generation.content_gen_methods.mdx.mdx_ordered_code_doc import OrderedMdxCodeDocumentation
 
 from .base import ADocContentGenMethod
@@ -14,6 +17,7 @@ __all__ = [
     "ACodeDocumentation",
     "ACommand",
     "ADocContentGenMethod",
+    "CollapsedOverloadCodeDocumentation",
     "CommandOutputDocContentGenMethod",
     "FilePrintingDocContentGenMethod",
     "Jinja2DocContentGenMethod",

--- a/docs/docs_generation/content_gen_methods/mdx/__init__.py
+++ b/docs/docs_generation/content_gen_methods/mdx/__init__.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from .mdx_code_doc import ACodeDocumentation, MdxCodeDocumentation, MdxFile
+from .mdx_collapsed_overload_code_doc import CollapsedOverloadCodeDocumentation
+from .mdx_collapsed_overload_section import CollapsedOverloadSection
 from .mdx_ordered_code_doc import OrderedMdxCodeDocumentation
 from .mdx_ordered_section import OrderedMdxSection
 from .mdx_section import MdxSection
 
 __all__ = [
     "ACodeDocumentation",
+    "CollapsedOverloadCodeDocumentation",
+    "CollapsedOverloadSection",
     "MdxCodeDocumentation",
     "MdxFile",
     "MdxSection",

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import groupby
 from typing import TYPE_CHECKING
 
 from .mdx_code_doc import ACodeDocumentation, MdxFile
@@ -24,10 +25,12 @@ class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
     documentation: ACodeDocumentation
 
     def generate(self, context: Context, modules_to_document: list[str]) -> dict[str, MdxFile]:
+        """Generate MDX files and collapse overloaded methods in each one."""
         files = self.documentation.generate(context, modules_to_document)
         return {name: self._collapse_overloads(mdx_file) for name, mdx_file in files.items()}
 
     def _collapse_overloads(self, mdx_file: MdxFile) -> MdxFile:
+        """Return a copy of *mdx_file* with overloaded methods collapsed."""
         lines = mdx_file.content.split("\n")
         parsed_h2 = _parse_sections(lines, heading_level=2)
 
@@ -35,6 +38,7 @@ class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
         for h2 in parsed_h2.sections:
             processed_h3 = self._process_class_sections(h2.content)
             if processed_h3 is None:
+                # No subsection means no method to manage
                 processed_h2.append(h2)
             else:
                 h3_parsed = _parse_sections(h2.content, heading_level=3)
@@ -47,6 +51,7 @@ class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
         return MdxFile(name=mdx_file.name, content=new_content, source_path=mdx_file.source_path)
 
     def _process_class_sections(self, h2_content: list[str]) -> list[ASection] | None:
+        """Collapse overloads inside each H3 class section, or return ``None`` if nothing changed."""
         h3_parsed = _parse_sections(h2_content, heading_level=3)
         if not h3_parsed.sections:
             return None
@@ -68,6 +73,7 @@ class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
         return processed if any_collapsed else None
 
     def _collapse_methods_in_class(self, h3_content: list[str]) -> list[ASection] | None:
+        """Collapse consecutive same-name H4 methods, or return ``None`` if no overloads found."""
         h4_parsed = _parse_sections(h3_content, heading_level=4)
         if not h4_parsed.sections:
             return None
@@ -85,12 +91,7 @@ class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
                 collapsed.append(CollapsedOverloadSection.from_overloads(group))
         return collapsed
 
-    def _group_consecutive_overloads(self, sections: list[MdxSection]) -> list[list[MdxSection]]:
+    @staticmethod
+    def _group_consecutive_overloads(sections: list[MdxSection]) -> list[list[MdxSection]]:
         """Group consecutive sections sharing the same name."""
-        groups: list[list[MdxSection]] = []
-        for section in sections:
-            if groups and groups[-1][0].name == section.name:
-                groups[-1].append(section)
-            else:
-                groups.append([section])
-        return groups
+        return [list(group) for _, group in groupby(sections, key=lambda s: s.name)]

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py
@@ -5,7 +5,7 @@ from itertools import groupby
 from typing import TYPE_CHECKING
 
 from .mdx_code_doc import ACodeDocumentation, MdxFile
-from .mdx_collapsed_overload_section import CollapsedOverloadSection
+from .mdx_collapsed_overload_section import CollapsedOverloadSection, MethodSignature
 from .mdx_section import ASection, MdxSection, _parse_sections
 
 if TYPE_CHECKING:
@@ -88,10 +88,46 @@ class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
             if len(group) == 1:
                 collapsed.append(group[0])
             else:
-                collapsed.append(CollapsedOverloadSection.from_overloads(group))
+                accessors, overloads = _split_property_accessors(group)
+                collapsed.extend(accessors)
+                if len(overloads) > 1:
+                    collapsed.append(CollapsedOverloadSection.from_overloads(overloads))
+                else:
+                    collapsed.extend(overloads)
         return collapsed
 
     @staticmethod
     def _group_consecutive_overloads(sections: list[MdxSection]) -> list[list[MdxSection]]:
         """Group consecutive sections sharing the same name."""
         return [list(group) for _, group in groupby(sections, key=lambda s: s.name)]
+
+
+def _split_property_accessors(sections: list[MdxSection]) -> tuple[list[MdxSection], list[MdxSection]]:
+    """Partition *sections* into property accessors and remaining overloads.
+
+    Recognised accessor patterns:
+
+    * **getter** — 0 params, non-``None`` return
+    * **setter** — 1 param, ``None`` return
+    * **deleter** — 0 params, ``None`` return
+    """
+    sigs = [(section, MethodSignature(section)) for section in sections]
+
+    def is_accessor(sig: MethodSignature) -> bool:
+        return getter_sig(sig) or setter_sig(sig) or deleter_sig(sig)
+
+    accessors = [section for section, sig in sigs if is_accessor(sig)]
+    overloads = [section for section, sig in sigs if not is_accessor(sig)]
+    return accessors, overloads
+
+
+def deleter_sig(sig: MethodSignature) -> bool:
+    return sig.param_count() == 0 and sig.return_type() == "None"
+
+
+def setter_sig(sig: MethodSignature) -> bool:
+    return sig.param_count() == 1 and sig.return_type() == "None"
+
+
+def getter_sig(sig: MethodSignature) -> bool:
+    return sig.param_count() == 0 and sig.return_type() != "None"

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .mdx_code_doc import ACodeDocumentation, MdxFile
+from .mdx_collapsed_overload_section import CollapsedOverloadSection
+from .mdx_section import ASection, MdxSection, _parse_sections
+
+if TYPE_CHECKING:
+    from invoke import Context
+
+
+@dataclass
+class CollapsedOverloadCodeDocumentation(ACodeDocumentation):
+    """Decorator around :class:`ACodeDocumentation` that collapses overloaded methods.
+
+    Delegates generation to the wrapped *documentation* instance, then
+    replaces groups of same-name H4 method sections within each class
+    with a :class:`CollapsedOverloadSection` showing the primary overload
+    and a collapsible ``<details>`` block for the rest.
+    """
+
+    documentation: ACodeDocumentation
+
+    def generate(self, context: Context, modules_to_document: list[str]) -> dict[str, MdxFile]:
+        files = self.documentation.generate(context, modules_to_document)
+        return {name: self._collapse_overloads(mdx_file) for name, mdx_file in files.items()}
+
+    def _collapse_overloads(self, mdx_file: MdxFile) -> MdxFile:
+        lines = mdx_file.content.split("\n")
+        parsed_h2 = _parse_sections(lines, heading_level=2)
+
+        processed_h2: list[ASection] = []
+        for h2 in parsed_h2.sections:
+            processed_h3 = self._process_class_sections(h2.content)
+            if processed_h3 is None:
+                processed_h2.append(h2)
+            else:
+                h3_parsed = _parse_sections(h2.content, heading_level=3)
+                new_lines = h3_parsed.reassembled(processed_h3)
+                processed_h2.append(
+                    MdxSection(name=h2.name, heading_level=h2.heading_level, _lines=[h2.heading] + new_lines)
+                )
+
+        new_content = "\n".join(parsed_h2.reassembled(processed_h2))
+        return MdxFile(name=mdx_file.name, content=new_content, source_path=mdx_file.source_path)
+
+    def _process_class_sections(self, h2_content: list[str]) -> list[ASection] | None:
+        h3_parsed = _parse_sections(h2_content, heading_level=3)
+        if not h3_parsed.sections:
+            return None
+
+        any_collapsed = False
+        processed: list[ASection] = []
+        for h3 in h3_parsed.sections:
+            collapsed_methods = self._collapse_methods_in_class(h3.content)
+            if collapsed_methods is None:
+                processed.append(h3)
+            else:
+                any_collapsed = True
+                h4_parsed = _parse_sections(h3.content, heading_level=4)
+                new_lines = h4_parsed.reassembled(collapsed_methods)
+                processed.append(
+                    MdxSection(name=h3.name, heading_level=h3.heading_level, _lines=[h3.heading] + new_lines)
+                )
+
+        return processed if any_collapsed else None
+
+    def _collapse_methods_in_class(self, h3_content: list[str]) -> list[ASection] | None:
+        h4_parsed = _parse_sections(h3_content, heading_level=4)
+        if not h4_parsed.sections:
+            return None
+
+        groups = self._group_consecutive_overloads(h4_parsed.sections)
+        has_overloads = any(len(group) > 1 for group in groups)
+        if not has_overloads:
+            return None
+
+        collapsed: list[ASection] = []
+        for group in groups:
+            if len(group) == 1:
+                collapsed.append(group[0])
+            else:
+                collapsed.append(CollapsedOverloadSection.from_overloads(group))
+        return collapsed
+
+    def _group_consecutive_overloads(self, sections: list[MdxSection]) -> list[list[MdxSection]]:
+        """Group consecutive sections sharing the same name."""
+        groups: list[list[MdxSection]] = []
+        for section in sections:
+            if groups and groups[-1][0].name == section.name:
+                groups[-1].append(section)
+            else:
+                groups.append([section])
+        return groups

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from .mdx_section import ASection, MdxSection
+
+
+@dataclass
+class SignatureParameterCount:
+    """Number of parameters in a Python method signature, excluding ``self``.
+
+    Parses the raw signature text (as rendered in MDX code fences) and
+    counts comma-separated parameters at the top level, respecting
+    bracket nesting for generic types like ``dict[str, int]``.
+
+    Example::
+
+        >>> SignatureParameterCount("get(self, kind: str, id: int)").value()
+        2
+    """
+
+    signature: str
+
+    def value(self) -> int:
+        """Return the number of parameters excluding ``self``."""
+        params_text = self._extract_params_text()
+        if not params_text.strip():
+            return 0
+        tokens = self._split_top_level(params_text)
+        return len([t for t in tokens if t.strip() and t.strip() != "self"])
+
+    def _extract_params_text(self) -> str:
+        """Extract the text between the first ``(`` and its matching ``)``."""
+        start = self.signature.find("(")
+        if start == -1:
+            return ""
+        depth = 0
+        for i in range(start, len(self.signature)):
+            char = self.signature[i]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    return self.signature[start + 1 : i]
+        return self.signature[start + 1 :]
+
+    def _split_top_level(self, text: str) -> list[str]:
+        """Split *text* on commas that are not inside brackets."""
+        depth = 0
+        tokens: list[str] = []
+        current: list[str] = []
+        for char in text:
+            if char in {"[", "(", "{"}:
+                depth += 1
+                current.append(char)
+            elif char in {"]", ")", "}"}:
+                depth -= 1
+                current.append(char)
+            elif char == "," and depth == 0:
+                tokens.append("".join(current))
+                current = []
+            else:
+                current.append(char)
+        if current:
+            tokens.append("".join(current))
+        return tokens
+
+
+_CODE_FENCE_PATTERN = re.compile(r"^```python\s*$")
+_CODE_FENCE_END = re.compile(r"^```\s*$")
+
+
+@dataclass
+class CollapsedOverloadSection(ASection):
+    """Collapses a group of overloaded method sections into one primary entry
+    followed by a collapsible ``<details>`` block with the remaining overloads.
+
+    The *primary* overload is the one with the most parameters (excluding
+    ``self``).  On ties, the first in source order wins.
+
+    Example::
+
+        >>> section = CollapsedOverloadSection.from_overloads(overload_sections)
+        >>> section.heading  # delegates to primary
+        '#### `get`'
+    """
+
+    primary: MdxSection
+    others: list[MdxSection] = field(default_factory=list)
+
+    @property
+    def heading(self) -> str:
+        return self.primary.heading
+
+    @property
+    def content(self) -> list[str]:
+        if not self.others:
+            return self.primary.content
+
+        result = list(self.primary.content)
+
+        count = len(self.others)
+        noun = "overload" if count == 1 else "overloads"
+        result.extend(("", "<details>", f"<summary>Show {count} other {noun}</summary>", ""))
+
+        for other in self.others:
+            result.extend(other.lines)
+
+        result.extend(("", "</details>"))
+        return result
+
+    @classmethod
+    def from_overloads(cls, sections: list[MdxSection]) -> CollapsedOverloadSection:
+        """Create from a list of overloaded :class:`MdxSection` objects.
+
+        Selects the overload with the most parameters as *primary*.
+        On ties, the first in source order wins.
+        """
+        if not sections:
+            raise ValueError("Cannot create CollapsedOverloadSection from an empty list")
+
+        best_index = 0
+        best_count = -1
+        for i, section in enumerate(sections):
+            sig = _extract_signature(section)
+            count = SignatureParameterCount(sig).value() if sig else 0
+            if count > best_count:
+                best_count = count
+                best_index = i
+
+        primary = sections[best_index]
+        others = [s for i, s in enumerate(sections) if i != best_index]
+        return cls(primary=primary, others=others)
+
+
+def _extract_signature(section: MdxSection) -> str:
+    """Extract the Python signature from the first code fence in *section*."""
+    in_fence = False
+    sig_lines: list[str] = []
+    for line in section.content:
+        if not in_fence and _CODE_FENCE_PATTERN.match(line):
+            in_fence = True
+            continue
+        if in_fence:
+            if _CODE_FENCE_END.match(line):
+                break
+            sig_lines.append(line)
+    return " ".join(sig_lines).strip()

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
@@ -7,72 +7,6 @@ from .mdx_section import ASection, MdxSection
 
 
 @dataclass
-class SignatureParameterCount:
-    """Number of parameters in a Python method signature, excluding ``self``.
-
-    Parses the raw signature text (as rendered in MDX code fences) and
-    counts comma-separated parameters at the top level, respecting
-    bracket nesting for generic types like ``dict[str, int]``.
-
-    Example::
-
-        >>> SignatureParameterCount("get(self, kind: str, id: int)").value()
-        2
-    """
-
-    signature: str
-
-    def value(self) -> int:
-        """Return the number of parameters excluding ``self``."""
-        params_text = self._extract_params_text()
-        if not params_text.strip():
-            return 0
-        tokens = self._split_top_level(params_text)
-        return len([t for t in tokens if t.strip() and t.strip() != "self"])
-
-    def _extract_params_text(self) -> str:
-        """Extract the text between the first ``(`` and its matching ``)``."""
-        start = self.signature.find("(")
-        if start == -1:
-            return ""
-        depth = 0
-        for i in range(start, len(self.signature)):
-            char = self.signature[i]
-            if char == "(":
-                depth += 1
-            elif char == ")":
-                depth -= 1
-                if depth == 0:
-                    return self.signature[start + 1 : i]
-        return self.signature[start + 1 :]
-
-    def _split_top_level(self, text: str) -> list[str]:
-        """Split *text* on commas that are not inside brackets."""
-        depth = 0
-        tokens: list[str] = []
-        current: list[str] = []
-        for char in text:
-            if char in {"[", "(", "{"}:
-                depth += 1
-                current.append(char)
-            elif char in {"]", ")", "}"}:
-                depth -= 1
-                current.append(char)
-            elif char == "," and depth == 0:
-                tokens.append("".join(current))
-                current = []
-            else:
-                current.append(char)
-        if current:
-            tokens.append("".join(current))
-        return tokens
-
-
-_CODE_FENCE_PATTERN = re.compile(r"^```python\s*$")
-_CODE_FENCE_END = re.compile(r"^```\s*$")
-
-
-@dataclass
 class CollapsedOverloadSection(ASection):
     """Collapses a group of overloaded method sections into one primary entry
     followed by a collapsible ``<details>`` block with the remaining overloads.
@@ -92,23 +26,20 @@ class CollapsedOverloadSection(ASection):
 
     @property
     def heading(self) -> str:
+        """Return the heading of the primary overload."""
         return self.primary.heading
 
     @property
     def content(self) -> list[str]:
+        """Return primary content followed by a ``<details>`` block for the other overloads."""
         if not self.others:
             return self.primary.content
 
         result = list(self.primary.content)
-
+        inner = [line for other in self.others for line in other.lines]
         count = len(self.others)
         noun = "overload" if count == 1 else "overloads"
-        result.extend(("", "<details>", f"<summary>Show {count} other {noun}</summary>", ""))
-
-        for other in self.others:
-            result.extend(other.lines)
-
-        result.extend(("", "</details>"))
+        result.extend(_HtmlDetailsBlock(f"Show {count} other {noun}", inner).lines())
         return result
 
     @classmethod
@@ -121,22 +52,32 @@ class CollapsedOverloadSection(ASection):
         if not sections:
             raise ValueError("Cannot create CollapsedOverloadSection from an empty list")
 
-        best_index = 0
-        best_count = -1
-        for i, section in enumerate(sections):
-            sig = _extract_signature(section)
-            count = SignatureParameterCount(sig).value() if sig else 0
-            if count > best_count:
-                best_count = count
-                best_index = i
-
-        primary = sections[best_index]
-        others = [s for i, s in enumerate(sections) if i != best_index]
+        primary = max(sections, key=lambda s: MethodSignature(s).param_count())
+        others = [s for s in sections if s is not primary]
         return cls(primary=primary, others=others)
 
 
-def _extract_signature(section: MdxSection) -> str:
-    """Extract the Python signature from the first code fence in *section*."""
+# --- Private collaborators ---
+
+
+@dataclass(frozen=True)
+class _HtmlDetailsBlock:
+    """A collapsible HTML ``<details>`` block."""
+
+    summary: str
+    inner_lines: list[str]
+
+    def lines(self) -> list[str]:
+        """Return the full block as a list of MDX lines."""
+        return ["", "<details>", f"<summary>{self.summary}</summary>", "", *self.inner_lines, "", "</details>"]
+
+
+_CODE_FENCE_PATTERN = re.compile(r"^```python\s*$")
+_CODE_FENCE_END = re.compile(r"^```\s*$")
+
+
+def _extract_text(section: MdxSection) -> str:
+    """Extract the signature from the first code fence in *section*."""
     in_fence = False
     sig_lines: list[str] = []
     for line in section.content:
@@ -148,3 +89,58 @@ def _extract_signature(section: MdxSection) -> str:
                 break
             sig_lines.append(line)
     return " ".join(sig_lines).strip()
+
+
+def _split_params(text: str) -> list[str]:
+    """Split *text* on commas that are not inside brackets."""
+    depth = 0
+    tokens: list[str] = []
+    current: list[str] = []
+    for char in text:
+        if char in {"[", "(", "{"}:
+            depth += 1
+            current.append(char)
+        elif char in {"]", ")", "}"}:
+            depth -= 1
+            current.append(char)
+        elif char == "," and depth == 0:
+            tokens.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+class MethodSignature:
+    """A Python method signature extracted from an MDX code fence.
+
+    Parses the raw signature text and counts comma-separated parameters
+    at the top level, respecting bracket nesting for generic types
+    like ``dict[str, int]``.
+
+    Example::
+
+        >>> MethodSignature(section).param_count()
+        2
+    """
+
+    def __init__(self, section: MdxSection) -> None:
+        self._text = _extract_text(section)
+
+    def param_count(self) -> int:
+        """Return the number of parameters excluding ``self``."""
+        params_text = self._extract_params_text()
+        if not params_text.strip():
+            return 0
+        tokens = _split_params(params_text)
+        return len([t for t in tokens if t.strip() and t.strip() != "self"])
+
+    def _extract_params_text(self) -> str:
+        """Extract the text between the first ``(`` and its last ``)``."""
+        _, sep, after_open = self._text.partition("(")
+        if not sep:
+            return ""
+        params, _, _ = after_open.rpartition(")")
+        return params

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
@@ -119,11 +119,6 @@ class MethodSignature:
     Parses the raw signature text and counts comma-separated parameters
     at the top level, respecting bracket nesting for generic types
     like ``dict[str, int]``.
-
-    Example::
-
-        >>> MethodSignature(section).param_count()
-        2
     """
 
     def __init__(self, section: MdxSection) -> None:
@@ -136,6 +131,14 @@ class MethodSignature:
             return 0
         tokens = _split_params(params_text)
         return len([t for t in tokens if t.strip() and t.strip() != "self"])
+
+    def return_type(self) -> str:
+        """Return the return-type annotation (e.g. ``"None"``), or ``""`` if absent."""
+        _, sep, ret = self._text.rpartition(")")
+        if not sep:
+            return ""
+        _, arrow, after_arrow = ret.partition("->")
+        return after_arrow.strip() if arrow else ""
 
     def _extract_params_text(self) -> str:
         """Extract the text between the first ``(`` and its last ``)``."""

--- a/tasks.py
+++ b/tasks.py
@@ -189,6 +189,7 @@ def get_modules_to_document() -> list[str]:
 def _generate_sdk_api_docs(context: Context) -> None:
     """Generate API documentation for the Python SDK."""
     from docs.docs_generation.content_gen_methods import (
+        CollapsedOverloadCodeDocumentation,
         FilePrintingDocContentGenMethod,
         MdxCodeDocumentation,
         OrderedMdxCodeDocumentation,
@@ -205,9 +206,11 @@ def _generate_sdk_api_docs(context: Context) -> None:
     if (output_dir / "infrahub_sdk").exists():
         shutil.rmtree(output_dir / "infrahub_sdk")
 
-    documentation = OrderedMdxCodeDocumentation(
-        documentation=MdxCodeDocumentation(),
-        page_priorities=PAGE_PRIORITIES,
+    documentation = CollapsedOverloadCodeDocumentation(
+        documentation=OrderedMdxCodeDocumentation(
+            documentation=MdxCodeDocumentation(),
+            page_priorities=PAGE_PRIORITIES,
+        )
     )
     generated_files = documentation.generate(context=context, modules_to_document=modules_to_document)
 

--- a/tests/unit/doc_generation/mdx/conftest.py
+++ b/tests/unit/doc_generation/mdx/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures and helpers for OrderedMdxCodeDocumentation tests."""
+"""Shared fixtures and helpers for MDX documentation tests."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import pytest
 
 from docs.docs_generation.content_gen_methods.mdx.mdx_code_doc import ACodeDocumentation, MdxFile
 from docs.docs_generation.content_gen_methods.mdx.mdx_ordered_code_doc import OrderedMdxCodeDocumentation
+from docs.docs_generation.content_gen_methods.mdx.mdx_section import MdxSection
 
 if TYPE_CHECKING:
     from invoke import Context
@@ -61,6 +62,20 @@ def method_order(content: str, class_name: str) -> list[str]:
     if not match:
         return []
     return re.findall(r"^#### `([^`]+)`", match.group(1), re.MULTILINE)
+
+
+def make_method_section(name: str, signature: str, docstring: str = "") -> MdxSection:
+    """Create an MdxSection mimicking a method entry in MDX output."""
+    lines = [
+        f"#### `{name}`",
+        "",
+        "```python",
+        signature,
+        "```",
+    ]
+    if docstring:
+        lines.extend(("", docstring))
+    return MdxSection(name=name, heading_level=4, _lines=lines)
 
 
 # --- Fixtures ---

--- a/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py
@@ -2,24 +2,16 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 import pytest
 
-from docs.docs_generation.content_gen_methods.mdx.mdx_code_doc import ACodeDocumentation, MdxFile
+from docs.docs_generation.content_gen_methods.mdx.mdx_code_doc import MdxFile
 from docs.docs_generation.content_gen_methods.mdx.mdx_collapsed_overload_code_doc import (
     CollapsedOverloadCodeDocumentation,
 )
 
-if TYPE_CHECKING:
-    from invoke import Context
-
-FILE_KEY = "test.mdx"
-MOCK_CONTEXT = MagicMock(spec="Context")
-MODULES: list[str] = []
+from .conftest import FILE_KEY, MOCK_CONTEXT, MODULES, StubDocumentation
 
 
 class TestCollapseOverloads:
@@ -31,13 +23,89 @@ class TestCollapseOverloads:
         result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
 
         # Assert
-        get_headings = _method_headings(result, "InfrahubClient")
-        assert get_headings.count("get") == 1
-        assert _has_details_block(result, "get")
+        visible_part = result.split("<details>")[0]
+        assert visible_part.count("#### `get`") == 1
+        assert "<details>" in result
 
-    def test_non_overloaded_methods_unchanged(self) -> None:
+    def test_non_overloaded_methods_unchanged(self, sample_mdx_no_overloads: str) -> None:
         # Arrange
-        content = """\
+        doc = _build_collapsed_doc(sample_mdx_no_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert result == sample_mdx_no_overloads
+
+    def test_mixed_overloaded_and_non_overloaded(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "#### `get`" in result
+        assert "#### `create`" in result
+        assert "#### `delete`" in result
+        assert result.count("<details>") == 2
+
+    def test_primary_is_overload_with_most_params(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "timeout" in result
+
+    def test_details_label_shows_correct_count(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "Show 2 other overloads" in result
+
+    def test_singular_label_for_two_overloads(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "Show 1 other overload" in result
+
+
+class TestNoOverloads:
+    def test_empty_content_passes_through(self) -> None:
+        # Arrange
+        content = "# minimal"
+        doc = _build_collapsed_doc(content)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert result == content
+
+
+def _build_collapsed_doc(content: str) -> CollapsedOverloadCodeDocumentation:
+    """Build a ``CollapsedOverloadCodeDocumentation`` with a stub inner documentation."""
+    inner = StubDocumentation({FILE_KEY: MdxFile(name=FILE_KEY, content=content, source_path=Path("test.py"))})
+    return CollapsedOverloadCodeDocumentation(documentation=inner)
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def sample_mdx_no_overloads() -> str:
+    return """\
 ---
 title: test
 ---
@@ -63,226 +131,6 @@ save(self, data: str) -> None
 ```python
 delete(self, id: str) -> None
 ```"""
-        doc = _build_collapsed_doc(content)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        assert result == content
-
-    def test_mixed_overloaded_and_non_overloaded(self, sample_mdx_with_overloads: str) -> None:
-        # Arrange
-        doc = _build_collapsed_doc(sample_mdx_with_overloads)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        methods = _method_headings(result, "InfrahubClient")
-        assert methods.count("get") == 1
-        assert methods.count("create") == 1
-        assert methods.count("delete") == 1
-        assert _has_details_block(result, "get")
-        assert _has_details_block(result, "create")
-        assert not _has_details_block(result, "delete")
-
-    def test_primary_is_overload_with_most_params(self, sample_mdx_with_overloads: str) -> None:
-        # Arrange
-        doc = _build_collapsed_doc(sample_mdx_with_overloads)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        primary_sig = _primary_signature(result, "InfrahubClient", "create")
-        assert "timeout" in primary_sig
-
-    def test_details_label_shows_correct_count(self, sample_mdx_with_overloads: str) -> None:
-        # Arrange
-        doc = _build_collapsed_doc(sample_mdx_with_overloads)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        assert "Show 2 other overloads" in result
-
-    def test_singular_label_for_two_overloads(self, sample_mdx_with_overloads: str) -> None:
-        # Arrange
-        doc = _build_collapsed_doc(sample_mdx_with_overloads)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        assert "Show 1 other overload" in result
-
-    def test_file_without_classes_returned_unchanged(self) -> None:
-        # Arrange
-        content = """\
----
-title: test
----
-
-# `test_module`
-
-## Functions
-
-### `helper_func`
-
-```python
-helper_func(x: int) -> str
-```"""
-        doc = _build_collapsed_doc(content)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        assert result == content
-
-    def test_multiple_classes_each_collapsed_independently(self) -> None:
-        # Arrange
-        content = """\
----
-title: test
----
-
-# `test_module`
-
-## Classes
-
-### `ClassA`
-
-**Methods:**
-
-#### `run`
-
-```python
-run(self, x: int) -> None
-```
-
-#### `run`
-
-```python
-run(self, x: int, y: int) -> None
-```
-
-### `ClassB`
-
-**Methods:**
-
-#### `execute`
-
-```python
-execute(self, a: str) -> None
-```
-
-#### `execute`
-
-```python
-execute(self, a: str, b: str) -> None
-```"""
-        doc = _build_collapsed_doc(content)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        assert _has_details_block(result, "run")
-        assert _has_details_block(result, "execute")
-        assert result.count("Show 1 other overload") == 2
-
-
-class TestNoOverloads:
-    def test_empty_content_passes_through(self) -> None:
-        # Arrange
-        content = "# minimal"
-        doc = _build_collapsed_doc(content)
-
-        # Act
-        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
-
-        # Assert
-        assert result == content
-
-
-# --- Helpers ---
-
-
-class _StubDocumentation(ACodeDocumentation):
-    """Minimal stub returning pre-built MdxFile dicts."""
-
-    def __init__(self, files: dict[str, MdxFile]) -> None:
-        self._files = files
-
-    def generate(self, context: Context, modules_to_document: list[str]) -> dict[str, MdxFile]:
-        return self._files
-
-
-def _build_collapsed_doc(content: str) -> CollapsedOverloadCodeDocumentation:
-    """Build a ``CollapsedOverloadCodeDocumentation`` with a stub inner documentation."""
-    inner = _StubDocumentation({FILE_KEY: MdxFile(name=FILE_KEY, content=content, source_path=Path("test.py"))})
-    return CollapsedOverloadCodeDocumentation(documentation=inner)
-
-
-def _method_headings(content: str, class_name: str) -> list[str]:
-    """Extract H4 method names under a given H3 class section, excluding those inside details blocks."""
-    pattern = rf"^### `{re.escape(class_name)}`\n(.*?)(?=^### |\Z)"
-    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
-    if not match:
-        return []
-    section = match.group(1)
-    in_details = False
-    methods: list[str] = []
-    for line in section.split("\n"):
-        if "<details>" in line:
-            in_details = True
-        elif "</details>" in line:
-            in_details = False
-        elif not in_details:
-            m = re.match(r"^#### `([^`]+)`", line)
-            if m:
-                methods.append(m.group(1))
-    return methods
-
-
-def _has_details_block(content: str, method_name: str) -> bool:
-    """Check if a <details> block exists near a method heading."""
-    pattern = rf"#### `{re.escape(method_name)}`.*?(?=#### |### |\Z)"
-    match = re.search(pattern, content, re.DOTALL)
-    if not match:
-        return False
-    return "<details>" in match.group(0)
-
-
-def _primary_signature(content: str, class_name: str, method_name: str) -> str:
-    """Extract the primary (visible, not inside details) signature for a method."""
-    pattern = rf"^### `{re.escape(class_name)}`\n(.*?)(?=^### |\Z)"
-    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
-    if not match:
-        return ""
-    section = match.group(1)
-    in_details = False
-    capture_next_fence = False
-    for line in section.split("\n"):
-        if "<details>" in line:
-            in_details = True
-        elif "</details>" in line:
-            in_details = False
-        elif not in_details and re.match(rf"^#### `{re.escape(method_name)}`", line):
-            capture_next_fence = True
-        elif capture_next_fence and line.startswith("```python"):
-            capture_next_fence = False
-        elif capture_next_fence is False and not in_details and line and not line.startswith("```"):
-            if "(" in line:
-                return line
-            capture_next_fence = None
-    return ""
-
-
-# --- Fixtures ---
 
 
 @pytest.fixture

--- a/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py
@@ -81,6 +81,42 @@ class TestCollapseOverloads:
         assert "Show 1 other overload" in result
 
 
+class TestPropertyPairNotCollapsed:
+    def test_property_getter_setter_kept_separate(self, sample_mdx_with_property_pair: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_property_pair)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "<details>" not in result
+        assert result.count("#### `value`") == 2
+
+    def test_property_getter_setter_deleter_kept_separate(self, sample_mdx_with_property_triplet: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_property_triplet)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "<details>" not in result
+        assert result.count("#### `value`") == 3
+
+    def test_property_pair_alongside_real_overloads(self, sample_mdx_property_and_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_property_and_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert result.count("#### `value`") == 2
+        assert "<details>" in result
+        assert "#### `get`" in result
+
+
 class TestNoOverloads:
     def test_empty_content_passes_through(self) -> None:
         # Arrange
@@ -185,4 +221,121 @@ create(self, kind: str, data: dict | None = None, branch: str | None = None, tim
 
 ```python
 delete(self, kind: str, id: str) -> None
+```"""
+
+
+@pytest.fixture
+def sample_mdx_with_property_pair() -> str:
+    return """\
+---
+title: attribute
+sidebarTitle: attribute
+---
+
+# `infrahub_sdk.node.attribute`
+
+## Classes
+
+### `Attribute`
+
+Represents an attribute of a Node.
+
+**Methods:**
+
+#### `value`
+
+```python
+value(self) -> Any
+```
+
+#### `value`
+
+```python
+value(self, value: Any) -> None
+```"""
+
+
+@pytest.fixture
+def sample_mdx_property_and_overloads() -> str:
+    return """\
+---
+title: attribute
+sidebarTitle: attribute
+---
+
+# `infrahub_sdk.node.attribute`
+
+## Classes
+
+### `Attribute`
+
+Represents an attribute of a Node.
+
+**Methods:**
+
+#### `value`
+
+```python
+value(self) -> Any
+```
+
+#### `value`
+
+```python
+value(self, value: Any) -> None
+```
+
+#### `get`
+
+```python
+get(self, kind: str) -> InfrahubNode
+```
+
+#### `get`
+
+```python
+get(self, kind: str, id: int) -> InfrahubNode
+```
+
+#### `get`
+
+```python
+get(self, kind: str, id: int, branch: str) -> InfrahubNode
+```"""
+
+
+@pytest.fixture
+def sample_mdx_with_property_triplet() -> str:
+    return """\
+---
+title: attribute
+sidebarTitle: attribute
+---
+
+# `infrahub_sdk.node.attribute`
+
+## Classes
+
+### `Attribute`
+
+Represents an attribute of a Node.
+
+**Methods:**
+
+#### `value`
+
+```python
+value(self) -> Any
+```
+
+#### `value`
+
+```python
+value(self, value: Any) -> None
+```
+
+#### `value`
+
+```python
+value(self) -> None
 ```"""

--- a/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py
@@ -1,0 +1,340 @@
+"""Tests for CollapsedOverloadCodeDocumentation pipeline decorator."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from docs.docs_generation.content_gen_methods.mdx.mdx_code_doc import ACodeDocumentation, MdxFile
+from docs.docs_generation.content_gen_methods.mdx.mdx_collapsed_overload_code_doc import (
+    CollapsedOverloadCodeDocumentation,
+)
+
+if TYPE_CHECKING:
+    from invoke import Context
+
+FILE_KEY = "test.mdx"
+MOCK_CONTEXT = MagicMock(spec="Context")
+MODULES: list[str] = []
+
+
+class TestCollapseOverloads:
+    def test_overloaded_methods_collapsed_to_primary_plus_details(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        get_headings = _method_headings(result, "InfrahubClient")
+        assert get_headings.count("get") == 1
+        assert _has_details_block(result, "get")
+
+    def test_non_overloaded_methods_unchanged(self) -> None:
+        # Arrange
+        content = """\
+---
+title: test
+---
+
+# `test_module`
+
+## Classes
+
+### `MyClass`
+
+A simple class.
+
+**Methods:**
+
+#### `save`
+
+```python
+save(self, data: str) -> None
+```
+
+#### `delete`
+
+```python
+delete(self, id: str) -> None
+```"""
+        doc = _build_collapsed_doc(content)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert result == content
+
+    def test_mixed_overloaded_and_non_overloaded(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        methods = _method_headings(result, "InfrahubClient")
+        assert methods.count("get") == 1
+        assert methods.count("create") == 1
+        assert methods.count("delete") == 1
+        assert _has_details_block(result, "get")
+        assert _has_details_block(result, "create")
+        assert not _has_details_block(result, "delete")
+
+    def test_primary_is_overload_with_most_params(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        primary_sig = _primary_signature(result, "InfrahubClient", "create")
+        assert "timeout" in primary_sig
+
+    def test_details_label_shows_correct_count(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "Show 2 other overloads" in result
+
+    def test_singular_label_for_two_overloads(self, sample_mdx_with_overloads: str) -> None:
+        # Arrange
+        doc = _build_collapsed_doc(sample_mdx_with_overloads)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert "Show 1 other overload" in result
+
+    def test_file_without_classes_returned_unchanged(self) -> None:
+        # Arrange
+        content = """\
+---
+title: test
+---
+
+# `test_module`
+
+## Functions
+
+### `helper_func`
+
+```python
+helper_func(x: int) -> str
+```"""
+        doc = _build_collapsed_doc(content)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert result == content
+
+    def test_multiple_classes_each_collapsed_independently(self) -> None:
+        # Arrange
+        content = """\
+---
+title: test
+---
+
+# `test_module`
+
+## Classes
+
+### `ClassA`
+
+**Methods:**
+
+#### `run`
+
+```python
+run(self, x: int) -> None
+```
+
+#### `run`
+
+```python
+run(self, x: int, y: int) -> None
+```
+
+### `ClassB`
+
+**Methods:**
+
+#### `execute`
+
+```python
+execute(self, a: str) -> None
+```
+
+#### `execute`
+
+```python
+execute(self, a: str, b: str) -> None
+```"""
+        doc = _build_collapsed_doc(content)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert _has_details_block(result, "run")
+        assert _has_details_block(result, "execute")
+        assert result.count("Show 1 other overload") == 2
+
+
+class TestNoOverloads:
+    def test_empty_content_passes_through(self) -> None:
+        # Arrange
+        content = "# minimal"
+        doc = _build_collapsed_doc(content)
+
+        # Act
+        result = doc.generate(MOCK_CONTEXT, MODULES)[FILE_KEY].content
+
+        # Assert
+        assert result == content
+
+
+# --- Helpers ---
+
+
+class _StubDocumentation(ACodeDocumentation):
+    """Minimal stub returning pre-built MdxFile dicts."""
+
+    def __init__(self, files: dict[str, MdxFile]) -> None:
+        self._files = files
+
+    def generate(self, context: Context, modules_to_document: list[str]) -> dict[str, MdxFile]:
+        return self._files
+
+
+def _build_collapsed_doc(content: str) -> CollapsedOverloadCodeDocumentation:
+    """Build a ``CollapsedOverloadCodeDocumentation`` with a stub inner documentation."""
+    inner = _StubDocumentation({FILE_KEY: MdxFile(name=FILE_KEY, content=content, source_path=Path("test.py"))})
+    return CollapsedOverloadCodeDocumentation(documentation=inner)
+
+
+def _method_headings(content: str, class_name: str) -> list[str]:
+    """Extract H4 method names under a given H3 class section, excluding those inside details blocks."""
+    pattern = rf"^### `{re.escape(class_name)}`\n(.*?)(?=^### |\Z)"
+    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+    if not match:
+        return []
+    section = match.group(1)
+    in_details = False
+    methods: list[str] = []
+    for line in section.split("\n"):
+        if "<details>" in line:
+            in_details = True
+        elif "</details>" in line:
+            in_details = False
+        elif not in_details:
+            m = re.match(r"^#### `([^`]+)`", line)
+            if m:
+                methods.append(m.group(1))
+    return methods
+
+
+def _has_details_block(content: str, method_name: str) -> bool:
+    """Check if a <details> block exists near a method heading."""
+    pattern = rf"#### `{re.escape(method_name)}`.*?(?=#### |### |\Z)"
+    match = re.search(pattern, content, re.DOTALL)
+    if not match:
+        return False
+    return "<details>" in match.group(0)
+
+
+def _primary_signature(content: str, class_name: str, method_name: str) -> str:
+    """Extract the primary (visible, not inside details) signature for a method."""
+    pattern = rf"^### `{re.escape(class_name)}`\n(.*?)(?=^### |\Z)"
+    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+    if not match:
+        return ""
+    section = match.group(1)
+    in_details = False
+    capture_next_fence = False
+    for line in section.split("\n"):
+        if "<details>" in line:
+            in_details = True
+        elif "</details>" in line:
+            in_details = False
+        elif not in_details and re.match(rf"^#### `{re.escape(method_name)}`", line):
+            capture_next_fence = True
+        elif capture_next_fence and line.startswith("```python"):
+            capture_next_fence = False
+        elif capture_next_fence is False and not in_details and line and not line.startswith("```"):
+            if "(" in line:
+                return line
+            capture_next_fence = None
+    return ""
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def sample_mdx_with_overloads() -> str:
+    return """\
+---
+title: client
+sidebarTitle: client
+---
+
+# `infrahub_sdk.client`
+
+## Classes
+
+### `InfrahubClient`
+
+GraphQL Client to interact with Infrahub.
+
+**Methods:**
+
+#### `get`
+
+```python
+get(self, kind: str) -> InfrahubNode
+```
+
+#### `get`
+
+```python
+get(self, kind: type[SchemaType]) -> SchemaType
+```
+
+#### `get`
+
+```python
+get(self, kind: str | type[SchemaType], raise_when_missing: bool = True) -> InfrahubNode | SchemaType | None
+```
+
+#### `create`
+
+```python
+create(self, kind: str) -> InfrahubNode
+```
+
+#### `create`
+
+```python
+create(self, kind: str, data: dict | None = None, branch: str | None = None, timeout: int | None = None) -> InfrahubNode
+```
+
+#### `delete`
+
+```python
+delete(self, kind: str, id: str) -> None
+```"""

--- a/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_section.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_section.py
@@ -1,4 +1,4 @@
-"""Tests for CollapsedOverloadSection and SignatureParameterCount."""
+"""Tests for CollapsedOverloadSection."""
 
 from __future__ import annotations
 
@@ -6,127 +6,16 @@ import pytest
 
 from docs.docs_generation.content_gen_methods.mdx.mdx_collapsed_overload_section import (
     CollapsedOverloadSection,
-    SignatureParameterCount,
 )
-from docs.docs_generation.content_gen_methods.mdx.mdx_section import ASection, MdxSection
+from docs.docs_generation.content_gen_methods.mdx.mdx_section import ASection
 
-
-class TestSignatureParameterCount:
-    def test_simple_signature_returns_correct_count(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, kind: str, id: int)")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 2
-
-    def test_self_only_returns_zero(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self)")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 0
-
-    def test_kwargs_counts_as_one(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, **kwargs: Any)")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 1
-
-    def test_args_and_kwargs_count_separately(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, *args: str, **kwargs: Any)")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 2
-
-    def test_nested_brackets_not_split(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, kind: dict[str, int], other: list[str])")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 2
-
-    def test_deeply_nested_generics(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, x: dict[str, list[tuple[int, ...]]])")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 1
-
-    def test_signature_with_return_type(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, kind: str) -> InfrahubNode")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 1
-
-    def test_default_values_dont_affect_count(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get(self, kind: str = ..., id: int = None)")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 2
-
-    def test_real_world_get_signature(self) -> None:
-        # Arrange
-        signature = (
-            "get(self, kind: str | type[SchemaType], raise_when_missing: bool = True, "
-            "at: Timestamp | None = None, branch: str | None = None, "
-            "timeout: int | None = None, id: str | None = None, "
-            "hfid: list[str] | None = None, include: list[str] | None = None, "
-            "exclude: list[str] | None = None, populate_store: bool = True, "
-            "fragment: bool = False, prefetch_relationships: bool = False, "
-            "property: bool = False, include_metadata: bool = False, "
-            "**kwargs: Any) -> InfrahubNode | SchemaType | None"
-        )
-        counter = SignatureParameterCount(signature=signature)
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 15
-
-    def test_empty_signature(self) -> None:
-        # Arrange
-        counter = SignatureParameterCount(signature="get()")
-
-        # Act
-        result = counter.value()
-
-        # Assert
-        assert result == 0
+from .conftest import make_method_section
 
 
 class TestCollapsedOverloadSection:
     def test_heading_delegates_to_primary(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, kind: str)")
+        primary = make_method_section("get", "get(self, kind: str)")
         section = CollapsedOverloadSection(primary=primary, others=[])
 
         # Act
@@ -137,7 +26,7 @@ class TestCollapsedOverloadSection:
 
     def test_no_others_returns_primary_content_only(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, kind: str)")
+        primary = make_method_section("get", "get(self, kind: str)")
         section = CollapsedOverloadSection(primary=primary, others=[])
 
         # Act
@@ -149,9 +38,9 @@ class TestCollapsedOverloadSection:
 
     def test_others_rendered_in_details_block(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, kind: str, id: int)")
-        other1 = _make_method_section("get", "get(self, kind: str)")
-        other2 = _make_method_section("get", "get(self)")
+        primary = make_method_section("get", "get(self, kind: str, id: int)")
+        other1 = make_method_section("get", "get(self, kind: str)")
+        other2 = make_method_section("get", "get(self)")
         section = CollapsedOverloadSection(primary=primary, others=[other1, other2])
 
         # Act
@@ -164,8 +53,8 @@ class TestCollapsedOverloadSection:
 
     def test_singular_label_for_one_other(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, kind: str)")
-        other = _make_method_section("get", "get(self)")
+        primary = make_method_section("get", "get(self, kind: str)")
+        other = make_method_section("get", "get(self)")
         section = CollapsedOverloadSection(primary=primary, others=[other])
 
         # Act
@@ -176,8 +65,8 @@ class TestCollapsedOverloadSection:
 
     def test_plural_label_for_multiple_others(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, a: int, b: int, c: int)")
-        others = [_make_method_section("get", f"get(self, x{i}: int)") for i in range(3)]
+        primary = make_method_section("get", "get(self, a: int, b: int, c: int)")
+        others = [make_method_section("get", f"get(self, x{i}: int)") for i in range(3)]
         section = CollapsedOverloadSection(primary=primary, others=others)
 
         # Act
@@ -188,7 +77,7 @@ class TestCollapsedOverloadSection:
 
     def test_lines_includes_heading_plus_content(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, kind: str)")
+        primary = make_method_section("get", "get(self, kind: str)")
         section = CollapsedOverloadSection(primary=primary, others=[])
 
         # Act
@@ -204,8 +93,8 @@ class TestCollapsedOverloadSection:
 
     def test_details_block_contains_other_section_lines(self) -> None:
         # Arrange
-        primary = _make_method_section("get", "get(self, kind: str, id: int)")
-        other = _make_method_section("get", "get(self, kind: str)", docstring="Get by kind.")
+        primary = make_method_section("get", "get(self, kind: str, id: int)")
+        other = make_method_section("get", "get(self, kind: str)", docstring="Get by kind.")
         section = CollapsedOverloadSection(primary=primary, others=[other])
 
         # Act
@@ -219,9 +108,9 @@ class TestCollapsedOverloadSection:
 class TestCollapsedOverloadSectionFromOverloads:
     def test_primary_is_overload_with_most_params(self) -> None:
         # Arrange
-        s1 = _make_method_section("get", "get(self, a: int, b: int)")
-        s2 = _make_method_section("get", "get(self, a: int, b: int, c: int, d: int, e: int)")
-        s3 = _make_method_section("get", "get(self, a: int, b: int, c: int)")
+        s1 = make_method_section("get", "get(self, a: int, b: int)")
+        s2 = make_method_section("get", "get(self, a: int, b: int, c: int, d: int, e: int)")
+        s3 = make_method_section("get", "get(self, a: int, b: int, c: int)")
 
         # Act
         section = CollapsedOverloadSection.from_overloads([s1, s2, s3])
@@ -232,8 +121,8 @@ class TestCollapsedOverloadSectionFromOverloads:
 
     def test_tie_breaking_selects_first_in_source_order(self) -> None:
         # Arrange
-        s1 = _make_method_section("get", "get(self, a: int, b: str)")
-        s2 = _make_method_section("get", "get(self, x: int, y: str)")
+        s1 = make_method_section("get", "get(self, a: int, b: str)")
+        s2 = make_method_section("get", "get(self, x: int, y: str)")
 
         # Act
         section = CollapsedOverloadSection.from_overloads([s1, s2])
@@ -244,7 +133,7 @@ class TestCollapsedOverloadSectionFromOverloads:
 
     def test_single_section_returns_no_others(self) -> None:
         # Arrange
-        s1 = _make_method_section("get", "get(self, kind: str)")
+        s1 = make_method_section("get", "get(self, kind: str)")
 
         # Act
         section = CollapsedOverloadSection.from_overloads([s1])
@@ -257,20 +146,3 @@ class TestCollapsedOverloadSectionFromOverloads:
         # Act / Assert
         with pytest.raises(ValueError, match="empty"):
             CollapsedOverloadSection.from_overloads([])
-
-
-# --- Helpers ---
-
-
-def _make_method_section(name: str, signature: str, docstring: str = "") -> MdxSection:
-    """Create an MdxSection mimicking a method entry in MDX output."""
-    lines = [
-        f"#### `{name}`",
-        "",
-        "```python",
-        signature,
-        "```",
-    ]
-    if docstring:
-        lines.extend(("", docstring))
-    return MdxSection(name=name, heading_level=4, _lines=lines)

--- a/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_section.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_section.py
@@ -1,0 +1,276 @@
+"""Tests for CollapsedOverloadSection and SignatureParameterCount."""
+
+from __future__ import annotations
+
+import pytest
+
+from docs.docs_generation.content_gen_methods.mdx.mdx_collapsed_overload_section import (
+    CollapsedOverloadSection,
+    SignatureParameterCount,
+)
+from docs.docs_generation.content_gen_methods.mdx.mdx_section import ASection, MdxSection
+
+
+class TestSignatureParameterCount:
+    def test_simple_signature_returns_correct_count(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, kind: str, id: int)")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 2
+
+    def test_self_only_returns_zero(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self)")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 0
+
+    def test_kwargs_counts_as_one(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, **kwargs: Any)")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 1
+
+    def test_args_and_kwargs_count_separately(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, *args: str, **kwargs: Any)")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 2
+
+    def test_nested_brackets_not_split(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, kind: dict[str, int], other: list[str])")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 2
+
+    def test_deeply_nested_generics(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, x: dict[str, list[tuple[int, ...]]])")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 1
+
+    def test_signature_with_return_type(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, kind: str) -> InfrahubNode")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 1
+
+    def test_default_values_dont_affect_count(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get(self, kind: str = ..., id: int = None)")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 2
+
+    def test_real_world_get_signature(self) -> None:
+        # Arrange
+        signature = (
+            "get(self, kind: str | type[SchemaType], raise_when_missing: bool = True, "
+            "at: Timestamp | None = None, branch: str | None = None, "
+            "timeout: int | None = None, id: str | None = None, "
+            "hfid: list[str] | None = None, include: list[str] | None = None, "
+            "exclude: list[str] | None = None, populate_store: bool = True, "
+            "fragment: bool = False, prefetch_relationships: bool = False, "
+            "property: bool = False, include_metadata: bool = False, "
+            "**kwargs: Any) -> InfrahubNode | SchemaType | None"
+        )
+        counter = SignatureParameterCount(signature=signature)
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 15
+
+    def test_empty_signature(self) -> None:
+        # Arrange
+        counter = SignatureParameterCount(signature="get()")
+
+        # Act
+        result = counter.value()
+
+        # Assert
+        assert result == 0
+
+
+class TestCollapsedOverloadSection:
+    def test_heading_delegates_to_primary(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, kind: str)")
+        section = CollapsedOverloadSection(primary=primary, others=[])
+
+        # Act
+        result = section.heading
+
+        # Assert
+        assert result == primary.heading
+
+    def test_no_others_returns_primary_content_only(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, kind: str)")
+        section = CollapsedOverloadSection(primary=primary, others=[])
+
+        # Act
+        result = section.content
+
+        # Assert
+        assert result == primary.content
+        assert "<details>" not in "\n".join(result)
+
+    def test_others_rendered_in_details_block(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, kind: str, id: int)")
+        other1 = _make_method_section("get", "get(self, kind: str)")
+        other2 = _make_method_section("get", "get(self)")
+        section = CollapsedOverloadSection(primary=primary, others=[other1, other2])
+
+        # Act
+        result = "\n".join(section.content)
+
+        # Assert
+        assert "<details>" in result
+        assert "<summary>Show 2 other overloads</summary>" in result
+        assert "</details>" in result
+
+    def test_singular_label_for_one_other(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, kind: str)")
+        other = _make_method_section("get", "get(self)")
+        section = CollapsedOverloadSection(primary=primary, others=[other])
+
+        # Act
+        result = "\n".join(section.content)
+
+        # Assert
+        assert "<summary>Show 1 other overload</summary>" in result
+
+    def test_plural_label_for_multiple_others(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, a: int, b: int, c: int)")
+        others = [_make_method_section("get", f"get(self, x{i}: int)") for i in range(3)]
+        section = CollapsedOverloadSection(primary=primary, others=others)
+
+        # Act
+        result = "\n".join(section.content)
+
+        # Assert
+        assert "<summary>Show 3 other overloads</summary>" in result
+
+    def test_lines_includes_heading_plus_content(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, kind: str)")
+        section = CollapsedOverloadSection(primary=primary, others=[])
+
+        # Act
+        result = section.lines
+
+        # Assert
+        assert result[0] == section.heading
+        assert result[1:] == section.content
+
+    def test_is_asection_subclass(self) -> None:
+        # Assert
+        assert issubclass(CollapsedOverloadSection, ASection)
+
+    def test_details_block_contains_other_section_lines(self) -> None:
+        # Arrange
+        primary = _make_method_section("get", "get(self, kind: str, id: int)")
+        other = _make_method_section("get", "get(self, kind: str)", docstring="Get by kind.")
+        section = CollapsedOverloadSection(primary=primary, others=[other])
+
+        # Act
+        result = "\n".join(section.content)
+
+        # Assert
+        assert "Get by kind." in result
+        assert "get(self, kind: str)" in result
+
+
+class TestCollapsedOverloadSectionFromOverloads:
+    def test_primary_is_overload_with_most_params(self) -> None:
+        # Arrange
+        s1 = _make_method_section("get", "get(self, a: int, b: int)")
+        s2 = _make_method_section("get", "get(self, a: int, b: int, c: int, d: int, e: int)")
+        s3 = _make_method_section("get", "get(self, a: int, b: int, c: int)")
+
+        # Act
+        section = CollapsedOverloadSection.from_overloads([s1, s2, s3])
+
+        # Assert
+        assert "e: int" in "\n".join(section.primary.lines)
+        assert len(section.others) == 2
+
+    def test_tie_breaking_selects_first_in_source_order(self) -> None:
+        # Arrange
+        s1 = _make_method_section("get", "get(self, a: int, b: str)")
+        s2 = _make_method_section("get", "get(self, x: int, y: str)")
+
+        # Act
+        section = CollapsedOverloadSection.from_overloads([s1, s2])
+
+        # Assert
+        assert "a: int" in "\n".join(section.primary.lines)
+        assert len(section.others) == 1
+
+    def test_single_section_returns_no_others(self) -> None:
+        # Arrange
+        s1 = _make_method_section("get", "get(self, kind: str)")
+
+        # Act
+        section = CollapsedOverloadSection.from_overloads([s1])
+
+        # Assert
+        assert section.primary is s1
+        assert section.others == []
+
+    def test_empty_list_raises(self) -> None:
+        # Act / Assert
+        with pytest.raises(ValueError, match="empty"):
+            CollapsedOverloadSection.from_overloads([])
+
+
+# --- Helpers ---
+
+
+def _make_method_section(name: str, signature: str, docstring: str = "") -> MdxSection:
+    """Create an MdxSection mimicking a method entry in MDX output."""
+    lines = [
+        f"#### `{name}`",
+        "",
+        "```python",
+        signature,
+        "```",
+    ]
+    if docstring:
+        lines.extend(("", docstring))
+    return MdxSection(name=name, heading_level=4, _lines=lines)

--- a/tests/unit/doc_generation/mdx/test_mdx_method_signature.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_method_signature.py
@@ -131,3 +131,66 @@ class TestMethodSignatureParamCount:
 
         # Assert
         assert result == 0
+
+
+class TestMethodSignatureReturnType:
+    def test_returns_none_type(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("value", "value(self, value: Any) -> None"))
+
+        # Act
+        result = sig.return_type()
+
+        # Assert
+        assert result == "None"
+
+    def test_returns_concrete_type(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("value", "value(self) -> Any"))
+
+        # Act
+        result = sig.return_type()
+
+        # Assert
+        assert result == "Any"
+
+    def test_no_return_annotation_returns_empty(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, kind: str)"))
+
+        # Act
+        result = sig.return_type()
+
+        # Assert
+        assert not result
+
+    def test_generic_return_type(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self) -> dict[str, list[int]]"))
+
+        # Act
+        result = sig.return_type()
+
+        # Assert
+        assert result == "dict[str, list[int]]"
+
+    def test_union_return_type(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, kind: str) -> InfrahubNode | None"))
+
+        # Act
+        result = sig.return_type()
+
+        # Assert
+        assert result == "InfrahubNode | None"
+
+    def test_no_code_fence_returns_empty(self) -> None:
+        # Arrange
+        section = MdxSection(name="get", heading_level=4, _lines=["#### `get`", "", "Some description."])
+        sig = MethodSignature(section)
+
+        # Act
+        result = sig.return_type()
+
+        # Assert
+        assert not result

--- a/tests/unit/doc_generation/mdx/test_mdx_method_signature.py
+++ b/tests/unit/doc_generation/mdx/test_mdx_method_signature.py
@@ -1,0 +1,133 @@
+"""Tests for MethodSignature."""
+
+from __future__ import annotations
+
+from docs.docs_generation.content_gen_methods.mdx.mdx_collapsed_overload_section import (
+    MethodSignature,
+)
+from docs.docs_generation.content_gen_methods.mdx.mdx_section import MdxSection
+
+from .conftest import make_method_section
+
+
+class TestMethodSignatureParamCount:
+    def test_simple_signature_returns_correct_count(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, kind: str, id: int)"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 2
+
+    def test_self_only_returns_zero(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self)"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 0
+
+    def test_kwargs_counts_as_one(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, **kwargs: Any)"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 1
+
+    def test_args_and_kwargs_count_separately(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, *args: str, **kwargs: Any)"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 2
+
+    def test_nested_brackets_not_split(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, kind: dict[str, int], other: list[str])"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 2
+
+    def test_deeply_nested_generics(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, x: dict[str, list[tuple[int, ...]]])"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 1
+
+    def test_signature_with_return_type(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, kind: str) -> InfrahubNode"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 1
+
+    def test_default_values_dont_affect_count(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get(self, kind: str = ..., id: int = None)"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 2
+
+    def test_real_world_get_signature(self) -> None:
+        # Arrange
+        signature = (
+            "get(self, kind: str | type[SchemaType], raise_when_missing: bool = True, "
+            "at: Timestamp | None = None, branch: str | None = None, "
+            "timeout: int | None = None, id: str | None = None, "
+            "hfid: list[str] | None = None, include: list[str] | None = None, "
+            "exclude: list[str] | None = None, populate_store: bool = True, "
+            "fragment: bool = False, prefetch_relationships: bool = False, "
+            "property: bool = False, include_metadata: bool = False, "
+            "**kwargs: Any) -> InfrahubNode | SchemaType | None"
+        )
+        sig = MethodSignature(make_method_section("get", signature))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 15
+
+    def test_empty_signature(self) -> None:
+        # Arrange
+        sig = MethodSignature(make_method_section("get", "get()"))
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 0
+
+    def test_no_code_fence_returns_zero(self) -> None:
+        # Arrange
+        section = MdxSection(name="get", heading_level=4, _lines=["#### `get`", "", "Some description."])
+        sig = MethodSignature(section)
+
+        # Act
+        result = sig.param_count()
+
+        # Assert
+        assert result == 0


### PR DESCRIPTION
# Why

The generated SDK API reference documentation (`client.mdx`, `attribute.mdx`) lists every overload of methods like `get()`, `create()`, `all()`, `filters()`, and `allocate_next_ip_*()` one after another, creating walls of nearly-identical
signatures that overwhelm readers with useless and repetitive information.

**Goal:** Automatically collapse groups of consecutive overloaded method sections into one primary signature (the most-parameter variant) followed by a collapsible `<details>` block containing the remaining overloads, so users see the essential API surface first and can expand for specifics.

Closes [IHS-206]

## What changed

- **New section type`CollapsedOverloadSection`**: selects the overload with the most parameters (excluding `self`) as the "primary" entry via the `from_overloads()` factory; ties are broken by source order (first wins). Wraps the rest in a `<details><summary>Show N other overload(s)</summary>` block.
- **New pipeline decorator: `CollapsedOverloadCodeDocumentation`** wraps any `ACodeDocumentation` (decorator pattern), walks the H2 → H3 → H4 section hierarchy, groups consecutive same-name H4 entries and replaces multi-entry groups with `CollapsedOverloadSection`. Each nesting level returns `None` on no-op for early exit, avoiding unnecessary content reconstruction.
- **Pipeline wiring**: code has been wired to documentation generation tasks `docs-generate`.
- **Regenerated docs** : SDK API documentation has been updated with the collapsable sections.

**What stayed the same:** Priority ordering (IHS-205), non-overloaded methods, all other generated documentation content.

  ### Suggested review order

1. `docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py`: core algorithm
2. `docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_code_doc.py`: pipeline decorator
3. `tasks.py` change  — wiring

  ## How to review

- **Focus on:** The collapsing algorithm in `CollapsedOverloadSection.from_overloads()` and the H2→H3→H4 traversal in `CollapsedOverloadCodeDocumentation._collapse_overloads()`.

  ## How to test

```bash
### Unit tests (all three test files)
uv run pytest tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_section.py -v
uv run pytest tests/unit/doc_generation/mdx/test_mdx_collapsed_overload_code_doc.py -v
uv run pytest tests/unit/doc_generation/mdx/test_mdx_method_signature.py -v

### Regenerate docs and verify no diff
uv run invoke docs-generate
uv run invoke docs-validate
```

### Documentation site 
Navigate to Python SDK > Reference > client — overloaded methods should show a single signature with expandable "Show N other overload(s)"

Impact & rollout

- Backward compatibility: No breaking changes. Pages without overloads are unchanged. The <details> HTML element is natively supported by Docusaurus/MDX.
- Performance: Negligible — adds one extra pass over parsed sections during doc generation (build-time only, not runtime).
- Config/env changes: None.
- Deployment notes: Check `infrahub-docs` project after the merge.

Checklist

- Tests added/updated -> Yes
- External docs updated (if user-facing or ops-facing change) -> Yes
- Internal .md docs updated (internal knowledge and AI code tools knowledge) -> No

[IHS-206]: https://opsmill.atlassian.net/browse/IHS-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ