### PR TITLE
Add GraphQL fragment support in .infrahub.yml

### DIFF
--- a/dev/specs/infp-496-graphql-fragment-inlining/spec.md
+++ b/dev/specs/infp-496-graphql-fragment-inlining/spec.md
@@ -1,0 +1,237 @@
+# SDK Spec: GraphQL Fragment Inlining
+
+**Jira**: INFP-496
+**Created**: 2026-03-13
+**Status**: Implemented
+**Parent spec**: [infrahub/dev/specs/infp-496-graphql-fragment-inlining/spec.md](../../../../dev/specs/infp-496-graphql-fragment-inlining/spec.md)
+
+## Scope
+
+This spec covers the SDK-side responsibilities for the GraphQL Fragment Inlining feature (FR-015). The Infrahub server and backend integration are documented in the parent spec.
+
+Per the architecture decision in the parent spec:
+
+> Fragment parsing, resolution, and rendering is **SDK responsibility**, not server responsibility.
+
+The SDK must provide:
+
+1. **Config model extension** — `graphql_fragments` in `.infrahub.yml`
+2. **Fragment renderer** — parse, resolve (transitively), and render queries
+3. **CLI integration** — `infrahubctl` local workflows apply fragment rendering automatically
+
+---
+
+## Component Responsibilities
+
+| Responsibility | SDK Module |
+| --- | --- |
+| `InfrahubRepositoryFragmentConfig` model | `infrahub_sdk/schema/repository.py` |
+| `graphql_fragments` field on `InfrahubRepositoryConfig` | `infrahub_sdk/schema/repository.py` |
+| Read fragment file content from disk | `InfrahubRepositoryFragmentConfig.load_fragments()` |
+| Parse `.gql` fragment files into AST | `infrahub_sdk/graphql/query_renderer.py` |
+| Build fragment name index (across all declared files) | `infrahub_sdk/graphql/query_renderer.py` |
+| Detect duplicate fragment names across files | `infrahub_sdk/graphql/query_renderer.py` |
+| Resolve transitive fragment dependencies | `infrahub_sdk/graphql/query_renderer.py` |
+| Detect circular fragment dependencies | `infrahub_sdk/graphql/query_renderer.py` |
+| Render self-contained query document | `infrahub_sdk/graphql/query_renderer.py` |
+| High-level `render_query()` entry point (load + render) | `infrahub_sdk/graphql/query_renderer.py` |
+| Typed error exceptions | `infrahub_sdk/exceptions.py` |
+| Apply rendering in `infrahubctl` execution | `infrahub_sdk/ctl/utils.py` |
+| Apply rendering in `infrahubctl` transform | `infrahub_sdk/ctl/cli_commands.py` |
+
+---
+
+## API Contract: Fragment Renderer
+
+### CLI-facing entry point
+
+```python
+# infrahub_sdk/graphql/query_renderer.py
+
+def render_query(name: str, config: InfrahubRepositoryConfig, relative_path: str = ".") -> str:
+    """Return a self-contained GraphQL document for the named query, with fragment definitions inlined.
+
+    Loads the query file and all declared fragment files from config, then delegates to
+    render_query_with_fragments.
+
+    Raises:
+        ResourceNotDefinedError: Query name not found in config.
+        FragmentFileNotFoundError: A declared fragment file path does not exist.
+        DuplicateFragmentError: Same fragment name declared in multiple files.
+        FragmentNotFoundError: Query references a fragment not found in any declared file.
+        CircularFragmentError: Circular dependency detected among fragments.
+    """
+```
+
+### Low-level entry point
+
+```python
+# infrahub_sdk/graphql/query_renderer.py
+
+def render_query_with_fragments(query_str: str, fragment_files: list[str]) -> str:
+    """Return a self-contained GraphQL document with required fragment definitions inlined.
+
+    If the query contains no fragment spreads, query_str is returned unchanged.
+
+    Raises:
+        QuerySyntaxError: Query string or a fragment file contains invalid GraphQL syntax.
+        DuplicateFragmentError: Same fragment name declared in multiple files.
+        FragmentNotFoundError: Query references a fragment not found in any declared file.
+        CircularFragmentError: Circular dependency detected among fragments.
+    """
+```
+
+### Public helpers in `query_renderer.py`
+
+```python
+def build_fragment_index(fragment_files: list[str]) -> dict[str, FragmentDefinitionNode]:
+    """Parse all fragment file contents and return a mapping from fragment name to its AST node."""
+
+def collect_required_fragments(
+    query_doc: DocumentNode,
+    fragment_index: dict[str, FragmentDefinitionNode],
+) -> list[str]:
+    """Walk query_doc and collect all fragment names required (transitively).
+
+    Returns a topologically ordered list of unique fragment names.
+    """
+```
+
+### Error types (additions to `infrahub_sdk/exceptions.py`)
+
+```python
+class GraphQLQueryError(Error):
+    """Base class for all errors raised during GraphQL query rendering."""
+
+
+class QuerySyntaxError(GraphQLQueryError):
+    def __init__(self, syntax_error: str) -> None: ...
+    # message: f"GraphQL syntax error: {syntax_error}"
+
+
+class FragmentNotFoundError(GraphQLQueryError):
+    def __init__(self, fragment_name: str, query_file: str | None = None, message: str | None = None) -> None: ...
+    # message: f"Fragment '{fragment_name}' not found." (or mentions query_file if provided)
+
+
+class DuplicateFragmentError(GraphQLQueryError):
+    def __init__(self, fragment_name: str, message: str | None = None) -> None: ...
+    # message: f"Fragment '{fragment_name}' is defined more than once across declared fragment files."
+
+
+class CircularFragmentError(GraphQLQueryError):
+    def __init__(self, cycle: list[str], message: str | None = None) -> None: ...
+    # message: f"Circular fragment dependency detected: {' -> '.join(cycle)}."
+
+
+class FragmentFileNotFoundError(GraphQLQueryError):
+    def __init__(self, file_path: str, message: str | None = None) -> None: ...
+    # message: f"Fragment file '{file_path}' declared in graphql_fragments does not exist."
+```
+
+`GraphQLQueryError` is also handled in `handle_exception()` in `ctl/utils.py` so CLI commands print
+a clean error message and exit instead of raising an unhandled exception.
+
+---
+
+## Config Model Extension
+
+```python
+# infrahub_sdk/schema/repository.py
+
+class InfrahubRepositoryFragmentConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="Logical name for this fragment file or directory")
+    file_path: Path = Field(..., description="Path to a .gql file or directory of .gql files, relative to repo root")
+
+    def load_fragments(self, relative_path: str = ".") -> list[str]:
+        """Read and return raw content of all fragment files at file_path.
+
+        If file_path is a .gql file, returns a single-element list.
+        If file_path is a directory, returns one entry per .gql file found (sorted).
+        Raises FragmentFileNotFoundError if file_path does not exist.
+        """
+        resolved = Path(f"{relative_path}/{self.file_path}")
+        if not resolved.exists():
+            raise FragmentFileNotFoundError(file_path=str(self.file_path))
+        if resolved.is_dir():
+            return [f.read_text(encoding="UTF-8") for f in sorted(resolved.glob("*.gql"))]
+        return [resolved.read_text(encoding="UTF-8")]
+
+
+class InfrahubRepositoryConfig(BaseModel):
+    # ... existing fields ...
+    graphql_fragments: list[InfrahubRepositoryFragmentConfig] = Field(
+        default_factory=list, description="GraphQL fragment files"
+    )
+```
+
+---
+
+## infrahubctl Integration
+
+Both CLI call sites use `render_query()` from `query_renderer.py`, which handles loading fragment
+files from config and delegating to `render_query_with_fragments`.
+
+### `execute_graphql_query()` in `ctl/utils.py`
+
+```python
+# Before
+query_str = query_object.load_query()
+
+# After
+query_str = render_query(name=query, config=repository_config)
+```
+
+### `transform()` in `ctl/cli_commands.py`
+
+```python
+# Before
+query_str = repository_config.get_query(name=transform.query).load_query()
+
+# After
+query_str = render_query(name=transform.query, config=repository_config)
+```
+
+---
+
+## Testing Requirements
+
+### Unit tests — `tests/unit/sdk/graphql/test_fragment_renderer.py` (imports from `query_renderer`)
+
+- Render query with single direct fragment spread → correct output
+- Render query with fragment spreads across two files → correct output
+- Render query with transitive dependency (A → B across files) → correct output
+- Render query with no fragment spreads → returned unchanged
+- Same fragment spread used twice → fragment definition appears once in output
+- Only required fragments included, not all from the file
+- `FragmentNotFoundError` raised for unresolved spread
+- `DuplicateFragmentError` raised for duplicate name across multiple content strings
+- `DuplicateFragmentError` raised for duplicate name within the same content string
+- `CircularFragmentError` raised for A→B→A cycle
+- `QuerySyntaxError` raised for invalid GraphQL syntax in query or fragment file
+
+### Unit tests — `tests/unit/sdk/graphql/test_query_renderer.py`
+
+- `render_query()` loads query + fragments from config and returns rendered document
+- `render_query()` with no `graphql_fragments` in config returns query unchanged
+
+### Unit tests — `tests/unit/sdk/test_repository.py`
+
+- `InfrahubRepositoryConfig` parses `graphql_fragments` YAML correctly
+- `InfrahubRepositoryFragmentConfig.load_fragments()` with a file path returns a single-element list with the file content
+- `InfrahubRepositoryFragmentConfig.load_fragments()` with a directory path returns one entry per `.gql` file found
+- `load_fragments()` raises `FragmentFileNotFoundError` for a path that does not exist
+
+### Integration / functional tests — caller-side
+
+- See main repo plan for backend integration tests and E2E fixtures
+
+---
+
+## Constraints
+
+- Fragment rendering uses only `graphql-core` (already a dependency). No new dependencies.
+- All new public functions carry full type hints.
+- Both async and sync `InfrahubClient` paths are unaffected — rendering is a pure string transformation with no I/O.
+- Generated files (`protocols.py`) are not touched.

