### PR TITLE
Clean up of logic within Node

### DIFF
--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -11,11 +11,8 @@ from ..file_handler import FileHandler, FileHandlerBase, FileHandlerSync, Prepar
 from ..graphql import Mutation, Query
 from ..schema import (
     GenericSchemaAPI,
-    ProfileSchemaAPI,
     RelationshipCardinality,
     RelationshipKind,
-    RelationshipSchemaAPI,
-    TemplateSchemaAPI,
 )
 from ..utils import compare_lists, generate_short_id
 from .attribute import Attribute
@@ -68,20 +65,13 @@ class InfrahubNodeBase:
         self._attributes = [item.name for item in self._schema.attributes]
         self._relationships = [item.name for item in self._schema.relationships]
 
-        # GenericSchemaAPI doesn't have inherit_from
-        inherit_from: list[str] = getattr(schema, "inherit_from", None) or []
-        self._artifact_support = "CoreArtifactTarget" in inherit_from
-        self._file_object_support = "CoreFileObject" in inherit_from
-        self._artifact_definition_support = schema.kind == "CoreArtifactDefinition"
+        self._artifact_support = schema.supports_artifacts
+        self._file_object_support = schema.supports_file_object
+        self._hierarchy_support = schema.supports_hierarchy
+        self._artifact_definition_support = schema.supports_artifact_definition
 
         self._file_content: bytes | Path | BinaryIO | None = None
         self._file_name: str | None = None
-
-        # Check if this node is hierarchical (supports parent/children and ancestors/descendants)
-        if not isinstance(schema, (ProfileSchemaAPI, GenericSchemaAPI, TemplateSchemaAPI)):
-            self._hierarchy_support = getattr(schema, "hierarchy", None) is not None
-        else:
-            self._hierarchy_support = False
 
         if not self.id:
             self._existing = False
@@ -653,74 +643,25 @@ class InfrahubNode(InfrahubNodeBase):
                     data=rel_data,
                 )
         # Initialize parent, children, ancestors and descendants for hierarchical nodes
-        if self._hierarchy_support:
-            # Create pseudo-schema for parent (cardinality one)
-            parent_schema = RelationshipSchemaAPI(
-                name="parent",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                kind=RelationshipKind.HIERARCHY,
-                cardinality="one",
-                optional=True,
-            )
-            parent_data = data.get("parent", None) if isinstance(data, dict) else None
-            self._hierarchical_data["parent"] = RelatedNode(
-                name="parent",
-                client=self._client,
-                branch=self._branch,
-                schema=parent_schema,
-                data=parent_data,
-            )
-            # Create pseudo-schema for children (many cardinality)
-            children_schema = RelationshipSchemaAPI(
-                name="children",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                kind=RelationshipKind.HIERARCHY,
-                cardinality="many",
-                optional=True,
-            )
-            children_data = data.get("children", None) if isinstance(data, dict) else None
-            self._hierarchical_data["children"] = RelationshipManager(
-                name="children",
-                client=self._client,
-                node=self,
-                branch=self._branch,
-                schema=children_schema,
-                data=children_data,
-            )
-            # Create pseudo-schema for ancestors (read-only, many cardinality)
-            ancestors_schema = RelationshipSchemaAPI(
-                name="ancestors",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                cardinality="many",
-                read_only=True,
-                optional=True,
-            )
-            ancestors_data = data.get("ancestors", None) if isinstance(data, dict) else None
-            self._hierarchical_data["ancestors"] = RelationshipManager(
-                name="ancestors",
-                client=self._client,
-                node=self,
-                branch=self._branch,
-                schema=ancestors_schema,
-                data=ancestors_data,
-            )
-            # Create pseudo-schema for descendants (read-only, many cardinality)
-            descendants_schema = RelationshipSchemaAPI(
-                name="descendants",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                cardinality="many",
-                read_only=True,
-                optional=True,
-            )
-            descendants_data = data.get("descendants", None) if isinstance(data, dict) else None
-            self._hierarchical_data["descendants"] = RelationshipManager(
-                name="descendants",
-                client=self._client,
-                node=self,
-                branch=self._branch,
-                schema=descendants_schema,
-                data=descendants_data,
-            )
+        for rel_schema in self._schema.hierarchical_relationship_schemas:
+            rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
+            if rel_schema.cardinality_is_one:
+                self._hierarchical_data[rel_schema.name] = RelatedNode(
+                    name=rel_schema.name,
+                    client=self._client,
+                    branch=self._branch,
+                    schema=rel_schema,
+                    data=rel_data,
+                )
+            else:
+                self._hierarchical_data[rel_schema.name] = RelationshipManager(
+                    name=rel_schema.name,
+                    client=self._client,
+                    node=self,
+                    branch=self._branch,
+                    schema=rel_schema,
+                    data=rel_data,
+                )
 
     def __getattr__(self, name: str) -> Attribute | RelationshipManager | RelatedNode:
         if "_attribute_data" in self.__dict__ and name in self._attribute_data:
