### PR TITLE
Fix typing warnings with ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,9 @@ addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope"
 [tool.ty.environment]
 python-version = "3.10"
 
+[tool.ty.rules]
+possibly-missing-attribute = "error"
+
 [[tool.ty.overrides]]
 include = ["infrahub_sdk/**"]
 

--- a/tests/unit/sdk/pool/test_allocate.py
+++ b/tests/unit/sdk/pool/test_allocate.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
     from pytest_httpx import HTTPXMock
 
+    from infrahub_sdk.protocols import BuiltinIPAddressSync
     from infrahub_sdk.protocols_base import CoreNode, CoreNodeSync
     from infrahub_sdk.schema import NodeSchemaAPI
     from tests.unit.sdk.conftest import BothClients
@@ -115,8 +116,8 @@ async def test_allocate_next_ip_address(
         )
 
     assert ip_address
-    assert str(cast("InfrahubNodeSync", ip_address).address.value) == "192.0.2.0/32"
-    assert cast("InfrahubNodeSync", ip_address).description.value == "test"
+    assert str(cast("BuiltinIPAddressSync", ip_address).address.value) == "192.0.2.0/32"
+    assert cast("BuiltinIPAddressSync", ip_address).description.value == "test"
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
# Why

Running "ty check ." produced warnings in the console but with a successful exit status. This leads to extra noise when running the command.

## What changed

* Changed the configuration for these warnings to instead report an error
* Update tests so that the linting passed.