--- a/dev/specs/infp-496-graphql-fragment-inlining/tasks.md
+++ b/dev/specs/infp-496-graphql-fragment-inlining/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: GraphQL Fragment Inlining — SDK Scope
+
+**Input**: `python_sdk/dev/specs/infp-496-graphql-fragment-inlining/spec.md`
+**Parent tasks**: `specs/infp-496-graphql-fragment-inlining/tasks.md` (full feature view including backend)
+**Scope**: All work inside `python_sdk/` only (FR-015: all fragment logic lives in the SDK)
+
+**Path note**: All file paths below are relative to the **infrahub repo root** (e.g.,
+`python_sdk/infrahub_sdk/...`). The `python_sdk/` directory is a git submodule — changes inside
+it must be committed separately from the main infrahub repo.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Fixture Repository)
+
+**Purpose**: Create the fixture repository used by SDK unit tests and backend component tests.
+All fixture files live inside the `python_sdk` submodule.
+
+- [*] T001 Create fixture repo directory structure at `python_sdk/tests/fixtures/repos/fragment_inlining/` (subdirectories: `fragments/`, `queries/`)
+- [*] T002 [P] Create `python_sdk/tests/fixtures/repos/fragment_inlining/fragments/interfaces.gql` (defines `interfaceFragment`, `portFragment`) and `python_sdk/tests/fixtures/repos/fragment_inlining/fragments/devices.gql` (defines `deviceFragment` that spreads `...interfaceFragment`, and `chassisFragment`)
+- [*] T003 [P] Create `python_sdk/tests/fixtures/repos/fragment_inlining/queries/query_two_files.gql` (spreads `...interfaceFragment` and `...deviceFragment`), `query_no_fragments.gql` (no spreads), `query_transitive.gql` (spreads `...deviceFragment` only), `query_missing_fragment.gql` (spreads `...undeclaredFragment`)
+- [*] T004 Create `python_sdk/tests/fixtures/repos/fragment_inlining/.infrahub.yml` declaring `graphql_fragments` (both fragment files under `fragments/`) and `graphql_queries` (all four query files under `queries/`)
+
+---
+
+## Phase 2: Foundational (SDK Core — Blocking Prerequisites)
+
+**Purpose**: Exception types, config model, and renderer are needed by all user story phases.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T005 Add `GraphQLQueryError` base class plus five typed exception classes (`QuerySyntaxError`, `FragmentNotFoundError`, `DuplicateFragmentError`, `CircularFragmentError`, `FragmentFileNotFoundError`) to `python_sdk/infrahub_sdk/exceptions.py` — all use `__init__`-based pattern, all extend `GraphQLQueryError`; update `handle_exception()` in `ctl/utils.py` to also catch `GraphQLQueryError`
+- [x] T006 Add `InfrahubRepositoryFragmentConfig` class with `name: str`, `file_path: Path`, and `load_fragments(relative_path: str = ".") -> list[str]` method to `python_sdk/infrahub_sdk/schema/repository.py` — mirror the existing `InfrahubRepositoryGraphQLConfig` pattern
+- [x] T007 Add `graphql_fragments: list[InfrahubRepositoryFragmentConfig] = Field(default_factory=list)` field to `InfrahubRepositoryConfig` in `python_sdk/infrahub_sdk/schema/repository.py`
+- [x] T008 Add **public** functions `build_fragment_index(fragment_files: list[str]) -> dict[str, FragmentDefinitionNode]` and `collect_required_fragments(query_doc: DocumentNode, fragment_index: dict[str, FragmentDefinitionNode]) -> list[str]` to `python_sdk/infrahub_sdk/graphql/query_renderer.py`
+- [x] T009 Add `render_query_with_fragments(query_str: str, fragment_files: list[str]) -> str` to `python_sdk/infrahub_sdk/graphql/query_renderer.py`; early-return when query has no fragment spreads (FR-011); also raises `QuerySyntaxError` for invalid syntax in query or fragment files
+- [x] T009b Create `python_sdk/infrahub_sdk/graphql/query_renderer.py` with `render_query(name: str, config: InfrahubRepositoryConfig, relative_path: str = ".") -> str` — high-level entry point used by CLI: loads query + fragment files from the configuration, delegates to `render_query_with_fragments`
+
+**Checkpoint**: SDK core complete — all test and CLI phases can now proceed
+
+---
+
+## Phase 3: User Story 1 — Basic Fragment Import (Priority: P1) 🎯 MVP
+
+**Goal**: The renderer correctly inlines required fragments from multiple files and excludes
+unreferenced ones. Repository configuration parses `graphql_fragments` YAML correctly.
+
+**Independent Test**:
+
+```bash
+cd python_sdk && uv run pytest tests/unit/sdk/graphql/test_fragment_renderer.py -v
+cd python_sdk && uv run pytest tests/unit/sdk/test_repository.py -v -k fragment
+```
+
+- [ ] T010 [P] [US1] Write unit tests covering: single direct spread from one file → renders correctly; spreads across two files → both rendered; no spreads → query returned unchanged; same spread used twice → definition appears once; surplus definitions excluded — in `python_sdk/tests/unit/sdk/graphql/test_fragment_renderer.py`
+- [ ] T011 [P] [US1] Write unit tests covering: `InfrahubRepositoryConfig` parses `graphql_fragments` YAML section; `load_fragments()` with a file path returns single-element list with file content; `load_fragments()` with a directory path returns one entry per `.gql` file (sorted alphabetically); `load_fragments()` raises `FragmentFileNotFoundError` for a path that does not exist — in `python_sdk/tests/unit/sdk/test_repository.py`
+
+**Checkpoint**: US1 SDK work fully tested and independently verifiable
+
+---
+
+## Phase 4: User Story 2 — Transitive Fragment Dependencies (Priority: P2)
+
+**Goal**: `collect_required_fragments` resolves transitive spreads so both A and its dependency B
+are included even when the query only references A directly.
+
+**Independent Test**:
+
+```bash
+cd python_sdk && uv run pytest tests/unit/sdk/graphql/test_fragment_renderer.py -v -k transitive
+```
+
+- [ ] T013 [P] [US2] Write unit tests covering: transitive dependency across two files (query spreads `...deviceFragment`; `deviceFragment` spreads `...interfaceFragment` in a different file → both definitions in output); only directly/transitively required fragments included, not all from the files — in `python_sdk/tests/unit/sdk/graphql/test_fragment_renderer.py`
+
+**Checkpoint**: US1 + US2 SDK logic fully tested
+
+---
+
+## Phase 5: User Story 4 — Graceful Failure for Unresolved Fragments (Priority: P2)
+
+**Goal**: All four error types are raised correctly under their documented conditions.
+
+**Independent Test**:
+
+```bash
+cd python_sdk && uv run pytest tests/unit/sdk/graphql/test_fragment_renderer.py -v -k error
+```
+
+- [ ] T014 [P] [US4] Write unit tests covering: `FragmentNotFoundError` raised when spread references name absent from all fragment files; `DuplicateFragmentError` raised when same name appears in two separate content strings; `DuplicateFragmentError` raised when same name appears twice within one content string; `CircularFragmentError` raised for A→B→A cycle — in `python_sdk/tests/unit/sdk/graphql/test_fragment_renderer.py`
+
+**Checkpoint**: All renderer error paths tested
+
+---
+
+## Phase 6: infrahubctl CLI Integration (enables US1 + US4 for local workflows)
+
+**Goal**: `infrahubctl` local execution paths apply fragment rendering automatically when
+`graphql_fragments` is declared in `.infrahub.yml` (FR-016).
+
+**Independent Test**: Run `infrahubctl run` pointing at the fixture repository; the query executes
+without unresolved-spread errors.
+
+- [x] T019 [P] [US1] Update `execute_graphql_query()` in `python_sdk/infrahub_sdk/ctl/utils.py`: replace `query_object.load_query()` with `render_query(name=query, config=repository_config)` from `query_renderer.py`
+- [x] T020 [P] [US1] Update `transform()` in `python_sdk/infrahub_sdk/ctl/cli_commands.py`: replace `repository_config.get_query(name=...).load_query()` with `render_query(name=transform.query, config=repository_config)` from `query_renderer.py`
+
+**Checkpoint**: Both server sync and infrahubctl CLI paths apply fragment rendering
+
+---
+
+## Phase 7: Polish & SDK-Specific Concerns
+
+- [ ] T021 [P] Run `cd python_sdk && uv run invoke format lint-code` to verify no ruff/mypy violations in modified files (`exceptions.py`, `schema/repository.py`, `graphql/query_renderer.py`, `ctl/utils.py`, `ctl/cli_commands.py`)
+- [ ] T022 Run `cd python_sdk && uv run invoke docs-generate` to regenerate SDK CLI + configuration docs after docstring additions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user story phases
+- **US1 (Phase 3)**: Depends on Phase 2; T010 and T011 are independent [P]
+- **US2 (Phase 4)**: Depends on Phase 2 (renderer transitive logic already in T008)
+- **US4 (Phase 5)**: Depends on Phase 2 (error types in T005, error logic in T008)
+- **CLI Integration (Phase 6)**: Depends on Phase 2; T019 and T020 are independent [P]
+- **Polish (Phase 7)**: After all phases complete
+
+### Parallel Opportunities
+
+```bash
+# Phase 1 — after T001 completes:
+T002  python_sdk/tests/fixtures/repos/fragment_inlining/fragments/*.gql
+T003  python_sdk/tests/fixtures/repos/fragment_inlining/queries/*.gql
+
+# Phase 3 — after Phase 2 completes:
+T010  python_sdk/tests/unit/sdk/graphql/test_fragment_renderer.py
+T011  python_sdk/tests/unit/sdk/test_repository.py
+
+# Phase 6 — after Phase 2 completes (independent of Phase 3):
+T019  python_sdk/infrahub_sdk/ctl/utils.py
+T020  python_sdk/infrahub_sdk/ctl/cli_commands.py
+```
+
+---
+
+## Notes
+
+- `python_sdk/` is a git submodule — commit changes there separately from the main Infrahub repository
+- Run `cd python_sdk && uv run invoke format lint-code` before committing any Python changes
+- Run `cd python_sdk && uv run invoke docs-generate` after any docstring or CLI command changes
+- Backend integration tasks (updating `backend/infrahub/git/integrator.py` and writing component tests) are in `specs/infp-496-graphql-fragment-inlining/tasks.md`

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -44,6 +44,7 @@ from ..ctl.utils import (
 )
 from ..ctl.validate import app as validate_app
 from ..exceptions import GraphQLError, ModuleImportError