@@ -1537,77 +1478,25 @@ class InfrahubNodeSync(InfrahubNodeBase):
                 )
 
         # Initialize parent, children, ancestors and descendants for hierarchical nodes
-        if self._hierarchy_support:
-            # Create pseudo-schema for parent (cardinality one)
-            parent_schema = RelationshipSchemaAPI(
-                name="parent",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                kind=RelationshipKind.HIERARCHY,
-                cardinality="one",
-                optional=True,
-            )
-            parent_data = data.get("parent", None) if isinstance(data, dict) else None
-            self._hierarchical_data["parent"] = RelatedNodeSync(
-                name="parent",
-                client=self._client,
-                branch=self._branch,
-                schema=parent_schema,
-                data=parent_data,
-            )
-
-            # Create pseudo-schema for children (many cardinality)
-            children_schema = RelationshipSchemaAPI(
-                name="children",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                kind=RelationshipKind.HIERARCHY,
-                cardinality="many",
-                optional=True,
-            )
-            children_data = data.get("children", None) if isinstance(data, dict) else None
-            self._hierarchical_data["children"] = RelationshipManagerSync(
-                name="children",
-                client=self._client,
-                node=self,
-                branch=self._branch,
-                schema=children_schema,
-                data=children_data,
-            )
-
-            # Create pseudo-schema for ancestors (read-only, many cardinality)
-            ancestors_schema = RelationshipSchemaAPI(
-                name="ancestors",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                cardinality="many",
-                read_only=True,
-                optional=True,
-            )
-            ancestors_data = data.get("ancestors", None) if isinstance(data, dict) else None
-            self._hierarchical_data["ancestors"] = RelationshipManagerSync(
-                name="ancestors",
-                client=self._client,
-                node=self,
-                branch=self._branch,
-                schema=ancestors_schema,
-                data=ancestors_data,
-            )
-
-            # Create pseudo-schema for descendants (read-only, many cardinality)
-            descendants_schema = RelationshipSchemaAPI(
-                name="descendants",
-                peer=self._schema.hierarchy,  # type: ignore[union-attr, arg-type]
-                cardinality="many",
-                read_only=True,
-                optional=True,
-            )
-            descendants_data = data.get("descendants", None) if isinstance(data, dict) else None
-            self._hierarchical_data["descendants"] = RelationshipManagerSync(
-                name="descendants",
-                client=self._client,
-                node=self,
-                branch=self._branch,
-                schema=descendants_schema,
-                data=descendants_data,
-            )
+        for rel_schema in self._schema.hierarchical_relationship_schemas:
+            rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
+            if rel_schema.cardinality_is_one:
+                self._hierarchical_data[rel_schema.name] = RelatedNodeSync(
+                    name=rel_schema.name,
+                    client=self._client,
+                    branch=self._branch,
+                    schema=rel_schema,
+                    data=rel_data,
+                )
+            else:
+                self._hierarchical_data[rel_schema.name] = RelationshipManagerSync(
+                    name=rel_schema.name,
+                    client=self._client,
+                    node=self,
+                    branch=self._branch,
+                    schema=rel_schema,
+                    data=rel_data,
+                )
 
     def __getattr__(self, name: str) -> Attribute | RelationshipManagerSync | RelatedNodeSync:
         if "_attribute_data" in self.__dict__ and name in self._attribute_data:

--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -150,6 +150,14 @@ class RelationshipSchemaAPI(RelationshipSchema):
     hierarchical: str | None = None
     allow_override: AllowOverrideType = AllowOverrideType.ANY
 
+    @property
+    def cardinality_is_one(self) -> bool:
+        return self.cardinality == RelationshipCardinality.ONE
+
+    @property
+    def cardinality_is_many(self) -> bool:
+        return self.cardinality == RelationshipCardinality.MANY
+
 
 class BaseSchemaAttrRel(BaseModel):
     attributes: list[AttributeSchema] = Field(default_factory=list)
@@ -279,6 +287,36 @@ class BaseSchema(BaseModel):
     def kind(self) -> str:
         return self.namespace + self.name
 
