### PR TITLE
Merge 'stable' into 'develop'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
     runs-on:
       group: "huge-runners"
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"

--- a/changelog/894.fixed.md
+++ b/changelog/894.fixed.md
@@ -1,0 +1,1 @@
+Generate protocols so that optional attributes with a default value are rendered as required (not nullable).

--- a/infrahub_sdk/protocols_generator/generator.py
+++ b/infrahub_sdk/protocols_generator/generator.py
@@ -117,7 +117,7 @@ class CodeGenerator:
     def _jinja2_filter_render_attribute(value: AttributeSchemaAPI) -> str:
         attribute_kind: str = ATTRIBUTE_KIND_MAP[value.kind]
 
-        if value.optional:
+        if value.optional and value.default_value is None:
             attribute_kind += "Optional"
 
         return f"{value.name}: {attribute_kind}"

--- a/tests/unit/sdk/test_protocols_generator.py
+++ b/tests/unit/sdk/test_protocols_generator.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.protocols_generator.generator import CodeGenerator
+from infrahub_sdk.schema import AttributeSchemaAPI
 
 if TYPE_CHECKING:
     from pytest_httpx import HTTPXMock
@@ -34,6 +35,56 @@ SYNCIFY_TEST_CASES = [
         output=["LineageSource", "CoreObjectTemplate", "CoreNode"],
     ),
 ]
+
+
+@dataclass
+class RenderAttributeTestCase:
+    name: str
+    optional: bool
+    default_value: Any
+    expected: str
+
+
+RENDER_ATTRIBUTE_TEST_CASES = [
+    RenderAttributeTestCase(
+        name="required-no-default",
+        optional=False,
+        default_value=None,
+        expected="enabled: Boolean",
+    ),
+    RenderAttributeTestCase(
+        name="required-with-default",
+        optional=False,
+        default_value=True,
+        expected="enabled: Boolean",
+    ),
+    RenderAttributeTestCase(
+        name="optional-no-default",
+        optional=True,
+        default_value=None,
+        expected="enabled: BooleanOptional",
+    ),
+    RenderAttributeTestCase(
+        name="optional-with-default",
+        optional=True,
+        default_value=True,
+        expected="enabled: Boolean",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(tc, id=tc.name) for tc in RENDER_ATTRIBUTE_TEST_CASES],
+)
+async def test_filter_render_attribute(test_case: RenderAttributeTestCase) -> None:
+    attr = AttributeSchemaAPI(
+        name="enabled",
+        kind="Boolean",
+        optional=test_case.optional,
+        default_value=test_case.default_value,
+    )
+    assert CodeGenerator._jinja2_filter_render_attribute(attr) == test_case.expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

# Why

Bring in the changes from `stable` into `develop`.

## What changed

* All changes from 'stable'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected protocol generation to render optional attributes with default values as required types instead of nullable.

* **Tests**
  * Added comprehensive test coverage for attribute type rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->