### PR TITLE
Raise timeout for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
     runs-on:
       group: "huge-runners"
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"


### PR DESCRIPTION
# Why

With all of the new integration tests and how they run in Docker the current timeout of 30 minutes seems to not be enough.

## What changed

Raise timeout of integration tests from 30 to 40 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline configuration for test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->