### PR TITLE
Set version to 1.19.0 release candidate 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-sdk"
-version = "1.19.0b0"
+version = "1.19.0rc0"
 description = "Python Client to interact with Infrahub"
 authors = [
     {name = "OpsMill", email = "info@opsmill.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.19.0b0"
+version = "1.19.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },


### PR DESCRIPTION
# Why

Prepare for a release candidate version of 1.19.0

## What changed

* Version in pyproject.toml & uv.lock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated from 1.19.0b0 (beta) to 1.19.0rc0 (release candidate). No functional changes or new features in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->