+from ..graphql.query_renderer import render_query
 from ..node import InfrahubNode
 from ..protocols_generator.generator import CodeGenerator
 from ..schema import MainSchemaTypesAll, SchemaRoot
@@ -342,7 +343,7 @@ def transform(
         convert_query_response=transform_config.convert_query_response,
     )
     # Get data
-    query_str = repository_config.get_query(name=transform.query).load_query()
+    query_str = render_query(name=transform.query, config=repository_config)
     data = asyncio.run(
         transform.client.execute_graphql(query=query_str, variables=variables_dict, branch_name=transform.branch_name)
     )

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -20,6 +20,7 @@ from ..exceptions import (
     Error,
     FileNotValidError,
     GraphQLError,
+    GraphQLQueryError,
     NodeNotFoundError,
     ResourceNotDefinedError,
     SchemaNotFoundError,
@@ -27,6 +28,7 @@ from ..exceptions import (
     ServerNotResponsiveError,
     ValidationError,
 )
+from ..graphql.query_renderer import render_query
 from ..yaml import YamlFile
 from .client import initialize_client_sync
 from .exceptions import QueryNotFoundError
@@ -66,7 +68,7 @@ def handle_exception(exc: Exception, console: Console, exit_code: int) -> NoRetu
     if isinstance(exc, GraphQLError):
         print_graphql_errors(console=console, errors=exc.errors)
         raise typer.Exit(code=exit_code)
-    if isinstance(exc, (SchemaNotFoundError, NodeNotFoundError, ResourceNotDefinedError)):
+    if isinstance(exc, (SchemaNotFoundError, NodeNotFoundError, ResourceNotDefinedError, GraphQLQueryError)):
         console.print(f"[red]Error: {exc!s}")
         raise typer.Exit(code=exit_code)
 
@@ -114,8 +116,7 @@ def execute_graphql_query(
     debug: bool = False,
 ) -> dict:
     console = Console()
-    query_object = repository_config.get_query(name=query)
-    query_str = query_object.load_query()
+    query_str = render_query(name=query, config=repository_config)
 
     client = initialize_client_sync()
 

--- a/infrahub_sdk/exceptions.py
+++ b/infrahub_sdk/exceptions.py
@@ -173,3 +173,49 @@ class TimestampFormatError(Error):
     def __init__(self, message: str | None = None) -> None:
         self.message = message or "Invalid timestamp format"
         super().__init__(self.message)
+
+
+class GraphQLQueryError(Error):
+    """Base class for errors raised during GraphQL query rendering (fragment resolution)."""
+
+
+class QuerySyntaxError(GraphQLQueryError):
+    def __init__(self, syntax_error: str) -> None:
+        self.message = f"GraphQL syntax error: {syntax_error}"
+        super().__init__(self.message)
+
+
+class FragmentNotFoundError(GraphQLQueryError):
+    def __init__(self, fragment_name: str, query_file: str | None = None, message: str | None = None) -> None:
+        self.fragment_name = fragment_name
+        self.query_file = query_file
+        if message:
+            self.message = message
+        elif query_file:
+            self.message = f"Fragment '{fragment_name}' not found (referenced in '{query_file}')."
+        else:
+            self.message = f"Fragment '{fragment_name}' not found."
+        super().__init__(self.message)
+
+
+class DuplicateFragmentError(GraphQLQueryError):
+    def __init__(self, fragment_name: str, message: str | None = None) -> None:
+        self.fragment_name = fragment_name
+        self.message = (
+            message or f"Fragment '{fragment_name}' is defined more than once across declared fragment files."
+        )
+        super().__init__(self.message)
+
+
+class CircularFragmentError(GraphQLQueryError):
+    def __init__(self, cycle: list[str], message: str | None = None) -> None:
+        self.cycle = cycle
+        self.message = message or f"Circular fragment dependency detected: {' -> '.join(cycle)}."
+        super().__init__(self.message)
+
+
+class FragmentFileNotFoundError(GraphQLQueryError):
+    def __init__(self, file_path: str, message: str | None = None) -> None:
+        self.file_path = file_path
+        self.message = message or f"Fragment file '{file_path}' declared in graphql_fragments does not exist."
+        super().__init__(self.message)

--- a/infrahub_sdk/graphql/query_renderer.py
+++ b/infrahub_sdk/graphql/query_renderer.py
@@ -1,0 +1,179 @@
+"""GraphQL query rendering: fragment parsing, inlining, and loading from InfrahubRepositoryConfig."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+from graphql import DocumentNode, FragmentDefinitionNode, FragmentSpreadNode, parse, print_ast
+from graphql.error import GraphQLSyntaxError
+from graphql.language.ast import Node as ASTNode
+
+from ..exceptions import CircularFragmentError, DuplicateFragmentError, FragmentNotFoundError, QuerySyntaxError
+
+if TYPE_CHECKING:
+    from ..schema.repository import InfrahubRepositoryConfig
+
+
+def _iter_nodes(node: ASTNode) -> Iterator[ASTNode]:
+    """Yield node and every descendant in depth-first order."""
+    stack: list[ASTNode] = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        for key in reversed(current.keys):
+            child = getattr(current, key, None)
+            if isinstance(child, ASTNode):
+                stack.append(child)
+            elif isinstance(child, tuple):
+                stack.extend(item for item in reversed(child) if isinstance(item, ASTNode))
+
+
+def _collect_spread_names(node: ASTNode) -> list[str]:
+    """Return the names of all fragment spreads within node."""
+    return [n.name.value for n in _iter_nodes(node) if isinstance(n, FragmentSpreadNode)]
+
+
+def build_fragment_index(fragment_files: list[str]) -> dict[str, FragmentDefinitionNode]:
+    """Parse all fragment file contents and return a mapping from fragment name to its AST node.
+
+    Raises DuplicateFragmentError if the same fragment name appears more than once.
+    """
+    index: dict[str, FragmentDefinitionNode] = {}
+    for content in fragment_files:
+        try:
+            doc = parse(content)
+        except GraphQLSyntaxError as exc:
+            raise QuerySyntaxError(syntax_error=str(exc)) from exc
+        for definition in doc.definitions:
+            if isinstance(definition, FragmentDefinitionNode):
+                name = definition.name.value
+                if name in index:
+                    raise DuplicateFragmentError(fragment_name=name)
+                index[name] = definition
+    return index
+
+
+def collect_required_fragments(
+    query_doc: DocumentNode,
+    fragment_index: dict[str, FragmentDefinitionNode],
+) -> list[str]:
+    """Walk query_doc and collect all fragment names required (transitively).
+
+    Returns a topologically ordered list of unique fragment names.
+    Raises FragmentNotFoundError for any unresolved name.
+    Raises CircularFragmentError for cyclic dependencies.
+    """
+    # Collect spreads only from operation definitions — any fragment definitions already
+    # present in the query document are self-contained and do not need external resolution.
+    top_level_spreads = [
+        node.name.value
+        for definition in query_doc.definitions
+        if not isinstance(definition, FragmentDefinitionNode)
+        for node in _iter_nodes(definition)
+        if isinstance(node, FragmentSpreadNode)
+    ]
+
+    local_fragments = {
+        definition.name.value for definition in query_doc.definitions if isinstance(definition, FragmentDefinitionNode)
+    }
+
+    ordered: list[str] = []
+    visited: set[str] = set()
+
+    def resolve(name: str, stack: list[str]) -> None:
+        if name in stack:
+            cycle = [*stack[stack.index(name) :], name]
+            raise CircularFragmentError(cycle=cycle)
+        if name in visited:
+            return
+        if name in local_fragments:
+            return
+        if name not in fragment_index:
+            raise FragmentNotFoundError(fragment_name=name)
+        stack.append(name)
+        for dep in _collect_spread_names(fragment_index[name]):
+            resolve(dep, stack)
+        stack.pop()
+        visited.add(name)
+        ordered.append(name)
+
+    for spread_name in top_level_spreads:
+        resolve(spread_name, [])
+
+    return ordered
+
+
+def render_query_with_fragments(query_str: str, fragment_files: list[str]) -> str:
+    """Return a self-contained GraphQL document with required fragment definitions inlined.
+
+    If the query contains no fragment spreads, query_str is returned unchanged.
+
+    Raises:
+        QuerySyntaxError: Query string or a fragment file contains invalid GraphQL syntax.
+        DuplicateFragmentError: Same fragment name declared in multiple files.
+        FragmentNotFoundError: Query references a fragment not found in any declared file.
+        CircularFragmentError: Circular dependency detected among fragments.
+    """
+    try:
+        query_doc = parse(query_str)
+    except GraphQLSyntaxError as exc:
+        raise QuerySyntaxError(syntax_error=str(exc)) from exc
+
+    return _render_doc_with_fragments(query_doc, query_str, fragment_files)
+
+
+def _render_doc_with_fragments(query_doc: DocumentNode, query_str: str, fragment_files: list[str]) -> str:
+    """Inline fragments into an already-parsed query document.
+
+    query_str is returned unchanged when the document contains no fragment spreads.
+    """
+    if not _has_fragment_spread(query_doc):
+        return query_str
+
+    fragment_index = build_fragment_index(fragment_files)
+    required_names = collect_required_fragments(query_doc, fragment_index)
+
+    query_definitions = list(query_doc.definitions)
+    fragment_definitions = [fragment_index[name] for name in required_names]
+
+    output_doc = DocumentNode(definitions=tuple(query_definitions + fragment_definitions))
+    return print_ast(output_doc)
+
+
+def _has_fragment_spread(doc: DocumentNode) -> bool:
+    """Return True if the document contains any fragment spread in an operation definition."""
+    return any(
+        isinstance(node, FragmentSpreadNode)
+        for definition in doc.definitions
+        if not isinstance(definition, FragmentDefinitionNode)
+        for node in _iter_nodes(definition)
+    )
+
+
+def render_query(name: str, config: InfrahubRepositoryConfig, relative_path: str = ".") -> str:
+    """Return a self-contained GraphQL document for the named query, with fragment definitions inlined.
+
+    Fragment files are only loaded from disk when the query actually uses fragment spreads.
+
+    Raises:
+        ResourceNotDefinedError: Query name not found in config.
+        QuerySyntaxError: Query string contains invalid GraphQL syntax.
+        FragmentFileNotFoundError: A declared fragment file path does not exist.
+        DuplicateFragmentError: Same fragment name declared in multiple files.
+        FragmentNotFoundError: Query references a fragment not found in any declared file.
+        CircularFragmentError: Circular dependency detected among fragments.
+    """
+    raw = config.get_query(name).load_query(relative_path=relative_path)
+    try:
+        query_doc = parse(raw)
+    except GraphQLSyntaxError as exc:
+        raise QuerySyntaxError(syntax_error=str(exc)) from exc
+
+    if not _has_fragment_spread(query_doc) or not config.graphql_fragments:
+        return raw
+
+    fragment_contents: list[str] = []
+    for frag in config.graphql_fragments:
+        fragment_contents.extend(frag.load_fragments(relative_path=relative_path))
+    return _render_doc_with_fragments(query_doc, raw, fragment_contents)

--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from .._importer import import_module
 from ..checks import InfrahubCheck
 from ..exceptions import (
+    FragmentFileNotFoundError,
     ModuleImportError,
     ResourceNotDefinedError,
 )
@@ -152,6 +153,28 @@ class InfrahubRepositoryGraphQLConfig(InfrahubRepositoryConfigElement):
         return file_name.read_text(encoding="UTF-8")
 
 
+class InfrahubRepositoryFragmentConfig(InfrahubRepositoryConfigElement):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(..., description="Logical name for this fragment file or directory")
+    file_path: Path = Field(
+        ..., description="Path to a .gql fragment file or a directory of .gql files, relative to repo root"
+    )
+
+    def load_fragments(self, relative_path: str = ".") -> list[str]:
+        """Return raw content of all fragment files at file_path.
+
+        If file_path is a .gql file, returns a single-element list.
+        If file_path is a directory, returns one entry per .gql file found (sorted alphabetically).
+        Raises FragmentFileNotFoundError if file_path does not exist.
+        """
+        resolved = Path(f"{relative_path}/{self.file_path}")
+        if not resolved.exists():
+            raise FragmentFileNotFoundError(file_path=str(self.file_path))
+        if resolved.is_dir():
+            return [f.read_text(encoding="UTF-8") for f in sorted(resolved.glob("*.gql"))]
+        return [resolved.read_text(encoding="UTF-8")]
+
+
 class InfrahubObjectConfig(InfrahubRepositoryConfigElement):
     model_config = ConfigDict(extra="forbid")
     name: str = Field(..., description="The name associated to the object file")
@@ -183,6 +206,9 @@ class InfrahubRepositoryConfig(BaseModel):
         default_factory=list, description="Generator definitions"
     )
     queries: list[InfrahubRepositoryGraphQLConfig] = Field(default_factory=list, description="GraphQL Queries")
+    graphql_fragments: list[InfrahubRepositoryFragmentConfig] = Field(
+        default_factory=list, description="GraphQL fragment files declared for this repository"
+    )
     objects: list[Path] = Field(default_factory=list, description="Objects")
     menus: list[Path] = Field(default_factory=list, description="Menus")
 
@@ -193,6 +219,7 @@ class InfrahubRepositoryConfig(BaseModel):
         "python_transforms",
         "generator_definitions",
         "queries",
+        "graphql_fragments",
     )
     @classmethod
     def unique_items(cls, v: list[Any]) -> list[Any]:
@@ -254,3 +281,12 @@ class InfrahubRepositoryConfig(BaseModel):
             if item.name == name:
                 return item
         raise ResourceNotDefinedError(f"Unable to find {name!r} in 'queries'")
+
+    def has_fragment(self, name: str) -> bool:
+        return any(item.name == name for item in self.graphql_fragments)
+
+    def get_fragment(self, name: str) -> InfrahubRepositoryFragmentConfig:
+        for item in self.graphql_fragments:
+            if item.name == name:
+                return item
+        raise ResourceNotDefinedError(f"Unable to find {name!r} in 'graphql_fragments'")

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,3 +1,9 @@
+from pathlib import Path
+
 CLIENT_TYPE_ASYNC = "standard"
 CLIENT_TYPE_SYNC = "sync"
 CLIENT_TYPES = [CLIENT_TYPE_ASYNC, CLIENT_TYPE_SYNC]
+
+TEST_DIR = Path(__file__).parent
+FIXTURES_DIR = TEST_DIR / "fixtures"
+FIXTURE_REPOS_DIR = FIXTURES_DIR / "repos"

--- a/tests/fixtures/repos/fragment_inlining/.infrahub.yml
+++ b/tests/fixtures/repos/fragment_inlining/.infrahub.yml
@@ -1,0 +1,16 @@
+---
+graphql_fragments:
+  - name: interfaces
+    file_path: fragments/interfaces.gql
+  - name: devices
+    file_path: fragments/devices.gql
+
+graphql_queries:
+  - name: query_two_files
+    file_path: queries/query_two_files.gql
+  - name: query_no_fragments
+    file_path: queries/query_no_fragments.gql
+  - name: query_transitive
+    file_path: queries/query_transitive.gql
+  - name: query_missing_fragment
+    file_path: queries/query_missing_fragment.gql

--- a/tests/fixtures/repos/fragment_inlining/fragments/devices.gql
+++ b/tests/fixtures/repos/fragment_inlining/fragments/devices.gql
@@ -1,0 +1,24 @@
+fragment deviceFragment on InfraDevice {
+  id
+  name {
+    value
+  }
+  interfaces {
+    edges {
+      node {
+        ...interfaceFragment
+      }
+    }
+  }
+}
+
+fragment chassisFragment on InfraDevice {
+  id
+  platform {
+    node {
+      name {
+        value
+      }
+    }
+  }
+}

--- a/tests/fixtures/repos/fragment_inlining/fragments/interfaces.gql
+++ b/tests/fixtures/repos/fragment_inlining/fragments/interfaces.gql
@@ -1,0 +1,26 @@
+fragment interfaceFragment on InterfaceL3 {
+  id
+  name {
+    value
+  }
+  ip_addresses {
+    edges {
+      node {
+        id
+        address {
+          value
+        }
+      }
+    }
+  }
+}
+
+fragment portFragment on InterfaceL2 {
+  id
+  name {
+    value
+  }
+  enabled {
+    value
+  }
+}

--- a/tests/fixtures/repos/fragment_inlining/queries/query_missing_fragment.gql
+++ b/tests/fixtures/repos/fragment_inlining/queries/query_missing_fragment.gql
@@ -1,0 +1,9 @@
+query QueryMissingFragment {
+  InfraDevice {
+    edges {
+      node {
+        ...undeclaredFragment
+      }
+    }
+  }
+}

--- a/tests/fixtures/repos/fragment_inlining/queries/query_no_fragments.gql
+++ b/tests/fixtures/repos/fragment_inlining/queries/query_no_fragments.gql
@@ -1,0 +1,12 @@
+query QueryNoFragments {
+  InfraDevice {
+    edges {
+      node {
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/repos/fragment_inlining/queries/query_transitive.gql
+++ b/tests/fixtures/repos/fragment_inlining/queries/query_transitive.gql
@@ -1,0 +1,9 @@
+query QueryTransitive {
+  InfraDevice {
+    edges {
+      node {
+        ...deviceFragment
+      }
+    }
+  }
+}

--- a/tests/fixtures/repos/fragment_inlining/queries/query_two_files.gql
+++ b/tests/fixtures/repos/fragment_inlining/queries/query_two_files.gql
@@ -1,0 +1,10 @@
+query QueryTwoFiles {
+  InfraDevice {
+    edges {
+      node {
+        ...interfaceFragment
+        ...deviceFragment
+      }
+    }
+  }
+}

--- a/tests/integration/test_infrahubctl.py
+++ b/tests/integration/test_infrahubctl.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
     from infrahub_sdk.node import InfrahubNode
 
-FIXTURE_BASE_DIR = Path(Path(Path(__file__).resolve()).parent / ".." / "fixtures")
+from tests.constants import FIXTURES_DIR
+
+FIXTURE_BASE_DIR = FIXTURES_DIR
 
 
 runner = CliRunner()

--- a/tests/unit/ctl/test_graphql_app.py
+++ b/tests/unit/ctl/test_graphql_app.py
@@ -10,11 +10,12 @@ from graphql import OperationDefinitionNode
 from typer.testing import CliRunner
 
 from infrahub_sdk.ctl.graphql import app, find_gql_files, get_graphql_query
+from tests.constants import FIXTURES_DIR as _FIXTURES_DIR
 from tests.helpers.cli import remove_ansi_color
 
 runner = CliRunner()
 
-FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "unit" / "test_infrahubctl" / "graphql"
+FIXTURES_DIR = _FIXTURES_DIR / "unit" / "test_infrahubctl" / "graphql"
 
 
 class TestFindGqlFiles:

--- a/tests/unit/ctl/test_render_app.py
+++ b/tests/unit/ctl/test_render_app.py
@@ -1,19 +1,18 @@
 import json
 from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from infrahub_sdk.ctl.cli_commands import app
+from tests.constants import FIXTURE_REPOS_DIR
 from tests.helpers.fixtures import read_fixture
 from tests.helpers.utils import strip_color, temp_repo_and_cd
 
 runner = CliRunner()
 
-
-FIXTURE_BASE_DIR = Path(Path(Path(__file__).resolve()).parent / ".." / ".." / "fixtures" / "repos")
+FIXTURE_BASE_DIR = FIXTURE_REPOS_DIR
 
 
 @dataclass

--- a/tests/unit/ctl/test_transform_app.py
+++ b/tests/unit/ctl/test_transform_app.py
@@ -12,15 +12,13 @@ from typer.testing import CliRunner
 
 from infrahub_sdk.ctl.cli_commands import app
 from infrahub_sdk.repository import GitRepoManager
+from tests.constants import FIXTURES_DIR
 from tests.helpers.fixtures import read_fixture
 from tests.helpers.utils import change_directory, strip_color
 
 runner = CliRunner()
 
-
-FIXTURE_BASE_DIR = Path(
-    Path(Path(__file__).resolve()).parent / ".." / ".." / "fixtures" / "integration" / "test_infrahubctl"
-)
+FIXTURE_BASE_DIR = FIXTURES_DIR / "integration" / "test_infrahubctl"
 
 
 @pytest.fixture

--- a/tests/unit/sdk/graphql/test_fragment_renderer.py
+++ b/tests/unit/sdk/graphql/test_fragment_renderer.py
@@ -1,0 +1,338 @@
+"""Unit tests for fragment rendering functions in infrahub_sdk.graphql.query_renderer."""
+
+from __future__ import annotations
+
+import pytest
+from graphql import parse
+
+from infrahub_sdk.exceptions import (
+    CircularFragmentError,
+    DuplicateFragmentError,
+    FragmentNotFoundError,
+    QuerySyntaxError,
+)
+from infrahub_sdk.graphql.query_renderer import (
+    build_fragment_index,
+    collect_required_fragments,
+    render_query_with_fragments,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FRAG_INTERFACE = """
+fragment interfaceFragment on InterfaceL3 {
+  id
+  name { value }
+}
+"""
+
+FRAG_DEVICE = """
+fragment deviceFragment on InfraDevice {
+  id
+  interfaces {
+    edges {
+      node {
+        ...interfaceFragment
+      }
+    }
+  }
+}
+"""
+
+FRAG_PORT = """
+fragment portFragment on InterfaceL2 {
+  id
+  enabled { value }
+}
+"""
+
+QUERY_USE_INTERFACE = """
+query Q {
+  Devices {
+    edges {
+      node {
+        ...interfaceFragment
+      }
+    }
+  }
+}
+"""
+
+QUERY_NO_SPREADS = """
+query Q {
+  Devices {
+    edges {
+      node {
+        id
+        name { value }
+      }
+    }
+  }
+}
+"""
+
+QUERY_USE_DEVICE = """
+query Q {
+  Devices {
+    edges {
+      node {
+        ...deviceFragment
+      }
+    }
+  }
+}
+"""
+
+QUERY_USE_BOTH = """
+query Q {
+  Devices {
+    edges {
+      node {
+        ...interfaceFragment
+        ...deviceFragment
+      }
+    }
+  }
+}
+"""
+
+QUERY_USE_INTERFACE_TWICE = """
+query Q {
+  A: Devices {
+    edges {
+      node {
+        ...interfaceFragment
+      }
+    }
+  }
+  B: Devices {
+    edges {
+      node {
+        ...interfaceFragment
+      }
+    }
+  }
+}
+"""
+
+QUERY_MISSING_FRAGMENT = """
+query Q {
+  Devices {
+    edges {
+      node {
+        ...undeclaredFragment
+      }
+    }
+  }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# build_fragment_index tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_fragment_index_invalid_syntax_raises() -> None:
+    with pytest.raises(QuerySyntaxError):
+        build_fragment_index(["this is not @@ valid graphql"])
+
+
+def test_build_fragment_index_single_file() -> None:
+    index = build_fragment_index([FRAG_INTERFACE])
+    assert "interfaceFragment" in index
+
+
+def test_build_fragment_index_skips_non_fragment_definitions() -> None:
+    # A file that mixes an operation definition with a fragment definition —
+    # the operation is not a FragmentDefinitionNode and must be skipped.
+    mixed = "query Q { id }\nfragment mixedFragment on T { id }"
+    index = build_fragment_index([mixed])
+    assert "mixedFragment" in index
+    assert len(index) == 1
+
+
+def test_build_fragment_index_multiple_files() -> None:
+    index = build_fragment_index([FRAG_INTERFACE, FRAG_DEVICE])
+    assert "interfaceFragment" in index
+    assert "deviceFragment" in index
+
+
+def test_build_fragment_index_duplicate_same_name_two_files() -> None:
+    with pytest.raises(DuplicateFragmentError) as exc_info:
+        build_fragment_index([FRAG_INTERFACE, FRAG_INTERFACE])
+    assert exc_info.value.fragment_name == "interfaceFragment"
+
+
+def test_build_fragment_index_duplicate_same_name_within_file() -> None:
+    combined = FRAG_INTERFACE + FRAG_INTERFACE
+    with pytest.raises(DuplicateFragmentError) as exc_info:
+        build_fragment_index([combined])
+    assert exc_info.value.fragment_name == "interfaceFragment"
+
+
+# ---------------------------------------------------------------------------
+# collect_required_fragments tests
+# ---------------------------------------------------------------------------
+
+
+def test_collect_required_fragments_direct_single() -> None:
+    index = build_fragment_index([FRAG_INTERFACE])
+    doc = parse(QUERY_USE_INTERFACE)
+    required = collect_required_fragments(doc, index)
+    assert required == ["interfaceFragment"]
+
+
+def test_collect_required_fragments_transitive() -> None:
+    """deviceFragment spreads interfaceFragment — both must be collected."""
+    index = build_fragment_index([FRAG_INTERFACE, FRAG_DEVICE])
+    doc = parse(QUERY_USE_DEVICE)
+    required = collect_required_fragments(doc, index)
+    assert "deviceFragment" in required
+    assert "interfaceFragment" in required
+    # interfaceFragment must appear before deviceFragment (dependency first)
+    assert required.index("interfaceFragment") < required.index("deviceFragment")
+
+
+def test_collect_required_fragments_deduplication() -> None:
+    """Fragment used twice in query must appear only once in output."""
+    index = build_fragment_index([FRAG_INTERFACE])
+    doc = parse(QUERY_USE_INTERFACE_TWICE)
+    required = collect_required_fragments(doc, index)
+    assert required.count("interfaceFragment") == 1
+
+
+def test_collect_required_fragments_missing_raises() -> None:
+    index = build_fragment_index([FRAG_INTERFACE])
+    doc = parse(QUERY_MISSING_FRAGMENT)
+    with pytest.raises(FragmentNotFoundError) as exc_info:
+        collect_required_fragments(doc, index)
+    assert exc_info.value.fragment_name == "undeclaredFragment"
+
+
+def test_collect_required_fragments_circular_raises() -> None:
+    frag_a = "fragment FragA on Foo { ...FragB }"
+    frag_b = "fragment FragB on Foo { ...FragA }"
+    query = "query Q { foo { ...FragA } }"
+    index = build_fragment_index([frag_a, frag_b])
+    doc = parse(query)
+    with pytest.raises(CircularFragmentError) as exc_info:
+        collect_required_fragments(doc, index)
+    assert "FragA" in exc_info.value.cycle
+    assert "FragB" in exc_info.value.cycle
+
+
+# ---------------------------------------------------------------------------
+# render_query_with_fragments tests
+# ---------------------------------------------------------------------------
+
+
+def test_render_no_fragment_files_raises_when_spreads_present() -> None:
+    with pytest.raises(FragmentNotFoundError):
+        render_query_with_fragments(QUERY_USE_INTERFACE, [])
+
+
+def test_render_no_spreads_returns_unchanged() -> None:
+    result = render_query_with_fragments(QUERY_NO_SPREADS, [FRAG_INTERFACE])
+    # Content should be semantically equivalent (re-printed by graphql-core)
+    assert "interfaceFragment" not in result
+
+
+def test_render_single_spread_from_one_file() -> None:
+    result = render_query_with_fragments(QUERY_USE_INTERFACE, [FRAG_INTERFACE])
+    assert "fragment interfaceFragment" in result
+    assert "fragment deviceFragment" not in result
+
+
+def test_render_spreads_across_two_files() -> None:
+    result = render_query_with_fragments(QUERY_USE_BOTH, [FRAG_INTERFACE, FRAG_DEVICE])
+    assert "fragment interfaceFragment" in result
+    assert "fragment deviceFragment" in result
+
+
+def test_render_transitive_dependency_included() -> None:
+    """Query uses ...deviceFragment only; interfaceFragment must be inlined transitively."""
+    result = render_query_with_fragments(QUERY_USE_DEVICE, [FRAG_INTERFACE, FRAG_DEVICE])
+    assert "fragment deviceFragment" in result
+    assert "fragment interfaceFragment" in result
+
+
+def test_render_surplus_fragment_excluded() -> None:
+    """portFragment is not referenced — it must not appear in output."""
+    result = render_query_with_fragments(QUERY_USE_INTERFACE, [FRAG_INTERFACE, FRAG_PORT])
+    assert "fragment interfaceFragment" in result
+    assert "fragment portFragment" not in result
+
+
+def test_render_deduplication_definition_appears_once() -> None:
+    """Fragment spread twice in query; definition must appear exactly once."""
+    result = render_query_with_fragments(QUERY_USE_INTERFACE_TWICE, [FRAG_INTERFACE])
+    assert result.count("fragment interfaceFragment") == 1
+
+
+def test_render_missing_fragment_raises() -> None:
+    with pytest.raises(FragmentNotFoundError) as exc_info:
+        render_query_with_fragments(QUERY_MISSING_FRAGMENT, [FRAG_INTERFACE])
+    assert exc_info.value.fragment_name == "undeclaredFragment"
+
+
+def test_render_duplicate_fragment_raises() -> None:
+    with pytest.raises(DuplicateFragmentError):
+        render_query_with_fragments(QUERY_USE_INTERFACE, [FRAG_INTERFACE, FRAG_INTERFACE])
+
+
+def test_render_circular_fragment_raises() -> None:
+    frag_a = "fragment FragA on Foo { ...FragB }"
+    frag_b = "fragment FragB on Foo { ...FragA }"
+    query = "query Q { foo { ...FragA } }"
+    with pytest.raises(CircularFragmentError):
+        render_query_with_fragments(query, [frag_a, frag_b])
+
+
+def test_render_invalid_query_syntax_raises() -> None:
+    with pytest.raises(QuerySyntaxError):
+        render_query_with_fragments("this is not @@ valid graphql", [])
+
+
+def test_render_invalid_fragment_file_syntax_raises() -> None:
+    with pytest.raises(QuerySyntaxError):
+        render_query_with_fragments(QUERY_USE_INTERFACE, ["this is not @@ valid graphql"])
+
+
+# ---------------------------------------------------------------------------
+# Inline (query-local) fragment tests
+# ---------------------------------------------------------------------------
+
+QUERY_WITH_INLINE_FRAGMENT = """
+query Q {
+  Devices {
+    edges {
+      node {
+        ...deviceFields
+      }
+    }
+  }
+}
+
+fragment deviceFields on InfraDevice {
+  id
+  name { value }
+}
+"""
+
+
+def test_collect_required_fragments_inline_fragment_not_raised() -> None:
+    """A fragment defined inside the query document must not raise FragmentNotFoundError."""
+    doc = parse(QUERY_WITH_INLINE_FRAGMENT)
+    # Empty index — no external fragment files
+    required = collect_required_fragments(doc, {})
+    # The inline fragment is self-contained; nothing needs to be appended from external files
+    assert required == []
+
+
+def test_render_inline_fragment_not_raised() -> None:
+    """render_query_with_fragments must not raise when the query already defines its own fragment."""
+    result = render_query_with_fragments(QUERY_WITH_INLINE_FRAGMENT, [])
+    assert "fragment deviceFields" in result

--- a/tests/unit/sdk/graphql/test_query_renderer.py
+++ b/tests/unit/sdk/graphql/test_query_renderer.py
@@ -1,0 +1,54 @@
+"""Unit tests for infrahub_sdk.graphql.query_renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from infrahub_sdk.exceptions import FragmentNotFoundError
+from infrahub_sdk.graphql.query_renderer import render_query
+from infrahub_sdk.schema.repository import (
+    InfrahubRepositoryConfig,
+    InfrahubRepositoryFragmentConfig,
+    InfrahubRepositoryGraphQLConfig,
+)
+from tests.constants import FIXTURE_REPOS_DIR
+
+FIXTURE_REPO = str(FIXTURE_REPOS_DIR / "fragment_inlining")
+
+
+@pytest.fixture
+def repo_config() -> InfrahubRepositoryConfig:
+    return InfrahubRepositoryConfig(
+        graphql_fragments=[
+            InfrahubRepositoryFragmentConfig(name="interfaces", file_path=Path("fragments/interfaces.gql")),
+            InfrahubRepositoryFragmentConfig(name="devices", file_path=Path("fragments/devices.gql")),
+        ],
+        queries=[
+            InfrahubRepositoryGraphQLConfig(name="query_two_files", file_path=Path("queries/query_two_files.gql")),
+            InfrahubRepositoryGraphQLConfig(
+                name="query_no_fragments", file_path=Path("queries/query_no_fragments.gql")
+            ),
+            InfrahubRepositoryGraphQLConfig(
+                name="query_missing_fragment", file_path=Path("queries/query_missing_fragment.gql")
+            ),
+        ],
+    )
+
+
+def test_render_query_inlines_fragments(repo_config: InfrahubRepositoryConfig) -> None:
+    result = render_query(name="query_two_files", config=repo_config, relative_path=FIXTURE_REPO)
+    assert "interfaceFragment" in result
+    assert "deviceFragment" in result
+
+
+def test_render_query_no_fragments_unchanged(repo_config: InfrahubRepositoryConfig) -> None:
+    original = (Path(FIXTURE_REPO) / "queries" / "query_no_fragments.gql").read_text(encoding="UTF-8")
+    result = render_query(name="query_no_fragments", config=repo_config, relative_path=FIXTURE_REPO)
+    assert result.count("fragment ") == original.count("fragment ")
+
+
+def test_render_query_missing_fragment_raises(repo_config: InfrahubRepositoryConfig) -> None:
+    with pytest.raises(FragmentNotFoundError):
+        render_query(name="query_missing_fragment", config=repo_config, relative_path=FIXTURE_REPO)

--- a/tests/unit/sdk/test_schema_repository.py
+++ b/tests/unit/sdk/test_schema_repository.py
@@ -1,7 +1,10 @@
+import tempfile
+from pathlib import Path
+
 import pytest
 
-from infrahub_sdk.exceptions import ResourceNotDefinedError
-from infrahub_sdk.schema.repository import InfrahubRepositoryConfig
+from infrahub_sdk.exceptions import FragmentFileNotFoundError, ResourceNotDefinedError
+from infrahub_sdk.schema.repository import InfrahubRepositoryConfig, InfrahubRepositoryFragmentConfig
 
 
 @pytest.fixture
@@ -237,3 +240,79 @@ def test_get_query_found(repo_config: InfrahubRepositoryConfig) -> None:
 def test_get_query_not_found(repo_config: InfrahubRepositoryConfig) -> None:
     with pytest.raises(ResourceNotDefinedError):
         repo_config.get_query("missing")
+
+
+# --- InfrahubRepositoryFragmentConfig / graphql_fragments ---
+
+
+def test_parse_infrahub_yml_with_graphql_fragments() -> None:
+    config = InfrahubRepositoryConfig(
+        graphql_fragments=[
+            InfrahubRepositoryFragmentConfig(name="interfaces", file_path=Path("fragments/interfaces.gql")),
+            InfrahubRepositoryFragmentConfig(name="devices", file_path=Path("fragments/devices.gql")),
+        ]
+    )
+    assert len(config.graphql_fragments) == 2
+    assert config.graphql_fragments[0].name == "interfaces"
+    assert str(config.graphql_fragments[0].file_path) == "fragments/interfaces.gql"
+
+
+def test_graphql_fragments_defaults_to_empty() -> None:
+    config = InfrahubRepositoryConfig()
+    assert config.graphql_fragments == []
+
+
+def test_has_fragment_found() -> None:
+    config = InfrahubRepositoryConfig(
+        graphql_fragments=[InfrahubRepositoryFragmentConfig(name="ifaces", file_path=Path("frags/ifaces.gql"))]
+    )
+    assert config.has_fragment("ifaces") is True
+
+
+def test_has_fragment_not_found() -> None:
+    config = InfrahubRepositoryConfig()
+    assert config.has_fragment("missing") is False
+
+
+def test_get_fragment_found() -> None:
+    config = InfrahubRepositoryConfig(
+        graphql_fragments=[InfrahubRepositoryFragmentConfig(name="ifaces", file_path=Path("frags/ifaces.gql"))]
+    )
+    result = config.get_fragment("ifaces")
+    assert result.name == "ifaces"
+
+
+def test_get_fragment_not_found() -> None:
+    config = InfrahubRepositoryConfig()
+    with pytest.raises(ResourceNotDefinedError):
+        config.get_fragment("missing")
+
+
+def test_load_fragments_single_file() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        frag_file = Path(tmp) / "ifaces.gql"
+        frag_file.write_text("fragment F on T { id }", encoding="UTF-8")
+        cfg = InfrahubRepositoryFragmentConfig(name="ifaces", file_path=Path("ifaces.gql"))
+        result = cfg.load_fragments(relative_path=tmp)
+    assert len(result) == 1
+    assert "fragment F on T" in result[0]
+
+
+def test_load_fragments_directory() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "a.gql").write_text("fragment A on T { id }", encoding="UTF-8")
+        (Path(tmp) / "b.gql").write_text("fragment B on T { id }", encoding="UTF-8")
+        (Path(tmp) / "not_a_gql.txt").write_text("ignored", encoding="UTF-8")
+        cfg = InfrahubRepositoryFragmentConfig(name="all", file_path=Path())
+        result = cfg.load_fragments(relative_path=tmp)
+    assert len(result) == 2
+    combined = "".join(result)
+    assert "fragment A" in combined
+    assert "fragment B" in combined
+
+
+def test_load_fragments_missing_file_raises() -> None:
+    cfg = InfrahubRepositoryFragmentConfig(name="ifaces", file_path=Path("does_not_exist.gql"))
+    with tempfile.TemporaryDirectory() as tmp, pytest.raises(FragmentFileNotFoundError) as exc_info:
+        cfg.load_fragments(relative_path=tmp)
+    assert "does_not_exist.gql" in exc_info.value.file_path


### PR DESCRIPTION
# Why

Customers with larger GraphQL queries might want to create smaller snippets with fragments. Both to make the queries themselves more readable but also to allow for reusing fragments in multiple queries. Because of this we're introducing a new section in a `.infrahub.yml` file for `graphql_fragments`

```yaml
queries:
  - name: blue_info
    file_path: blue_info.gql
  - name: character
    file_path: checks/character.gql

graphql_fragments:
  - name: fragments
    file_path: fragments (directory or points to a .gql file)
```

## What changed

* Introduced a new way to read and parse queries that uses the configuration object to determine if there are fragments involved in the query. The new function `render_query()` renders the query as is if it didn't contain any external fragments and if fragments are include they are added to the rendered output.
* Updates to `infrahubctl` to allow for the use of these fragments.
* Various tests

## How to test

The easiest is probably to start with an existing repository containing a `.infrahub.yml` file that you're familiar with and try to render transforms with `infrahubctl`.

Create a new section for `graphql_fragments` and move parts of one of the queries to a fragment file.

## Notes

* Ensure to also update any local `.graphqlrc.yml` files to match any new location where fragment files are stored (to allow for go to definition etc)
* Once this is in place we'll update the Infrahub repo to use this new feature of the SDK to allow for imports of GraphQL queries that use external fragments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GraphQL queries now automatically inline referenced fragments for simplified query composition and maintainability.
  * CLI query execution and transforms seamlessly integrate fragment inlining functionality.

* **Improvements**
  * Enhanced error handling for fragment-related issues, including detection of missing, duplicate, and circular dependencies with clear error messages.

* **Documentation**
  * Added comprehensive specification and implementation guide for GraphQL fragment inlining capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->