### PR TITLE
IFC-2303: update SDK protocols for CoreKeyValue schema

### DIFF
--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -356,7 +356,7 @@ class CoreDataValidator(CoreValidator):
     pass
 
 
-class CoreEnvironmentVariableKeyValue(CoreKeyValue):
+class CoreEnvKeyValue(CoreKeyValue):
     pass
 
 
@@ -937,7 +937,7 @@ class CoreDataValidatorSync(CoreValidatorSync):
     pass
 
 
-class CoreEnvironmentVariableKeyValueSync(CoreKeyValueSync):
+class CoreEnvKeyValueSync(CoreKeyValueSync):
     pass
 
 

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -152,6 +152,12 @@ class CoreGroup(CoreNode):
     children: RelationshipManager
 
 
+class CoreKeyValue(CoreNode):
+    name: String
+    key: String
+    description: StringOptional
+
+
 class CoreMenu(CoreNode):
     namespace: String
     name: String
@@ -240,6 +246,7 @@ class CoreWebhook(CoreNode):
     description: StringOptional
     url: URL
     validate_certificates: BooleanOptional
+    headers: RelationshipManager
 
 
 class CoreWeightedPoolResource(CoreNode):
@@ -346,6 +353,10 @@ class CoreDataCheck(CoreCheck):
 
 class CoreDataValidator(CoreValidator):
     pass
+
+
+class CoreEnvironmentVariableKeyValue(CoreKeyValue):
+    value: String
 
 
 class CoreFileCheck(CoreCheck):
@@ -552,6 +563,10 @@ class CoreStandardWebhook(CoreWebhook, CoreTaskTarget):
     shared_key: String
 
 
+class CoreStaticKeyValue(CoreKeyValue):
+    value: String
+
+
 class CoreThreadComment(CoreComment):
     thread: RelatedNode
 
@@ -717,6 +732,12 @@ class CoreGroupSync(CoreNodeSync):
     children: RelationshipManagerSync
 
 
+class CoreKeyValueSync(CoreNodeSync):
+    name: String
+    key: String
+    description: StringOptional
+
+
 class CoreMenuSync(CoreNodeSync):
     namespace: String
     name: String
@@ -805,6 +826,7 @@ class CoreWebhookSync(CoreNodeSync):
     description: StringOptional
     url: URL
     validate_certificates: BooleanOptional
+    headers: RelationshipManagerSync
 
 
 class CoreWeightedPoolResourceSync(CoreNodeSync):
@@ -911,6 +933,10 @@ class CoreDataCheckSync(CoreCheckSync):
 
 class CoreDataValidatorSync(CoreValidatorSync):
     pass
+
+
+class CoreEnvironmentVariableKeyValueSync(CoreKeyValueSync):
+    value: String
 
 
 class CoreFileCheckSync(CoreCheckSync):
@@ -1115,6 +1141,10 @@ class CoreStandardGroupSync(CoreGroupSync):
 
 class CoreStandardWebhookSync(CoreWebhookSync, CoreTaskTargetSync):
     shared_key: String
+
+
+class CoreStaticKeyValueSync(CoreKeyValueSync):
+    value: String
 
 
 class CoreThreadCommentSync(CoreCommentSync):

--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -156,6 +156,7 @@ class CoreKeyValue(CoreNode):
     name: String
     key: String
     description: StringOptional
+    value: String
 
 
 class CoreMenu(CoreNode):
@@ -356,7 +357,7 @@ class CoreDataValidator(CoreValidator):
 
 
 class CoreEnvironmentVariableKeyValue(CoreKeyValue):
-    value: String
+    pass
 
 
 class CoreFileCheck(CoreCheck):
@@ -564,7 +565,7 @@ class CoreStandardWebhook(CoreWebhook, CoreTaskTarget):
 
 
 class CoreStaticKeyValue(CoreKeyValue):
-    value: String
+    pass
 
 
 class CoreThreadComment(CoreComment):
@@ -736,6 +737,7 @@ class CoreKeyValueSync(CoreNodeSync):
     name: String
     key: String
     description: StringOptional
+    value: String
 
 
 class CoreMenuSync(CoreNodeSync):
@@ -936,7 +938,7 @@ class CoreDataValidatorSync(CoreValidatorSync):
 
 
 class CoreEnvironmentVariableKeyValueSync(CoreKeyValueSync):
-    value: String
+    pass
 
 
 class CoreFileCheckSync(CoreCheckSync):
@@ -1144,7 +1146,7 @@ class CoreStandardWebhookSync(CoreWebhookSync, CoreTaskTargetSync):
 
 
 class CoreStaticKeyValueSync(CoreKeyValueSync):
-    value: String
+    pass
 
 
 class CoreThreadCommentSync(CoreCommentSync):


### PR DESCRIPTION
# Why

Synchronization step with [opsmill/infrahub#8590](https://github.com/opsmill/infrahub/pull/8590) which introduces `CoreKeyValue` schema definitions for webhook custom headers.

This PR updates the SDK-side generated protocols to reflect the new schema entities added in the infrahub backend.

## What changed

- **`infrahub_sdk/protocols.py`**: Added generated protocol classes for `CoreKeyValue`, `CoreStaticKeyValue`, and `CoreEnvironmentVariableKeyValue` generics/nodes introduced in opsmill/infrahub#8590

No behavioral changes — this is purely additive generated protocol updates to stay in sync with the backend schema.

## How to review

1. Check `infrahub_sdk/protocols.py` diff — the new protocol stubs matching the backend schema additions

## How to test

```bash
uv run invoke format && uv run invoke lint   # Should pass
uv run pytest tests/unit/                     # Should pass
```

## Impact & rollout

- **Deployment notes:** Must be merged in coordination with opsmill/infrahub#8590. This is the SDK-side synchronization step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Key-value storage with named entries including key, optional description, and value.
  - Dedicated key-value types for environment variables and static values (available for both synchronous and asynchronous flows).
  - Webhook configuration now supports managed headers in both synchronous and asynchronous flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->