### PR TITLE
Fix: Wrong type passed to first argument of `pytest.mark.parametrize`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -428,7 +428,6 @@ max-complexity = 17
     "S106",    # Possible hardcoded password assigned to argument
     "ARG001",  # Unused function argument
     "ARG002",  # Unused method argument
-    "PT006",   # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
     "PT011",   # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
     "PT012",   # `pytest.raises()` block should contain a single simple statement
 ]

--- a/tests/unit/ctl/test_render_app.py
+++ b/tests/unit/ctl/test_render_app.py
@@ -71,7 +71,7 @@ def test_validate_template_not_found(test_case: RenderAppFailure, httpx_mock: HT
 
 
 @pytest.mark.parametrize(
-    "cli_branch,env_branch,from_git,expected_branch",
+    ("cli_branch", "env_branch", "from_git", "expected_branch"),
     [
         ("cli-branch", None, False, "cli-branch"),
         (None, "env-branch", False, "env-branch"),

--- a/tests/unit/sdk/spec/test_object.py
+++ b/tests/unit/sdk/spec/test_object.py
@@ -236,7 +236,7 @@ get_relationship_info_testdata = [
 ]
 
 
-@pytest.mark.parametrize("data,is_valid,format", get_relationship_info_testdata)
+@pytest.mark.parametrize(("data", "is_valid", "format"), get_relationship_info_testdata)
 async def test_get_relationship_info_tags(
     client_with_schema_01: InfrahubClient,
     data: dict | list,

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -280,7 +280,7 @@ async def test_method_all_multiple_pages(
     assert len(repos) == 5
 
 
-@pytest.mark.parametrize("client_type, use_parallel", batch_client_types)
+@pytest.mark.parametrize(("client_type", "use_parallel"), batch_client_types)
 async def test_method_all_batching(
     clients: BothClients,
     mock_query_location_batch_count: HTTPXMock,

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -132,7 +132,9 @@ async def test_validate_method_signature(
     )
 
 
-@pytest.mark.parametrize("hfid,expected_kind,expected_hfid", [("BuiltinLocation__JFK1", "BuiltinLocation", ["JFK1"])])
+@pytest.mark.parametrize(
+    ("hfid", "expected_kind", "expected_hfid"), [("BuiltinLocation__JFK1", "BuiltinLocation", ["JFK1"])]
+)
 def test_parse_human_friendly_id(hfid: str, expected_kind: str, expected_hfid: list[str]) -> None:
     kind, hfid = parse_human_friendly_id(hfid)
     assert kind == expected_kind

--- a/tests/unit/sdk/test_query_analyzer.py
+++ b/tests/unit/sdk/test_query_analyzer.py
@@ -148,7 +148,7 @@ async def test_get_variables(query_01: str, query_04: str, query_05: str, query_
 
 
 @pytest.mark.parametrize(
-    "var_type,var_required",
+    ("var_type", "var_required"),
     [("[ID]", False), ("[ID]!", True), ("[ID!]", False), ("[ID!]!", True)],
 )
 async def test_get_nested_variables(var_type: str, var_required: bool) -> None:

--- a/tests/unit/sdk/test_timestamp.py
+++ b/tests/unit/sdk/test_timestamp.py
@@ -43,7 +43,7 @@ def test_parse_string() -> None:
 
 
 @pytest.mark.parametrize(
-    "input_str,expected_datetime",
+    ("input_str", "expected_datetime"),
     [
         pytest.param(
             "2022-01-01T10:01:01.123000Z", datetime(2022, 1, 1, 10, 1, 1, 123000, tzinfo=UTC), id="milliseconds"
@@ -69,7 +69,7 @@ def test_to_datetime(input_str: str, expected_datetime: datetime) -> None:
 
 
 @pytest.mark.parametrize(
-    "input_str,expected_str,expected_str_no_z",
+    ("input_str", "expected_str", "expected_str_no_z"),
     [
         pytest.param(
             "2022-01-01T10:01:01.123000Z",


### PR DESCRIPTION
# Why

Minor linting correction

## What changed

Use the correct parameter type for pytest.mark.parametrize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete test warning suppression from project configuration.

* **Tests**
  * Refactored test parameterization declarations across multiple test modules using standardized syntax for improved code consistency and maintainability in the testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->