### PR TITLE
Fix incorrect docs URL for object conversion guide

### DIFF
--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -440,7 +440,7 @@ convert_object_type(self, node_id: str, target_kind: str, branch: str | None = N
 
 Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
 and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-convert-type
+in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
 for more information.
 
 ### `InfrahubClientSync`
@@ -880,7 +880,7 @@ convert_object_type(self, node_id: str, target_kind: str, branch: str | None = N
 
 Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
 and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-convert-type
+in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
 for more information.
 
 ### `ProcessRelationsNode`

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1864,7 +1864,7 @@ class InfrahubClient(BaseClient):
         """
         Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
         and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-        in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-convert-type
+        in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
         for more information.
         """
 
@@ -3422,7 +3422,7 @@ class InfrahubClientSync(BaseClient):
         """
         Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
         and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-        in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-convert-type
+        in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
         for more information.
         """
 


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation reference URLs for object conversion functionality to direct users to the correct guide pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Fix broken documentation URL in `convert_node` docstrings (both async and sync clients)
- Changed `/guides/object-convert-type` → `/guides/object-conversion`

## Test plan

- [ ] Verify the URL https://docs.infrahub.app/guides/object-conversion resolves correctly