### PR TITLE
Let the server validate in object CRUD commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Key rules:
 Deep-dive docs on architecture and workflows live in `dev/knowledge/`. Read these before making changes to the areas they cover.
 
 - [dev/knowledge/cli-architecture.md](dev/knowledge/cli-architecture.md) - CLI command hierarchy and design rules
+- [dev/knowledge/cli-design-principles.md](dev/knowledge/cli-design-principles.md) - Principles for writing CLI commands (no pre-validation, phrasing, etc.)
 - [dev/knowledge/doc-generation.md](dev/knowledge/doc-generation.md) - How docs are auto-generated from code
 
 ## Subdirectory guides

--- a/dev/knowledge/cli-design-principles.md
+++ b/dev/knowledge/cli-design-principles.md
@@ -1,0 +1,45 @@
+# CLI Design Principles
+
+Guidelines for writing `infrahubctl` commands. These complement the structural rules in `cli-architecture.md`.
+
+## Don't pre-validate what the server validates
+
+The CLI's job is to translate user intent into API calls, not to reimplement server-side logic. When in doubt, just fire the request and let the server respond.
+
+**Avoid**:
+
+- Extra round-trips to check whether an object already exists before creating it
+- Re-implementing uniqueness, permission, or referential-integrity checks client-side
+- Heuristics that guess at server behavior (e.g., deriving identifiers from partial data to simulate a lookup)
+
+**Why this matters**:
+
+- Pre-validation is stale by the time the real call is made (TOCTOU).
+- The server returns better errors than the CLI can construct.
+- Every client-side check is a duplication that will drift from the server implementation.
+- Extra calls slow the CLI down and make it feel laggy on high-latency links.
+
+**Exception**: local-only validation that doesn't need the server is fine — malformed `--set` arguments, mutually exclusive flags, missing required options, etc. The test is: "could the server figure this out from the request alone?" If yes, let the server do it.
+
+## Prefer HFID over `default_filter`
+
+When resolving identifiers, HFID (human-friendly ID) is the long-term path. `default_filter` is deprecated and will be removed. New code should not depend on it, and existing code should be written so its removal is a straightforward change.
+
+## Output phrasing should match semantics
+
+Messages like `Created`, `Updated`, `Deleted` are promises about what actually happened. When using upsert semantics (`allow_upsert=True`), the CLI genuinely doesn't know whether the object was created or updated — so use neutral phrasing like `Saved` or `Applied`. Don't lie to the user for the sake of a cleaner message.
+
+## Deduplicate redundant output
+
+When printing an object's label and ID, check that they're actually different before printing both. Many objects have `display_label == id`, in which case repeating the value adds noise:
+
+```python
+if node.display_label and node.display_label != node.id:
+    console.print(f"Saved {kind} '{node.display_label}' (ID: {node.id})")
+else:
+    console.print(f"Saved {kind} (ID: {node.id})")
+```
+
+## Raise errors directly, don't invoke dead calls
+
+If the CLI has determined a call will fail (e.g., no lookup strategy matched), raise the appropriate exception directly rather than making a request you know will error out just to piggyback on the server's error message. The request is wasted network traffic and the roundabout path is harder to read.

--- a/infrahub_sdk/ctl/object/create.py
+++ b/infrahub_sdk/ctl/object/create.py
@@ -6,18 +6,16 @@ arguments or from a JSON/YAML object file specified via ``--file``.
 
 from __future__ import annotations
 
-import contextlib
 from pathlib import Path
 
 import typer
 from rich.console import Console
 
 from infrahub_sdk.ctl.client import initialize_client
-from infrahub_sdk.ctl.object.utils import derive_identifier, prepare_relationship_data, resolve_node
+from infrahub_sdk.ctl.object.utils import prepare_relationship_data
 from infrahub_sdk.ctl.parameters import CONFIG_PARAM
 from infrahub_sdk.ctl.parsers import parse_set_args, validate_set_fields
 from infrahub_sdk.ctl.utils import catch_exception
-from infrahub_sdk.exceptions import NodeNotFoundError
 from infrahub_sdk.spec.object import ObjectFile
 
 console = Console()
