### PR TITLE
Corrected protocol typing for IPHost.value IPAddress -> IPInterface

### DIFF
--- a/changelog/891.fixed.md
+++ b/changelog/891.fixed.md
@@ -1,0 +1,1 @@
+Corrected protocol typing for IPHost.value IPAddress -> IPInterface

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -125,11 +125,11 @@ class IntegerOptional(Attribute):
 
 
 class IPHost(Attribute):
-    value: ipaddress.IPv4Address | ipaddress.IPv6Address
+    value: ipaddress.IPv4Interface | ipaddress.IPv6Interface
 
 
 class IPHostOptional(Attribute):
-    value: ipaddress.IPv4Address | ipaddress.IPv6Address | None
+    value: ipaddress.IPv4Interface | ipaddress.IPv6Interface | None
 
 
 class IPNetwork(Attribute):


### PR DESCRIPTION
# Why

The typing for IPHost.value within the protocol class was incorrect

## What changed

* Switch invalid reference to IPAddress for IPInterface

Fixes #891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IP host value type annotation to properly reflect network interface type instead of address type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->