### PR TITLE
IHS-114: Fix diff url

### DIFF
--- a/changelog/325.fixed.md
+++ b/changelog/325.fixed.md
@@ -1,1 +1,1 @@
-Fixed diff data url params
+Fixed diff data url query params missing "?" character

--- a/changelog/325.fixed.md
+++ b/changelog/325.fixed.md
@@ -1,0 +1,1 @@
+Fixed diff data url params

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -79,7 +79,7 @@ class InfraHubBranchManagerBase:
         if time_to:
             url_params["time_to"] = time_to
 
-        return url + urlencode(url_params)
+        return url + "?" + urlencode(url_params)
 
 
 class InfrahubBranchManager(InfraHubBranchManagerBase):


### PR DESCRIPTION
<!--
This template is a guide, not a gate. Use as much or as little as helps the
reviewer understand your change. For straightforward PRs (dependency bumps,
linting fixes, CI tweaks, typos) a one-liner description is perfectly fine
-- delete the sections that don't add value.

Rule of thumb: the more the change affects behavior, the more sections you
should fill in.
-->

# Why

The SDK's URL builder was missing a `?` separator before query parameters, producing malformed URLs like `/api/diff/databranch=test-branch&branch_only=true`.

Closes https://github.com/opsmill/infrahub-sdk-python/issues/325

## What changed

- **Fixed SDK URL bug** — `InfraHubBranchManagerBase.generate_diff_data_url` was concatenating query params without a `?` separator; now correctly produces `/api/diff/data?branch=...&branch_only=...`.

## How to review

1. `python_sdk/infrahub_sdk/branch.py:82` — the one-character URL fix (`+ "?" +`)

## Impact & rollout

- **Backward compatibility:** additive only
- **Performance:** no impact on existing endpoints
- **Config/env changes:** none
- **Deployment notes:** safe to deploy

## Checklist

- [ ] Tests added/updated
- [x] [Changelog entry](../dev/guidelines/changelog.md) added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query parameter formatting in diff data URLs to ensure proper query string construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->