### PR TITLE
Raise a new file not found error when loading queries

### DIFF
--- a/infrahub_sdk/exceptions.py
+++ b/infrahub_sdk/exceptions.py
@@ -163,6 +163,13 @@ class InvalidResponseError(Error):
     """Raised when an object requires an initialization step before use"""
 
 
+class RepositoryFileNotFoundError(Error):
+    def __init__(self, file_path: str, message: str | None = None) -> None:
+        self.file_path = file_path
+        self.message = message or f"File '{file_path}' does not exist."
+        super().__init__(self.message)
+
+
 class FileNotValidError(Error):
     def __init__(self, name: str, message: str = "") -> None:
         self.message = message or f"Cannot parse '{name}' content."

--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -10,6 +10,7 @@ from ..checks import InfrahubCheck
 from ..exceptions import (
     FragmentFileNotFoundError,
     ModuleImportError,
+    RepositoryFileNotFoundError,
     ResourceNotDefinedError,
 )
 from ..generator import InfrahubGenerator
@@ -157,7 +158,10 @@ class InfrahubRepositoryGraphQLConfig(InfrahubRepositoryConfigElement):
 
     def load_query(self, relative_path: str = ".") -> str:
         file_name = Path(f"{relative_path}/{self.file_path}")
-        return file_name.read_text(encoding="UTF-8")
+        try:
+            return file_name.read_text(encoding="UTF-8")
+        except FileNotFoundError as exc:
+            raise RepositoryFileNotFoundError(file_path=str(self.file_path)) from exc
 
 
 class InfrahubRepositoryFragmentConfig(InfrahubRepositoryConfigElement):

--- a/tests/unit/sdk/test_schema_repository.py
+++ b/tests/unit/sdk/test_schema_repository.py
@@ -3,8 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from infrahub_sdk.exceptions import FragmentFileNotFoundError, ResourceNotDefinedError
-from infrahub_sdk.schema.repository import InfrahubRepositoryConfig, InfrahubRepositoryFragmentConfig
+from infrahub_sdk.exceptions import FragmentFileNotFoundError, RepositoryFileNotFoundError, ResourceNotDefinedError
+from infrahub_sdk.schema.repository import (
+    InfrahubRepositoryConfig,
+    InfrahubRepositoryFragmentConfig,
+    InfrahubRepositoryGraphQLConfig,
+)
 
 
 @pytest.fixture
@@ -315,4 +319,20 @@ def test_load_fragments_missing_file_raises() -> None:
     cfg = InfrahubRepositoryFragmentConfig(name="ifaces", file_path=Path("does_not_exist.gql"))
     with tempfile.TemporaryDirectory() as tmp, pytest.raises(FragmentFileNotFoundError) as exc_info:
         cfg.load_fragments(relative_path=tmp)
+    assert "does_not_exist.gql" in exc_info.value.file_path
+
+
+def test_load_query_returns_content() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        query_file = Path(tmp) / "my_query.gql"
+        query_file.write_text("{ devices { id } }", encoding="UTF-8")
+        cfg = InfrahubRepositoryGraphQLConfig(name="my_query", file_path=Path("my_query.gql"))
+        result = cfg.load_query(relative_path=tmp)
+    assert result == "{ devices { id } }"
+
+
+def test_load_query_missing_file_raises() -> None:
+    cfg = InfrahubRepositoryGraphQLConfig(name="my_query", file_path=Path("does_not_exist.gql"))
+    with tempfile.TemporaryDirectory() as tmp, pytest.raises(RepositoryFileNotFoundError) as exc_info:
+        cfg.load_query(relative_path=tmp)
     assert "does_not_exist.gql" in exc_info.value.file_path


### PR DESCRIPTION
# Why

If a user has an `.infrahub.yml` file with a query section and the file for one of those queries are missing the error message isn't very helpful. Here we instead catch the file not found error and raise a custom SDK error that the backend will catch.

## What changed

* Add try/except around the loading of a query
* Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling for missing repository query files with a dedicated exception that includes the missing file path.

* **Tests**
  * Added test coverage for loading GraphQL query files and verifying proper error reporting when files are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->