### PR TITLE
Use RelationshipCardinality enum in favor of a string

### DIFF
--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -565,7 +565,7 @@ class InfrahubNodeBase:
         property: bool,
         include_metadata: bool,
     ) -> dict[str, Any] | None:
-        if rel_schema.cardinality == "one":
+        if rel_schema.cardinality == RelationshipCardinality.ONE:
             rel_data = RelatedNodeBase._generate_query_data(
                 peer_data=peer_data, property=property, include_metadata=include_metadata
             )
@@ -578,7 +578,7 @@ class InfrahubNodeBase:
                 rel_data["node"] = {}
                 rel_data["node"][f"...on {rel_schema.peer}"] = data_node
             return rel_data
-        if rel_schema.cardinality == "many":
+        if rel_schema.cardinality == RelationshipCardinality.MANY:
             return RelationshipManagerBase._generate_query_data(
                 peer_data=peer_data, property=property, include_metadata=include_metadata
             )
@@ -643,7 +643,7 @@ class InfrahubNode(InfrahubNodeBase):
         for rel_schema in self._schema.relationships:
             rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
 
-            if rel_schema.cardinality == "one":
+            if rel_schema.cardinality == RelationshipCardinality.ONE:
                 if isinstance(rel_data, RelatedNode):
                     peer_id_data: dict[str, Any] = {
                         key: value
@@ -1460,7 +1460,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         for rel_schema in self._schema.relationships:
             rel_data = data.get(rel_schema.name, None) if isinstance(data, dict) else None
 
-            if rel_schema.cardinality == "one":
+            if rel_schema.cardinality == RelationshipCardinality.ONE:
                 if isinstance(rel_data, RelatedNodeSync):
                     peer_id_data: dict[str, Any] = {
                         key: value

--- a/infrahub_sdk/protocols_generator/generator.py
+++ b/infrahub_sdk/protocols_generator/generator.py
@@ -14,6 +14,7 @@ from ..schema import (
     NodeSchema,
     NodeSchemaAPI,
     ProfileSchemaAPI,
+    RelationshipCardinality,
     RelationshipSchemaAPI,
     TemplateSchemaAPI,
 )
@@ -128,7 +129,7 @@ class CodeGenerator:
         cardinality = value.cardinality
 
         type_ = "RelatedNode"
-        if cardinality == "many":
+        if cardinality == RelationshipCardinality.MANY:
             type_ = "RelationshipManager"
 
         if sync:

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -217,10 +217,10 @@ class InfrahubSchemaBase:
             elif key in schema.relationship_names:
                 rel = schema.get_relationship(name=key)
                 if rel:
-                    if rel.cardinality == "one":
+                    if rel.cardinality == RelationshipCardinality.ONE:
                         obj_data[key] = {"id": str(value)}
                         obj_data[key].update(item_metadata)
-                    elif rel.cardinality == "many":
+                    elif rel.cardinality == RelationshipCardinality.MANY:
                         obj_data[key] = [{"id": str(item)} for item in value]
                         for item in obj_data[key]:
                             item.update(item_metadata)

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, Field
 
 from ..exceptions import ObjectValidationError, ValidationError
-from ..schema import GenericSchemaAPI, RelationshipKind, RelationshipSchema
+from ..schema import GenericSchemaAPI, RelationshipCardinality, RelationshipKind, RelationshipSchema
 from ..utils import is_valid_uuid
 from ..yaml import InfrahubFile, InfrahubFileKind
 from .models import InfrahubObjectParameters
@@ -102,7 +102,10 @@ class RelationshipInfo(BaseModel):
         # For hierarchical node, currently the relationship to the parent is always optional in the schema even if it's mandatory
         # In order to build the tree from top to bottom, we need to consider it as mandatory
         # While it should technically work bottom-up, it created some unexpected behavior while loading the menu
-        if self.peer_rel.cardinality == "one" and self.peer_rel.kind == RelationshipKind.HIERARCHY:
+        if (
+            self.peer_rel.cardinality == RelationshipCardinality.ONE
+            and self.peer_rel.kind == RelationshipKind.HIERARCHY
+        ):
             return True
         return not self.peer_rel.optional
 
@@ -116,9 +119,9 @@ class RelationshipInfo(BaseModel):
 
     def get_context(self, value: Any) -> dict:
         """Return a dict to insert to the context if the relationship is mandatory"""
-        if self.peer_rel and self.is_mandatory and self.peer_rel.cardinality == "one":
+        if self.peer_rel and self.is_mandatory and self.peer_rel.cardinality == RelationshipCardinality.ONE:
             return {self.peer_rel.name: value}
-        if self.peer_rel and self.is_mandatory and self.peer_rel.cardinality == "many":
+        if self.peer_rel and self.is_mandatory and self.peer_rel.cardinality == RelationshipCardinality.MANY:
             return {self.peer_rel.name: [value]}
         return {}
 
@@ -162,21 +165,21 @@ async def get_relationship_info(
             id=rel_schema.identifier or "", direction=rel_schema.direction
         )
 
-    if rel_schema.cardinality == "one" and isinstance(value, list):
+    if rel_schema.cardinality == RelationshipCardinality.ONE and isinstance(value, list):
         # validate the list is composed of string
         if validate_list_of_scalars(value):
             info.format = RelationshipDataFormat.ONE_REF
         else:
             info.reason_relationship_not_valid = "Too many objects provided for a relationship of cardinality one"
 
-    elif rel_schema.cardinality == "one" and isinstance(value, str):
+    elif rel_schema.cardinality == RelationshipCardinality.ONE and isinstance(value, str):
         info.format = RelationshipDataFormat.ONE_REF
 
-    elif rel_schema.cardinality == "one" and isinstance(value, dict) and "data" in value:
+    elif rel_schema.cardinality == RelationshipCardinality.ONE and isinstance(value, dict) and "data" in value:
         info.format = RelationshipDataFormat.ONE_OBJ
 
     elif (
-        rel_schema.cardinality == "many"
+        rel_schema.cardinality == RelationshipCardinality.MANY
         and isinstance(value, dict)
         and "data" in value
         and validate_list_of_objects(value["data"])
@@ -185,11 +188,11 @@ async def get_relationship_info(
         # it's helpful if there is only one type of object to manage
         info.format = RelationshipDataFormat.MANY_OBJ_DICT_LIST
 
-    elif rel_schema.cardinality == "many" and isinstance(value, dict) and "data" not in value:
+    elif rel_schema.cardinality == RelationshipCardinality.MANY and isinstance(value, dict) and "data" not in value:
         info.reason_relationship_not_valid = "Invalid structure for a relationship of cardinality many,"
         " either provide a dict with data as a list or a list of objects"
 
-    elif rel_schema.cardinality == "many" and isinstance(value, list):
+    elif rel_schema.cardinality == RelationshipCardinality.MANY and isinstance(value, list):
         if validate_list_of_data_dicts(value):
             info.format = RelationshipDataFormat.MANY_OBJ_LIST_DICT
         elif validate_list_of_hfids(value):

--- a/infrahub_sdk/transfer/importer/json.py
+++ b/infrahub_sdk/transfer/importer/json.py
@@ -12,6 +12,7 @@ from rich.progress import Progress
 
 from ...exceptions import GraphQLError
 from ...node import InfrahubNode, RelatedNode, RelationshipManager
+from ...schema import RelationshipCardinality
 from ..exceptions import TransferFileNotFoundError
 from .interface import ImporterInterface
 
@@ -130,11 +131,14 @@ class LineDelimitedJSONImporter(ImporterInterface):
                 relationship_schema = self.optional_relationships_schemas_by_node_kind[node_kind][relationship_attr]
 
                 # Check if we are in a many-many relationship, ignore importing it if it is
-                if relationship_schema.cardinality == "many":
+                if relationship_schema.cardinality == RelationshipCardinality.MANY:
                     if relationship_schema.peer not in self.schemas_by_kind:
                         continue
                     for peer_relationship in self.schemas_by_kind[relationship_schema.peer].relationships:
-                        if peer_relationship.cardinality == "many" and peer_relationship.peer == node_kind:
+                        if (
+                            peer_relationship.cardinality == RelationshipCardinality.MANY
+                            and peer_relationship.peer == node_kind
+                        ):
                             ignore = True
 
                 if not ignore:


### PR DESCRIPTION
# Why

We have an enum for `RelationshipCardinality` but in a number of places we were instead using a hard coded string, this is a slight cleanup to ensure that we have the correct types throughout the code.


## What changed

* Update static strings and replace with the `RelationshipCardinality` enum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code quality and type safety in relationship handling modules through improved consistency in cardinality checks across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->