### PR TITLE
Add opsmill/emma to repository dispatch targets

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         # Either a literal path, or the name of a secret...
         repo:
+          - "opsmill/emma"
           - "opsmill/infrahub-bundle-dc"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
           - "INFRAHUB_CUSTOMER3_REPOSITORY"

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -36,7 +36,7 @@ jobs:
         # Either a literal path, or the name of a secret...
         repo:
           - "opsmill/emma"
-          - "opsmill/infrahub-bundle-dc"
+          - "opsmill/infrahub-demo-dc"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
           - "INFRAHUB_CUSTOMER3_REPOSITORY"
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automated update distribution to reach two additional repositories and removed one previously targeted repository.
  * Dispatch mechanism remains unchanged; behavior and payload formats for updates are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Add `opsmill/emma` to the list of repositories notified via repository dispatch workflow

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm dispatch triggers correctly for the new repository on next SDK release