+    @property
+    def supports_artifact_definition(self) -> bool:
+        """Returns True if this schema represents CoreArtifactDefinition. Only meaningful for NodeSchemaAPI."""
+        return self.kind == "CoreArtifactDefinition"
+
+    @property
+    def supports_artifacts(self) -> bool:
+        """Returns True if this schema supports artifact operations via CoreArtifactTarget inheritance.
+        Only NodeSchemaAPI overrides this; all other schema types return False by design because
+        artifact capability is tied to node inheritance, not profiles, templates, or generics."""
+        return False
+
+    @property
+    def supports_file_object(self) -> bool:
+        """Returns True if this schema supports file object operations via CoreFileObject inheritance.
+        Only NodeSchemaAPI overrides this; all other schema types return False by design because
+        file object capability is tied to node inheritance, not profiles, templates, or generics."""
+        return False
+
+    @property
+    def supports_hierarchy(self) -> bool:
+        """Returns True if this schema participates in a hierarchy. Only NodeSchemaAPI overrides this."""
+        return False
+
+    @property
+    def hierarchical_relationship_schemas(self) -> list[RelationshipSchemaAPI]:
+        """Returns pseudo-schemas for parent/children/ancestors/descendants if hierarchy is set.
+        Only NodeSchemaAPI overrides this; all other schema types return an empty list."""
+        return []
+
 
 class GenericSchema(BaseSchema, BaseSchemaAttrRel):
     def convert_api(self) -> GenericSchemaAPI:
@@ -312,6 +350,37 @@ class NodeSchema(BaseNodeSchema, BaseSchemaAttrRel):
 class NodeSchemaAPI(BaseNodeSchema, BaseSchemaAttrRelAPI):
     hash: str | None = None
     hierarchy: str | None = None
+
+    @property
+    def supports_artifacts(self) -> bool:
+        return "CoreArtifactTarget" in self.inherit_from
+
+    @property
+    def supports_file_object(self) -> bool:
+        return "CoreFileObject" in self.inherit_from
+
+    @property
+    def supports_hierarchy(self) -> bool:
+        return self.hierarchy is not None
+
+    @property
+    def hierarchical_relationship_schemas(self) -> list[RelationshipSchemaAPI]:
+        if self.hierarchy is None:
+            return []
+        return [
+            RelationshipSchemaAPI(
+                name="parent", peer=self.hierarchy, kind=RelationshipKind.HIERARCHY, cardinality="one", optional=True
+            ),
+            RelationshipSchemaAPI(
+                name="children", peer=self.hierarchy, kind=RelationshipKind.HIERARCHY, cardinality="many", optional=True
+            ),
+            RelationshipSchemaAPI(
+                name="ancestors", peer=self.hierarchy, cardinality="many", read_only=True, optional=True
+            ),
+            RelationshipSchemaAPI(
+                name="descendants", peer=self.hierarchy, cardinality="many", read_only=True, optional=True
+            ),
+        ]
 
 
 class ProfileSchemaAPI(BaseSchema, BaseSchemaAttrRelAPI):


### PR DESCRIPTION
# Why

The node initialization code in InfrahubNodeBase was determining capability flags (_artifact_support, _file_object_support, _hierarchy_support, _artifact_definition_support) by inspecting schema internals directly — using getattr to reach into inherit_from, string comparisons against hardcoded kind names, and isinstance checks to exclude schema types that don't carry certain fields. This logic belonged on the schema layer, not the node layer.

The change moves these capability checks to where the relevant data lives: BaseSchema provides safe defaults (False / []) for all schema types, and NodeSchemaAPI overrides them with real logic using its own fields (inherit_from, hierarchy). The same pattern is applied to hierarchical_relationship_schemas — rather than constructing four hardcoded RelationshipSchemaAPI objects inline in _init_relationships (duplicated across the async and sync classes), the schema itself now produces the correct pseudo-schemas for hierarchical nodes.

The result is that node.py no longer needs to know anything about the structure of the schema to determine what a node supports. Four uniform assignments replace a mix of getattr hacks, isinstance guards, and inline schema construction. The _init_relationships hierarchical block drops from ~70 lines (×2 for async/sync) to a single loop.

## What changed

* infrahub_sdk/schema/main.py: define various generic properties related to the schema
* infrahub_sdk/node/node.py: refactor to use the new properties to simplify the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper properties on schemas to expose capability and cardinality information for more accurate feature detection.

* **Improvements**
  * Improved node capability detection to support broader and more flexible schema configurations.
  * Simplified hierarchical relationship initialization for more consistent behavior, fewer runtime checks, and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->