### PR TITLE
Add description field to InfrahubPythonTransformConfig

### DIFF
--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -128,6 +128,7 @@ class InfrahubPythonTransformConfig(InfrahubRepositoryConfigElement):
         default=False,
         description="Decide if the transform should convert the result of the GraphQL query to SDK InfrahubNode objects.",
     )
+    description: str | None = Field(default=None, description="Description for this transform")
 
     def load_class(self, import_root: str | None = None, relative_path: str | None = None) -> type[InfrahubTransform]:
         module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -341,6 +341,27 @@ async def test_infrahub_repository_config_dups() -> None:
     assert "Found multiples element with the same names: ['check01', 'check02']" in str(exc.value)
 
 
+async def test_python_transform_config_description() -> None:
+    """Verify InfrahubPythonTransformConfig supports an optional description field."""
+    # With description
+    config_with_desc = InfrahubPythonTransformConfig(
+        name="my_transform", file_path="transforms/my.py", class_name="MyTransform", description="A useful transform"
+    )
+    assert config_with_desc.description == "A useful transform"
+
+    # Without description (default None)
+    config_without_desc = InfrahubPythonTransformConfig(
+        name="my_transform", file_path="transforms/my.py", class_name="MyTransform"
+    )
+    assert config_without_desc.description is None
+
+    # Explicit None
+    config_explicit_none = InfrahubPythonTransformConfig(
+        name="my_transform", file_path="transforms/my.py", class_name="MyTransform", description=None
+    )
+    assert config_explicit_none.description is None
+
+
 @mock.patch(
     "infrahub_sdk.ctl.schema.get_node",
     return_value={


### PR DESCRIPTION
## Summary

Fixes opsmill/infrahub#6382 — Python transforms in `.infrahub.yml` don't support a `description` field, even though Jinja2 transforms do and both types appear in the same table in the Infrahub UI.

- Add optional `description: str | None` field to `InfrahubPythonTransformConfig`, matching the existing field on `InfrahubJinja2TransformConfig`
- Add unit test covering description field parsing (present, absent, explicit None)

## Before / After

**Before:** Setting `description` on a Python transform in `.infrahub.yml` raises a validation error (`extra="forbid"`).

**After:**
```yaml
python_transforms:
  - name: MyTransform
    description: "Converts device data to OpenConfig format"  # now accepted
    file_path: "transforms/my_transform.py"
    class_name: MyTransform
```

## Test plan

- [x] `InfrahubPythonTransformConfig` accepts `description` with a string value
- [x] `InfrahubPythonTransformConfig` defaults `description` to `None` when omitted
- [x] Existing configs without `description` continue to parse (backward compatible)
- [x] All 53 SDK schema tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)