### PR TITLE
fix: make sidebar path detection work in both repos

### DIFF
--- a/docs/sidebars/sidebar-utils.ts
+++ b/docs/sidebars/sidebar-utils.ts
@@ -1,3 +1,23 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Detects the base directory containing the docs content (python-sdk/, infrahubctl/, etc.).
+ *
+ * The sidebar files live in different locations depending on which repo they are in:
+ *   - infrahub-sdk-python: docs/sidebars/ → content is at docs/docs/
+ *   - infrahub-docs:       docs/           → content is at docs/docs-python-sdk/
+ *
+ * We detect the active layout by checking whether the SDK-repo content path exists.
+ */
+export function getDocsBaseDir(): string {
+  const sdkRepoDocsDir = join(__dirname, '..', 'docs');
+  if (existsSync(join(sdkRepoDocsDir, 'python-sdk'))) {
+    return sdkRepoDocsDir;
+  }
+  return join(__dirname, 'docs-python-sdk');
+}
+
 export function getCommandItems(files: string[], indexFile: string = 'infrahubctl.mdx'): string[] {
   return files
     .filter(file => file.endsWith('.mdx') && file !== indexFile)

--- a/docs/sidebars/sidebars-infrahubctl.ts
+++ b/docs/sidebars/sidebars-infrahubctl.ts
@@ -1,9 +1,9 @@
 import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 import {readdirSync} from 'fs';
 import {join} from 'path';
-import {getCommandItems} from './sidebar-utils';
+import {getCommandItems, getDocsBaseDir} from './sidebar-utils';
 
-const docsDir = join(__dirname, '..', 'docs', 'infrahubctl');
+const docsDir = join(getDocsBaseDir(), 'infrahubctl');
 const commandItems = getCommandItems(readdirSync(docsDir));
 
 const sidebars: SidebarsConfig = {

--- a/docs/sidebars/sidebars-python-sdk.ts
+++ b/docs/sidebars/sidebars-python-sdk.ts
@@ -1,9 +1,9 @@
 import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 import { readdirSync } from 'fs';
 import { join } from 'path';
-import { getItemsWithOrder } from './sidebar-utils';
+import { getDocsBaseDir, getItemsWithOrder } from './sidebar-utils';
 
-const pythonSdkDocsDir = join(__dirname, '..', 'docs', 'python-sdk');
+const pythonSdkDocsDir = join(getDocsBaseDir(), 'python-sdk');
 
 const guidesItems = getItemsWithOrder(
   readdirSync(join(pythonSdkDocsDir, 'guides')),


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved documentation directory path resolution with centralized base directory detection, providing more flexible and reliable doc location handling across sidebar configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Adds `getDocsBaseDir()` to `sidebar-utils.ts` that detects which repo the sidebar files are running in (infrahub-sdk-python vs infrahub-docs) by probing for the SDK-repo directory layout
- Updates `sidebars-python-sdk.ts` and `sidebars-infrahubctl.ts` to use `getDocsBaseDir()` instead of hardcoded `__dirname`-relative paths

## Problem

The sync workflow ([sync-docs.yml](.github/workflows/sync-docs.yml)) copies sidebar files from `docs/sidebars/` in this repo to `docs/` in `infrahub-docs`. This changes `__dirname`, breaking all hardcoded relative paths:

| Repo | `__dirname` | Resolved path |
|---|---|---|
| infrahub-sdk-python | `docs/sidebars/` | `docs/sidebars/../docs/python-sdk` = `docs/docs/python-sdk` ✓ |
| infrahub-docs | `docs/` | `docs/../docs/python-sdk` = `docs/python-sdk` ✗ (content is at `docs/docs-python-sdk/python-sdk`) |

## Test plan

- [ ] Verify Docusaurus builds successfully in this repo (`docs/`)
- [ ] Verify the sync workflow runs cleanly and the Docusaurus build succeeds in infrahub-docs after merge