### PR TITLE
Add doc regeneration rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ uv sync --all-groups --all-extras   # Install all deps
 uv run invoke format                # Format code
 uv run invoke lint                  # Full pipeline: ruff, yamllint, ty, mypy, markdownlint, vale
 uv run invoke lint-code             # All linters for Python code
+uv run invoke docs-generate         # Generate all docs (CLI + SDK)
+uv run invoke docs-validate         # Check generated docs match committed version
 uv run pytest tests/unit/           # Unit tests
 uv run pytest tests/integration/    # Integration tests
 ```
@@ -54,7 +56,7 @@ Key rules:
 ✅ **Always**
 
 - Run `uv run invoke format lint-code` before committing Python code
-- Run `uv run invoke generate-sdk generate-infrahubctl` after changing CLI commands or SDK config
+- Run `uv run invoke docs-generate` after creating, modifying or deleting CLI commands, SDK config, or Python docstrings
 - Run markdownlint before committing markdown changes
 - Follow async/sync dual pattern for new features
 - Use type hints on all function signatures

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,5 +66,7 @@ Use callouts for important notes.
 
 🚫 **Never**
 
-- Edit `docs/infrahubctl/*.mdx` directly (regenerate with `uv run invoke generate-infrahubctl`)
-- Edit `docs/python-sdk/reference/config.mdx` directly (regenerate with `uv run invoke generate-sdk`)
+- Edit `docs/infrahubctl/*.mdx` directly (regenerate with `uv run invoke docs-generate`)
+- Edit `docs/python-sdk/reference/config.mdx` directly (regenerate with `uv run invoke docs-generate`)
+- Edit `docs/python-sdk/reference/templating.mdx` directly (regenerate with `uv run invoke docs-generate`)
+- Edit `docs/python-sdk/sdk_ref/**/*.mdx` directly (regenerate with `uv run invoke docs-generate`)


### PR DESCRIPTION
Just seen the Agents.MD rule update on `stable` branch https://github.com/opsmill/infrahub-sdk-python/pull/837/changes 

Adapted it to new documentation generation code which has been merged in the following PRs: https://github.com/opsmill/infrahub-sdk-python/pull/822 & https://github.com/opsmill/infrahub-sdk-python/pull/832 & https://github.com/opsmill/infrahub-sdk-python/pull/833


**Documentation**
Add reminder to `run invoke docs-generate` after changing CLI commands, SDK config or Python docstrings so generated docs stay in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two local workflow commands: docs-generate and docs-validate to streamline documentation updates.
  * Updated guidelines to require running docs-generate after creating, modifying, or deleting CLI commands, SDK config, or Python docstrings.
  * Replaced prior separate regeneration instructions with a unified docs-generate workflow and adjusted related wording for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->