### PR TITLE
Replace deprecated Pydantic call

### DIFF
--- a/docs/docs_generation/helpers.py
+++ b/docs/docs_generation/helpers.py
@@ -18,7 +18,7 @@ def get_env_vars() -> dict[str, list[str]]:
     settings = ConfigBase()
     env_settings = EnvSettingsSource(settings.__class__, env_prefix=settings.model_config.get("env_prefix", ""))
 
-    for field_name, field in settings.model_fields.items():
+    for field_name, field in ConfigBase.model_fields.items():
         for field_key, field_env_name, _ in env_settings._extract_field_info(field, field_name):
             env_vars[field_key].append(field_env_name.upper())
 


### PR DESCRIPTION
# Why

When you run "pytest test/unit" there's deprecation warnings regarding the use of the replaced method from Pydantic.

```python
tests/unit/doc_generation/test_helpers.py::TestBuildConfigProperties::test_address_property_exists
tests/unit/doc_generation/test_helpers.py::TestBuildConfigProperties::test_address_has_env_vars
  /Users/patrick/Code/opsmill/infrahub-sdk-python/docs/docs_generation/helpers.py:21: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    for field_name, field in settings.model_fields.items():
```

## What changed

* Replace method call with class method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment variable extraction by using class-level field definitions instead of instance-level fields. No functional changes to output or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->