### PR TITLE
fix: resolve from_pool string names to pool IDs in object spec

### DIFF
--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
     from ..node import InfrahubNode
     from ..schema import MainSchemaTypesAPI, RelationshipSchema
 
+_ATTRIBUTE_KIND_TO_POOL_KIND: dict[str, str] = {
+    "Number": "CoreNumberPool",
+}
+
 
 def validate_list_of_scalars(value: list[Any]) -> bool:
     return all(isinstance(item, (str, int, float, bool)) for item in value)
@@ -427,6 +431,30 @@ class InfrahubObjectFileData(BaseModel):
         return data
 
     @classmethod
+    async def _resolve_attribute_pool(
+        cls,
+        client: InfrahubClient,
+        schema: MainSchemaTypesAPI,
+        name: str,
+        value: Any,
+        branch: str | None = None,
+    ) -> Any:
+        """If an attribute value has from_pool as a plain string name, resolve it to {id: uuid}."""
+        if not isinstance(value, dict) or "from_pool" not in value:
+            return value
+        from_pool = value["from_pool"]
+        if not isinstance(from_pool, str):
+            return value
+        attr_schema = schema.get_attribute_or_none(name=name)
+        if attr_schema is None:
+            return value
+        pool_kind = _ATTRIBUTE_KIND_TO_POOL_KIND.get(attr_schema.kind)
+        if pool_kind is None:
+            return value
+        pool = await client.get(kind=pool_kind, hfid=[from_pool], branch=branch, raise_when_missing=True)
+        return {**value, "from_pool": {"id": pool.id}}
+
+    @classmethod
     async def create_node(
         cls,
         client: InfrahubClient,
@@ -463,7 +491,9 @@ class InfrahubObjectFileData(BaseModel):
 
         for key, value in data.items():
             if key in schema.attribute_names:
-                clean_data[key] = value
+                clean_data[key] = await cls._resolve_attribute_pool(
+                    client=client, schema=schema, name=key, value=value, branch=branch
+                )
                 continue
 
             if key in schema.relationship_names:


### PR DESCRIPTION
## Problem

When loading objects via YAML spec files, attributes using `from_pool` with a plain string pool name are passed through unchanged:

```yaml
vlan_id:
  from_pool: "my-vlan-pool"
```

This causes failures at the API level because Infrahub expects the pool reference in `{id: uuid}` form:

```yaml
vlan_id:
  from_pool:
    id: "185b9728-1b76-dda7-d13d-106529b1bcd9"
```

## Fix

Add `_resolve_attribute_pool` to `InfrahubObjectFileData` that:
1. Detects when an attribute value has `from_pool` as a plain string
2. Looks up the pool by HFID using `client.get(kind=pool_kind, hfid=[name])`
3. Replaces the string with `{"id": pool.id}` before the node is created

A `_ATTRIBUTE_KIND_TO_POOL_KIND` mapping controls which attribute kinds are eligible — currently `Number` → `CoreNumberPool`.

Values that are already `{"from_pool": {"id": ...}}` (dict form) pass through unchanged, so existing usage is unaffected.

## Changes

- `infrahub_sdk/spec/object.py`: add `_ATTRIBUTE_KIND_TO_POOL_KIND` mapping and `_resolve_attribute_pool` classmethod; call it in `create_node` when processing attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pool references in attributes during node creation. Attribute pool references are now properly resolved and dereferenced when creating nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->