### PR TITLE
Fix typing violation in extract_fields()

### DIFF
--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -288,6 +288,8 @@ async def extract_fields(selection_set: SelectionSetNode | None) -> dict[str, di
 
         elif isinstance(node, InlineFragmentNode):
             for sub_node in node.selection_set.selections:
+                if not isinstance(sub_node, FieldNode):
+                    continue
                 sub_sub_selection_set = getattr(sub_node, "selection_set", None)
                 value = await extract_fields(sub_sub_selection_set)
                 if sub_node.name.value not in fields:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,10 +143,10 @@ include = ["infrahub_sdk/checks.py"]
 invalid-await = "ignore" # 1 violation
 
 [[tool.ty.overrides]]
-include = ["infrahub_sdk/file_handler.py", "infrahub_sdk/utils.py"]
+include = ["infrahub_sdk/file_handler.py"]
 
 [tool.ty.overrides.rules]
-unresolved-attribute = "ignore" # 5 violations total (1 in file_handler.py, 4 in utils.py)
+unresolved-attribute = "ignore" # 1 violation in file_handler.py (anyio type stub issue)
 
 [[tool.ty.overrides]]
 include = ["infrahub_sdk/transfer/**"]


### PR DESCRIPTION
# Why

Correct typing violations. - The inner loop iterates over node.selection_set.selections, which is typed as FrozenList[SelectionNode]. SelectionNode is a union of FieldNode | InlineFragmentNode | FragmentSpreadNode, but only FieldNode has a .name attribute — the other two don't. Without the guard, ty correctly flagged 4 unresolved-attribute errors on sub_node.name.value. The outer loop already had the correct isinstance(node, FieldNode) pattern; the inner loop was simply missing it.

## What changed

Added if not isinstance(sub_node, FieldNode): continue at the top of the inner loop in extract_fields