### PR TITLE
Set `*_content` filter context to `WORKER`

### DIFF
--- a/docs/docs/python-sdk/reference/templating.mdx
+++ b/docs/docs/python-sdk/reference/templating.mdx
@@ -185,10 +185,10 @@ These filters are provided by the Infrahub SDK for artifact and file object cont
 <!-- vale off -->
 | Name | CORE | WORKER | LOCAL |
 | ---- | ---- | ------ | ----- |
-| `artifact_content` | ❌ | ✅ | ✅ |
-| `file_object_content` | ❌ | ✅ | ✅ |
-| `file_object_content_by_hfid` | ❌ | ✅ | ✅ |
-| `file_object_content_by_id` | ❌ | ✅ | ✅ |
+| `artifact_content` | ❌ | ✅ | ❌ |
+| `file_object_content` | ❌ | ✅ | ❌ |
+| `file_object_content_by_hfid` | ❌ | ✅ | ❌ |
+| `file_object_content_by_id` | ❌ | ✅ | ❌ |
 | `from_json` | ✅ | ✅ | ✅ |
 | `from_yaml` | ✅ | ✅ | ✅ |
 <!-- vale on -->

--- a/infrahub_sdk/template/filters.py
+++ b/infrahub_sdk/template/filters.py
@@ -162,22 +162,10 @@ NETUTILS_FILTERS = [
 
 
 INFRAHUB_FILTERS = [
-    FilterDefinition(
-        name="artifact_content", allowed_contexts=ExecutionContext.WORKER | ExecutionContext.LOCAL, source="infrahub"
-    ),
-    FilterDefinition(
-        name="file_object_content", allowed_contexts=ExecutionContext.WORKER | ExecutionContext.LOCAL, source="infrahub"
-    ),
-    FilterDefinition(
-        name="file_object_content_by_hfid",
-        allowed_contexts=ExecutionContext.WORKER | ExecutionContext.LOCAL,
-        source="infrahub",
-    ),
-    FilterDefinition(
-        name="file_object_content_by_id",
-        allowed_contexts=ExecutionContext.WORKER | ExecutionContext.LOCAL,
-        source="infrahub",
-    ),
+    FilterDefinition(name="artifact_content", allowed_contexts=ExecutionContext.WORKER, source="infrahub"),
+    FilterDefinition(name="file_object_content", allowed_contexts=ExecutionContext.WORKER, source="infrahub"),
+    FilterDefinition(name="file_object_content_by_hfid", allowed_contexts=ExecutionContext.WORKER, source="infrahub"),
+    FilterDefinition(name="file_object_content_by_id", allowed_contexts=ExecutionContext.WORKER, source="infrahub"),
     FilterDefinition(name="from_json", allowed_contexts=ExecutionContext.ALL, source="infrahub"),
     FilterDefinition(name="from_yaml", allowed_contexts=ExecutionContext.ALL, source="infrahub"),
 ]

--- a/tests/unit/sdk/test_infrahub_filters.py
+++ b/tests/unit/sdk/test_infrahub_filters.py
@@ -62,12 +62,8 @@ class TestFilterDefinition:
         fd = FilterDefinition(name="safe", allowed_contexts=ExecutionContext.LOCAL, source="jinja2")
         assert fd.trusted is False
 
-    def test_not_trusted_when_worker_and_local(self) -> None:
-        fd = FilterDefinition(
-            name="artifact_content",
-            allowed_contexts=ExecutionContext.WORKER | ExecutionContext.LOCAL,
-            source="infrahub",
-        )
+    def test_not_trusted_when_worker_only(self) -> None:
+        fd = FilterDefinition(name="artifact_content", allowed_contexts=ExecutionContext.WORKER, source="infrahub")
         assert fd.trusted is False
 
     def test_not_trusted_when_core_only(self) -> None:
@@ -114,10 +110,11 @@ class TestValidateContext:
         jinja = Jinja2Template(template="{{ data | safe }}")
         jinja.validate(context=ExecutionContext.LOCAL)
 
-    def test_context_local_allows_artifact_content(self) -> None:
-        """LOCAL context allows artifact_content (WORKER | LOCAL)."""
+    def test_context_local_blocks_artifact_content(self) -> None:
+        """LOCAL context blocks artifact_content (WORKER only) — these filters require a worker."""
         jinja = Jinja2Template(template="{{ sid | artifact_content }}")
-        jinja.validate(context=ExecutionContext.LOCAL)
+        with pytest.raises(JinjaTemplateOperationViolationError):
+            jinja.validate(context=ExecutionContext.LOCAL)
 
     @pytest.mark.parametrize("context", [ExecutionContext.CORE, ExecutionContext.WORKER])
     def test_user_filters_always_allowed(self, context: ExecutionContext) -> None:


### PR DESCRIPTION
## Why & What

The idea is that these filters should *never* be used by the main API server. Making them `LOCAL` too would allow that. So rather than doing this, we prefer making them `WORKER` only and allow any filters to run on workers if the user turns on the proper setting in the API server.

Related to https://github.com/opsmill/infrahub/pull/8705
Following https://github.com/opsmill/infrahub-sdk-python/pull/904

## Checklist

- [x] Tests added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Infrahub SDK filter support matrix.

* **Bug Fixes**
  * Restricted `artifact_content`, `file_object_content`, `file_object_content_by_hfid`, and `file_object_content_by_id` filters to WORKER execution context; no longer available in LOCAL context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->