@@ -65,25 +63,16 @@ async def create_command(
         for obj_file in files:
             await obj_file.process(client=client, branch=branch)
             object_count = len(obj_file.spec.data)
-            console.print(f"[green]Created {object_count} objects of kind {obj_file.spec.kind}")
+            console.print(f"[green]Saved {object_count} objects of kind {obj_file.spec.kind}")
     elif set_args:
         data = parse_set_args(set_args)
         schema = await client.schema.get(kind=kind, branch=branch)
         validate_set_fields(data, schema.attribute_names, schema.relationship_names)
         data = prepare_relationship_data(data, schema)
 
-        # Check if node already exists to distinguish create from upsert
-        existing = None
-        identifier_value = derive_identifier(data, schema)
-        if identifier_value is not None:
-            with contextlib.suppress(NodeNotFoundError):
-                existing = await resolve_node(client, kind, identifier_value, schema=schema, branch=branch)
-
         node = await client.create(kind=kind, data=data, branch=branch)
         await node.save(allow_upsert=True)
-        label = node.display_label or identifier_value or node.id
-
-        if existing:
-            console.print(f"[yellow]Updated {kind} '{label}' (id: {node.id}) — already existed")
+        if node.display_label:
+            console.print(f"[green]Saved {kind} '{node.display_label}' (ID: {node.id})")
         else:
-            console.print(f"[green]Created {kind} '{label}' (id: {node.id})")
+            console.print(f"[green]Saved {kind} (ID: {node.id})")

--- a/infrahub_sdk/ctl/object/delete.py
+++ b/infrahub_sdk/ctl/object/delete.py
@@ -41,7 +41,7 @@ async def delete_command(
         typer.confirm(f"Delete {kind} '{node.display_label}'?", abort=True)
 
     await node.delete()
-    if node.display_label and node.display_label != node.id:
-        console.print(f"[green]Deleted {kind} '{node.display_label}' (id: {node.id})")
+    if node.display_label:
+        console.print(f"[green]Deleted {kind} '{node.display_label}' (ID: {node.id})")
     else:
-        console.print(f"[green]Deleted {kind} (id: {node.id})")
+        console.print(f"[green]Deleted {kind} (ID: {node.id})")

--- a/infrahub_sdk/ctl/object/delete.py
+++ b/infrahub_sdk/ctl/object/delete.py
@@ -41,4 +41,7 @@ async def delete_command(
         typer.confirm(f"Delete {kind} '{node.display_label}'?", abort=True)
 
     await node.delete()
-    console.print(f"[green]Deleted {kind} '{node.display_label}' (id: {node.id})")
+    if node.display_label and node.display_label != node.id:
+        console.print(f"[green]Deleted {kind} '{node.display_label}' (id: {node.id})")
+    else:
+        console.print(f"[green]Deleted {kind} (id: {node.id})")

--- a/infrahub_sdk/ctl/object/utils.py
+++ b/infrahub_sdk/ctl/object/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from infrahub_sdk.exceptions import NodeNotFoundError
 from infrahub_sdk.schema import NodeSchemaAPI
 from infrahub_sdk.utils import is_valid_uuid
 
@@ -74,50 +75,10 @@ async def resolve_node(
         if node is not None:
             return node
 
-    # Nothing found — raise with a helpful error via the standard path
-    return await client.get(kind=kind, id=identifier, branch=branch)
+    raise NodeNotFoundError(node_type=kind, identifier={"id": [identifier]}, branch_name=branch)
 
 
-def derive_identifier(
-    data: dict[str, Any],
-    schema: MainSchemaTypesAPI,
-) -> str | None:
-    """Derive an identifier string from user data and schema for existence checks.
-
-    Tries HFID components first, then default_filter, then falls back to "name".
-
-    Args:
-        data: Parsed data from ``--set`` arguments.
-        schema: Schema for the kind being created/updated.
-
-    Returns:
-        An identifier string suitable for ``resolve_node``, or None.
-    """
-    if isinstance(schema, NodeSchemaAPI) and schema.human_friendly_id:
-        parts: list[str] = []
-        for component in schema.human_friendly_id:
-            field_name = component.split("__")[0]
-            value = data.get(field_name)
-            if value is None:
-                break
-            parts.append(str(value))
-        if parts and len(parts) == len(schema.human_friendly_id):
-            return "/".join(parts)
-
-    if isinstance(schema, NodeSchemaAPI) and schema.default_filter:
-        field_name = schema.default_filter.replace("__value", "")
-        value = data.get(field_name)
-        if value is not None:
-            return str(value)
-
-    name = data.get("name")
-    return str(name) if name is not None else None
-
-
-def prepare_relationship_data(
-    data: dict[str, Any],
-    schema: MainSchemaTypesAPI,
-) -> dict[str, Any]:
+def prepare_relationship_data(data: dict[str, Any], schema: MainSchemaTypesAPI) -> dict[str, Any]:
     """Convert relationship values in a data dict to SDK-compatible format.
 
     Instead of resolving relationship values to UUIDs via round-trips,

--- a/tests/integration/test_enduser_cli.py
+++ b/tests/integration/test_enduser_cli.py
@@ -195,7 +195,7 @@ class TestEnduserCliWrite(_EnduserCliBase):
             ["object", "create", "TestingPerson", "--set", "name=Integration Test Person", "--set", "height=190"],
         )
         assert result.exit_code == 0, f"create failed: {result.output}"
-        assert "Created" in result.stdout
+        assert "Saved" in result.stdout
 
     async def test_create_inline_verify(self, base_dataset: None, client: InfrahubClient) -> None:
         """Verify the object created by test_create_inline exists."""

--- a/tests/unit/ctl/object/test_create.py
+++ b/tests/unit/ctl/object/test_create.py
@@ -8,7 +8,6 @@ import pytest
 from typer.testing import CliRunner
 
 from infrahub_sdk.ctl.cli_commands import app
-from infrahub_sdk.exceptions import NodeNotFoundError
 
 runner = CliRunner()
 
@@ -48,18 +47,11 @@ def test_create_with_set_args() -> None:
     mock_client.schema.get = AsyncMock(return_value=mock_schema)
     mock_client.create = AsyncMock(return_value=mock_node)
 
-    with (
-        patch("infrahub_sdk.ctl.object.create.initialize_client", return_value=mock_client),
-        patch(
-            "infrahub_sdk.ctl.object.create.resolve_node",
-            new_callable=AsyncMock,
-            side_effect=NodeNotFoundError(identifier={"name": ["router1"]}),
-        ),
-    ):
+    with patch("infrahub_sdk.ctl.object.create.initialize_client", return_value=mock_client):
         result = runner.invoke(app, ["object", "create", "InfraDevice", "--set", "name=router1"])
 
     assert result.exit_code == 0, result.stdout
-    assert "Created" in result.stdout
+    assert "Saved" in result.stdout
     mock_client.schema.get.assert_awaited_once_with(kind="InfraDevice", branch=None)
     mock_client.create.assert_awaited_once_with(kind="InfraDevice", data={"name": "router1"}, branch=None)
     mock_node.save.assert_awaited_once_with(allow_upsert=True)
@@ -81,14 +73,7 @@ def test_create_with_set_args_and_branch() -> None:
     mock_client.schema.get = AsyncMock(return_value=mock_schema)
     mock_client.create = AsyncMock(return_value=mock_node)
 
-    with (
-        patch("infrahub_sdk.ctl.object.create.initialize_client", return_value=mock_client),
-        patch(
-            "infrahub_sdk.ctl.object.create.resolve_node",
-            new_callable=AsyncMock,
-            side_effect=NodeNotFoundError(identifier={"name": ["router2"]}),
-        ),
-    ):
+    with patch("infrahub_sdk.ctl.object.create.initialize_client", return_value=mock_client):
         result = runner.invoke(
             app,
             ["object", "create", "InfraDevice", "--set", "name=router2", "--branch", "dev"],
@@ -119,7 +104,7 @@ def test_create_with_file() -> None:
         result = runner.invoke(app, ["object", "create", "InfraDevice", "--file", "devices.yml"])
 
     assert result.exit_code == 0, result.stdout
-    assert "Created" in result.stdout
+    assert "Saved" in result.stdout
     assert "2" in result.stdout
     assert "InfraDevice" in result.stdout
     mock_file.validate_format.assert_awaited_once_with(client=mock_client, branch=None)
@@ -213,14 +198,7 @@ def test_create_multiple_set_args() -> None:
     mock_client.schema.get = AsyncMock(return_value=mock_schema)
     mock_client.create = AsyncMock(return_value=mock_node)
 
-    with (
-        patch("infrahub_sdk.ctl.object.create.initialize_client", return_value=mock_client),
-        patch(
-            "infrahub_sdk.ctl.object.create.resolve_node",
-            new_callable=AsyncMock,
-            side_effect=NodeNotFoundError(identifier={"name": ["router3"]}),
-        ),
-    ):
+    with patch("infrahub_sdk.ctl.object.create.initialize_client", return_value=mock_client):
         result = runner.invoke(
             app,
             ["object", "create", "InfraDevice", "--set", "name=router3", "--set", "description=core router"],

--- a/tests/unit/ctl/object/test_utils.py
+++ b/tests/unit/ctl/object/test_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from infrahub_sdk.ctl.object.utils import derive_identifier, prepare_relationship_data, resolve_node
+from infrahub_sdk.ctl.object.utils import prepare_relationship_data, resolve_node
 from infrahub_sdk.exceptions import NodeNotFoundError
 from infrahub_sdk.schema import NodeSchemaAPI
 
@@ -109,16 +109,12 @@ async def test_resolve_by_hfid_multi_component(mock_client: MagicMock) -> None:
 
 
 async def test_resolve_fallback_raises(mock_client: MagicMock) -> None:
-    """When no lookup strategy matches, the fallback ``client.get(id=...)`` call raises."""
+    """When no lookup strategy matches, NodeNotFoundError is raised directly."""
 
     mock_schema = MagicMock(spec=NodeSchemaAPI)
     mock_schema.default_filter = None
     mock_schema.human_friendly_id = None
     mock_client.schema.get = AsyncMock(return_value=mock_schema)
-
-    mock_client.get = AsyncMock(
-        side_effect=NodeNotFoundError(identifier={"id": ["unknown-name"]}, node_type="InfraDevice")
-    )
 
     with (
         patch("infrahub_sdk.ctl.object.utils.is_valid_uuid", return_value=False),
@@ -126,7 +122,7 @@ async def test_resolve_fallback_raises(mock_client: MagicMock) -> None:
     ):
         await resolve_node(mock_client, "InfraDevice", "unknown-name")
 
-    mock_client.get.assert_awaited_once_with(kind="InfraDevice", id="unknown-name", branch=None)
+    mock_client.get.assert_not_awaited()
 
 
 async def test_resolve_uses_provided_schema(mock_client: MagicMock) -> None:
@@ -233,47 +229,3 @@ def test_prepare_relationship_data_mixed() -> None:
     with patch("infrahub_sdk.ctl.object.utils.is_valid_uuid", return_value=False):
         result = prepare_relationship_data(data, schema)
     assert result == {"name": "router1", "site": ["DC1"], "tags": [["blue"]]}
-
-
-# --- Tests for derive_identifier ---
-
-
-def test_derive_identifier_from_hfid() -> None:
-    """HFID components are assembled from data fields and joined with /."""
-    schema = MagicMock(spec=NodeSchemaAPI)
-    schema.human_friendly_id = ["site__name__value", "name__value"]
-    schema.default_filter = None
-    data = {"site": "DC1", "name": "router1"}
-    assert derive_identifier(data, schema) == "DC1/router1"
-
-
-def test_derive_identifier_from_hfid_partial() -> None:
-    """Partial HFID (missing component) falls through to default_filter."""
-    schema = MagicMock(spec=NodeSchemaAPI)
-    schema.human_friendly_id = ["site__name__value", "name__value"]
-    schema.default_filter = "name__value"
-    data = {"name": "router1"}
-    assert derive_identifier(data, schema) == "router1"
-
-
-def test_derive_identifier_from_default_filter() -> None:
-    """default_filter field is used when HFID is not defined."""
-    schema = MagicMock(spec=NodeSchemaAPI)
-    schema.human_friendly_id = None
-    schema.default_filter = "prefix__value"
-    data = {"prefix": "10.0.0.0/8"}
-    assert derive_identifier(data, schema) == "10.0.0.0/8"
-
-
-def test_derive_identifier_fallback_to_name() -> None:
-    """Falls back to 'name' field when no schema hints are available."""
-    schema = MagicMock()
-    data = {"name": "router1", "description": "core"}
-    assert derive_identifier(data, schema) == "router1"
-
-
-def test_derive_identifier_returns_none() -> None:
-    """Returns None when no identifier can be derived."""
-    schema = MagicMock()
-    data = {"description": "core"}
-    assert derive_identifier(data, schema) is None


### PR DESCRIPTION
## Why & What

The `object create/delete` commands were doing more work than they needed to. Most of that work was either unreliable or not necessary. This cleans it up and records the underlying principle so we don't reintroduce the same patterns.

`create` used to do a pre-flight `resolve_node` round-trip to figure out whether the object already existed, just so it could print `Created` vs `Updated` after the upsert. It wasted a network call but also wrongly fell back to a hardcoded `"name"` field and leaned on `default_filter`, which is on its way out.

`resolve_node` had a "fallback" path at the end that called `client.get(id=<not-a-uuid>)` purely to piggyback on the SDK's error message. That's now a direct `raise`.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added
- [ ] External docs updated
- [x] Internal .md docs updated (new `cli-design-principles.md`)
