### PR TITLE
IHS-219: Add query_name parameter to all(), filters(), and get() for observability

### DIFF
--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -158,7 +158,7 @@ Retrieve all nodes of a given kind
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else All_{str(kind)} is used.
+- `query_name`: If provided is used a the GraphQL operation name else All_&lt;kind&gt; is used.
 
 **Returns:**
 
@@ -205,7 +205,7 @@ Retrieve nodes of a given kind based on provided filters.
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
+- `query_name`: If provided is used a the GraphQL operation name else Filters_&lt;kind&gt; is used.
 - `**kwargs`: Additional filter criteria for the query.
 
 **Returns:**
@@ -574,7 +574,7 @@ Retrieve all nodes of a given kind
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else All_{str(kind)} is used.
+- `query_name`: If provided is used a the GraphQL operation name else All_&lt;kind&gt; is used.
 
 **Returns:**
 
@@ -621,7 +621,7 @@ Retrieve nodes of a given kind based on provided filters.
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
+- `query_name`: If provided is used a the GraphQL operation name else Filters_&lt;kind&gt; is used.
 - `**kwargs`: Additional filter criteria for the query.
 
 **Returns:**

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -16,7 +16,7 @@ GraphQL Client to interact with Infrahub.
 #### `get`
 
 ```python
-get(self, kind: type[SchemaType], raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaType | None
+get(self, kind: type[SchemaType], raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> SchemaType | None
 ```
 
 <details>
@@ -25,37 +25,37 @@ get(self, kind: type[SchemaType], raise_when_missing: Literal[False], at: Timest
 #### `get`
 
 ```python
-get(self, kind: type[SchemaType], raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaType
+get(self, kind: type[SchemaType], raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> SchemaType
 ```
 
 #### `get`
 
 ```python
-get(self, kind: type[SchemaType], raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaType
+get(self, kind: type[SchemaType], raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> SchemaType
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str, raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> InfrahubNode | None
+get(self, kind: str, raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> InfrahubNode | None
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str, raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> InfrahubNode
+get(self, kind: str, raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> InfrahubNode
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str, raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> InfrahubNode
+get(self, kind: str, raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> InfrahubNode
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str | type[SchemaType], raise_when_missing: bool = True, at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, id: str | None = None, hfid: list[str] | None = None, include: list[str] | None = None, exclude: list[str] | None = None, populate_store: bool = True, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, include_metadata: bool = False, **kwargs: Any) -> InfrahubNode | SchemaType | None
+get(self, kind: str | type[SchemaType], raise_when_missing: bool = True, at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, id: str | None = None, hfid: list[str] | None = None, include: list[str] | None = None, exclude: list[str] | None = None, populate_store: bool = True, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, include_metadata: bool = False, query_name: str | None = None, **kwargs: Any) -> InfrahubNode | SchemaType | None
 ```
 
 </details>
@@ -114,7 +114,7 @@ Return user permissions
 #### `count`
 
 ```python
-count(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, partial_match: bool = False, **kwargs: Any) -> int
+count(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, partial_match: bool = False, query_name: str | None = None, **kwargs: Any) -> int
 ```
 
 Return the number of nodes of a given kind.
@@ -122,7 +122,7 @@ Return the number of nodes of a given kind.
 #### `all`
 
 ```python
-all(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ...) -> list[SchemaType]
+all(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ...) -> list[SchemaType]
 ```
 
 <details>
@@ -131,13 +131,13 @@ all(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None
 #### `all`
 
 ```python
-all(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ...) -> list[InfrahubNode]
+all(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ...) -> list[InfrahubNode]
 ```
 
 #### `all`
 
 ```python
-all(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False) -> list[InfrahubNode] | list[SchemaType]
+all(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, query_name: str | None = None) -> list[InfrahubNode] | list[SchemaType]
 ```
 
 Retrieve all nodes of a given kind
@@ -167,7 +167,7 @@ Retrieve all nodes of a given kind
 #### `filters`
 
 ```python
-filters(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., **kwargs: Any) -> list[SchemaType]
+filters(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> list[SchemaType]
 ```
 
 <details>
@@ -176,13 +176,13 @@ filters(self, kind: type[SchemaType], at: Timestamp | None = ..., branch: str | 
 #### `filters`
 
 ```python
-filters(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., **kwargs: Any) -> list[InfrahubNode]
+filters(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> list[InfrahubNode]
 ```
 
 #### `filters`
 
 ```python
-filters(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, partial_match: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, **kwargs: Any) -> list[InfrahubNode] | list[SchemaType]
+filters(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, partial_match: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, query_name: str | None = None, **kwargs: Any) -> list[InfrahubNode] | list[SchemaType]
 ```
 
 Retrieve nodes of a given kind based on provided filters.
@@ -397,7 +397,7 @@ for more information.
 #### `get`
 
 ```python
-get(self, kind: type[SchemaTypeSync], raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaTypeSync | None
+get(self, kind: type[SchemaTypeSync], raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> SchemaTypeSync | None
 ```
 
 <details>
@@ -406,37 +406,37 @@ get(self, kind: type[SchemaTypeSync], raise_when_missing: Literal[False], at: Ti
 #### `get`
 
 ```python
-get(self, kind: type[SchemaTypeSync], raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaTypeSync
+get(self, kind: type[SchemaTypeSync], raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> SchemaTypeSync
 ```
 
 #### `get`
 
 ```python
-get(self, kind: type[SchemaTypeSync], raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> SchemaTypeSync
+get(self, kind: type[SchemaTypeSync], raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> SchemaTypeSync
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str, raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> InfrahubNodeSync | None
+get(self, kind: str, raise_when_missing: Literal[False], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> InfrahubNodeSync | None
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str, raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> InfrahubNodeSync
+get(self, kind: str, raise_when_missing: Literal[True], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> InfrahubNodeSync
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str, raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., **kwargs: Any) -> InfrahubNodeSync
+get(self, kind: str, raise_when_missing: bool = ..., at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., id: str | None = ..., hfid: list[str] | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., populate_store: bool = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> InfrahubNodeSync
 ```
 
 #### `get`
 
 ```python
-get(self, kind: str | type[SchemaTypeSync], raise_when_missing: bool = True, at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, id: str | None = None, hfid: list[str] | None = None, include: list[str] | None = None, exclude: list[str] | None = None, populate_store: bool = True, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, include_metadata: bool = False, **kwargs: Any) -> InfrahubNodeSync | SchemaTypeSync | None
+get(self, kind: str | type[SchemaTypeSync], raise_when_missing: bool = True, at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, id: str | None = None, hfid: list[str] | None = None, include: list[str] | None = None, exclude: list[str] | None = None, populate_store: bool = True, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, include_metadata: bool = False, query_name: str | None = None, **kwargs: Any) -> InfrahubNodeSync | SchemaTypeSync | None
 ```
 
 </details>
@@ -528,7 +528,7 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 #### `count`
 
 ```python
-count(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, partial_match: bool = False, **kwargs: Any) -> int
+count(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, partial_match: bool = False, query_name: str | None = None, **kwargs: Any) -> int
 ```
 
 Return the number of nodes of a given kind.
@@ -536,7 +536,7 @@ Return the number of nodes of a given kind.
 #### `all`
 
 ```python
-all(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ...) -> list[SchemaTypeSync]
+all(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ...) -> list[SchemaTypeSync]
 ```
 
 <details>
@@ -545,13 +545,13 @@ all(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | 
 #### `all`
 
 ```python
-all(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ...) -> list[InfrahubNodeSync]
+all(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ...) -> list[InfrahubNodeSync]
 ```
 
 #### `all`
 
 ```python
-all(self, kind: str | type[SchemaTypeSync], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False) -> list[InfrahubNodeSync] | list[SchemaTypeSync]
+all(self, kind: str | type[SchemaTypeSync], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, query_name: str | None = None) -> list[InfrahubNodeSync] | list[SchemaTypeSync]
 ```
 
 Retrieve all nodes of a given kind
@@ -581,7 +581,7 @@ Retrieve all nodes of a given kind
 #### `filters`
 
 ```python
-filters(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., **kwargs: Any) -> list[SchemaTypeSync]
+filters(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> list[SchemaTypeSync]
 ```
 
 <details>
@@ -590,13 +590,13 @@ filters(self, kind: type[SchemaTypeSync], at: Timestamp | None = ..., branch: st
 #### `filters`
 
 ```python
-filters(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., **kwargs: Any) -> list[InfrahubNodeSync]
+filters(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeout: int | None = ..., populate_store: bool = ..., offset: int | None = ..., limit: int | None = ..., include: list[str] | None = ..., exclude: list[str] | None = ..., fragment: bool = ..., prefetch_relationships: bool = ..., partial_match: bool = ..., property: bool = ..., parallel: bool = ..., order: Order | None = ..., include_metadata: bool = ..., query_name: str | None = ..., **kwargs: Any) -> list[InfrahubNodeSync]
 ```
 
 #### `filters`
 
 ```python
-filters(self, kind: str | type[SchemaTypeSync], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, partial_match: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, **kwargs: Any) -> list[InfrahubNodeSync] | list[SchemaTypeSync]
+filters(self, kind: str | type[SchemaTypeSync], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, partial_match: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, query_name: str | None = None, **kwargs: Any) -> list[InfrahubNodeSync] | list[SchemaTypeSync]
 ```
 
 Retrieve nodes of a given kind based on provided filters.

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -158,6 +158,7 @@ Retrieve all nodes of a given kind
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
+- `query_name`: If provided is used a the GraphQL operation name else All_{str(kind)} is used.
 
 **Returns:**
 
@@ -204,6 +205,7 @@ Retrieve nodes of a given kind based on provided filters.
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
+- `query_name`: If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
 - `**kwargs`: Additional filter criteria for the query.
 
 **Returns:**
@@ -572,6 +574,7 @@ Retrieve all nodes of a given kind
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
+- `query_name`: If provided is used a the GraphQL operation name else All_{str(kind)} is used.
 
 **Returns:**
 
@@ -618,6 +621,7 @@ Retrieve nodes of a given kind based on provided filters.
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
+- `query_name`: If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
 - `**kwargs`: Additional filter criteria for the query.
 
 **Returns:**
@@ -826,4 +830,10 @@ handle_relogin(func: Callable[..., Coroutine[Any, Any, httpx.Response]]) -> Call
 
 ```python
 handle_relogin_sync(func: Callable[..., httpx.Response]) -> Callable[..., httpx.Response]
+```
+
+### `get_kind_as_string`
+
+```python
+get_kind_as_string(kind: str | type[SchemaType | SchemaTypeSync]) -> str
 ```

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -158,7 +158,7 @@ Retrieve all nodes of a given kind
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else All_&lt;kind&gt; is used.
+- `query_name`: If provided is used as the GraphQL operation name else All_&lt;kind&gt; is used.
 
 **Returns:**
 
@@ -205,7 +205,7 @@ Retrieve nodes of a given kind based on provided filters.
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else Filters_&lt;kind&gt; is used.
+- `query_name`: If provided is used as the GraphQL operation name else Filters_&lt;kind&gt; is used.
 - `**kwargs`: Additional filter criteria for the query.
 
 **Returns:**
@@ -574,7 +574,7 @@ Retrieve all nodes of a given kind
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else All_&lt;kind&gt; is used.
+- `query_name`: If provided is used as the GraphQL operation name else All_&lt;kind&gt; is used.
 
 **Returns:**
 
@@ -621,7 +621,7 @@ Retrieve nodes of a given kind based on provided filters.
 - `parallel`: Whether to use parallel processing for the query.
 - `order`: Ordering related options. Setting `disable=True` enhances performances.
 - `include_metadata`: If True, includes node_metadata and relationship_metadata in the query.
-- `query_name`: If provided is used a the GraphQL operation name else Filters_&lt;kind&gt; is used.
+- `query_name`: If provided is used as the GraphQL operation name else Filters_&lt;kind&gt; is used.
 - `**kwargs`: Additional filter criteria for the query.
 
 **Returns:**

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -378,6 +378,7 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> SchemaType | None: ...
 
@@ -398,6 +399,7 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> SchemaType: ...
 
@@ -418,6 +420,7 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> SchemaType: ...
 
@@ -438,6 +441,7 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> InfrahubNode | None: ...
 
@@ -458,6 +462,7 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> InfrahubNode: ...
 
@@ -478,6 +483,7 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> InfrahubNode: ...
 
@@ -497,10 +503,13 @@ class InfrahubClient(BaseClient):
         prefetch_relationships: bool = False,
         property: bool = False,
         include_metadata: bool = False,
+        query_name: str | None = None,
         **kwargs: Any,
     ) -> InfrahubNode | SchemaType | None:
         branch = branch or self.default_branch
         schema = await self.schema.get(kind=kind, branch=branch)
+        if query_name is None:
+            query_name = f"Get_{schema.kind}"
 
         filters: MutableMapping[str, Any] = {}
 
@@ -531,6 +540,7 @@ class InfrahubClient(BaseClient):
             prefetch_relationships=prefetch_relationships,
             property=property,
             include_metadata=include_metadata,
+            query_name=query_name,
             **filters,
         )
 
@@ -591,6 +601,7 @@ class InfrahubClient(BaseClient):
         branch: str | None = None,
         timeout: int | None = None,
         partial_match: bool = False,
+        query_name: str | None = None,
         **kwargs: Any,
     ) -> int:
         """Return the number of nodes of a given kind."""
@@ -601,6 +612,8 @@ class InfrahubClient(BaseClient):
 
         schema = await self.schema.get(kind=kind, branch=branch)
         branch = branch or self.default_branch
+        if query_name is None:
+            query_name = f"Count_{schema.kind}"
         if at:
             at = Timestamp(at)
 
@@ -610,7 +623,7 @@ class InfrahubClient(BaseClient):
         }
 
         response = await self.execute_graphql(
-            query=Query(query={schema.kind: data}).render(),
+            query=Query(query={schema.kind: data}, name=query_name).render(),
             branch_name=branch,
             at=at,
             timeout=timeout,
@@ -635,6 +648,7 @@ class InfrahubClient(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
     ) -> list[SchemaType]: ...
 
     @overload
@@ -655,6 +669,7 @@ class InfrahubClient(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
     ) -> list[InfrahubNode]: ...
 
     async def all(
@@ -674,6 +689,7 @@ class InfrahubClient(BaseClient):
         parallel: bool = False,
         order: Order | None = None,
         include_metadata: bool = False,
+        query_name: str | None = None,
     ) -> list[InfrahubNode] | list[SchemaType]:
         """Retrieve all nodes of a given kind
 
@@ -696,6 +712,9 @@ class InfrahubClient(BaseClient):
         Returns:
             list[InfrahubNode]: List of Nodes
         """
+        if query_name is None:
+            kind_str = kind if isinstance(kind, str) else kind.__name__
+            query_name = f"All_{kind_str}"
         return await self.filters(
             kind=kind,
             at=at,
@@ -712,6 +731,7 @@ class InfrahubClient(BaseClient):
             parallel=parallel,
             order=order,
             include_metadata=include_metadata,
+            query_name=query_name,
         )
 
     @overload
@@ -733,6 +753,7 @@ class InfrahubClient(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> list[SchemaType]: ...
 
@@ -755,10 +776,11 @@ class InfrahubClient(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> list[InfrahubNode]: ...
 
-    async def filters(
+    async def filters(  # noqa: C901
         self,
         kind: str | type[SchemaType],
         at: Timestamp | None = None,
@@ -776,6 +798,7 @@ class InfrahubClient(BaseClient):
         parallel: bool = False,
         order: Order | None = None,
         include_metadata: bool = False,
+        query_name: str | None = None,
         **kwargs: Any,
     ) -> list[InfrahubNode] | list[SchemaType]:
         """Retrieve nodes of a given kind based on provided filters.
@@ -803,6 +826,8 @@ class InfrahubClient(BaseClient):
         """
         branch = branch or self.default_branch
         schema = await self.schema.get(kind=kind, branch=branch)
+        if query_name is None:
+            query_name = f"Filters_{schema.kind}"
         if at:
             at = Timestamp(at)
 
@@ -824,7 +849,7 @@ class InfrahubClient(BaseClient):
                 order=order,
                 include_metadata=include_metadata,
             )
-            query = Query(query=query_data)
+            query = Query(query=query_data, name=query_name)
             response = await self.execute_graphql(
                 query=query.render(),
                 branch_name=branch,
@@ -2010,6 +2035,7 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = None,
         timeout: int | None = None,
         partial_match: bool = False,
+        query_name: str | None = None,
         **kwargs: Any,
     ) -> int:
         """Return the number of nodes of a given kind."""
@@ -2020,6 +2046,8 @@ class InfrahubClientSync(BaseClient):
 
         schema = self.schema.get(kind=kind, branch=branch)
         branch = branch or self.default_branch
+        if query_name is None:
+            query_name = f"Count_{schema.kind}"
         if at:
             at = Timestamp(at)
 
@@ -2029,7 +2057,7 @@ class InfrahubClientSync(BaseClient):
         }
 
         response = self.execute_graphql(
-            query=Query(query={schema.kind: data}).render(),
+            query=Query(query={schema.kind: data}, name=query_name).render(),
             branch_name=branch,
             at=at,
             timeout=timeout,
@@ -2054,6 +2082,7 @@ class InfrahubClientSync(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
     ) -> list[SchemaTypeSync]: ...
 
     @overload
@@ -2074,6 +2103,7 @@ class InfrahubClientSync(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
     ) -> list[InfrahubNodeSync]: ...
 
     def all(
@@ -2093,6 +2123,7 @@ class InfrahubClientSync(BaseClient):
         parallel: bool = False,
         order: Order | None = None,
         include_metadata: bool = False,
+        query_name: str | None = None,
     ) -> list[InfrahubNodeSync] | list[SchemaTypeSync]:
         """Retrieve all nodes of a given kind
 
@@ -2115,6 +2146,9 @@ class InfrahubClientSync(BaseClient):
         Returns:
             list[InfrahubNodeSync]: List of Nodes
         """
+        if query_name is None:
+            kind_str = kind if isinstance(kind, str) else kind.__name__
+            query_name = f"All_{kind_str}"
         return self.filters(
             kind=kind,
             at=at,
@@ -2131,6 +2165,7 @@ class InfrahubClientSync(BaseClient):
             parallel=parallel,
             order=order,
             include_metadata=include_metadata,
+            query_name=query_name,
         )
 
     def _process_nodes_and_relationships(
@@ -2193,6 +2228,7 @@ class InfrahubClientSync(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> list[SchemaTypeSync]: ...
 
@@ -2215,10 +2251,11 @@ class InfrahubClientSync(BaseClient):
         parallel: bool = ...,
         order: Order | None = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> list[InfrahubNodeSync]: ...
 
-    def filters(
+    def filters(  # noqa: C901
         self,
         kind: str | type[SchemaTypeSync],
         at: Timestamp | None = None,
@@ -2236,6 +2273,7 @@ class InfrahubClientSync(BaseClient):
         parallel: bool = False,
         order: Order | None = None,
         include_metadata: bool = False,
+        query_name: str | None = None,
         **kwargs: Any,
     ) -> list[InfrahubNodeSync] | list[SchemaTypeSync]:
         """Retrieve nodes of a given kind based on provided filters.
@@ -2263,6 +2301,8 @@ class InfrahubClientSync(BaseClient):
         """
         branch = branch or self.default_branch
         schema = self.schema.get(kind=kind, branch=branch)
+        if query_name is None:
+            query_name = f"Filters_{schema.kind}"
         if at:
             at = Timestamp(at)
 
@@ -2284,7 +2324,7 @@ class InfrahubClientSync(BaseClient):
                 order=order,
                 include_metadata=include_metadata,
             )
-            query = Query(query=query_data)
+            query = Query(query=query_data, name=query_name)
             response = self.execute_graphql(
                 query=query.render(),
                 branch_name=branch,
@@ -2373,6 +2413,7 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> SchemaTypeSync | None: ...
 
@@ -2393,6 +2434,7 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> SchemaTypeSync: ...
 
@@ -2413,6 +2455,7 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> SchemaTypeSync: ...
 
@@ -2433,6 +2476,7 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> InfrahubNodeSync | None: ...
 
@@ -2453,6 +2497,7 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> InfrahubNodeSync: ...
 
@@ -2473,6 +2518,7 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = ...,
         property: bool = ...,
         include_metadata: bool = ...,
+        query_name: str | None = ...,
         **kwargs: Any,
     ) -> InfrahubNodeSync: ...
 
@@ -2492,10 +2538,13 @@ class InfrahubClientSync(BaseClient):
         prefetch_relationships: bool = False,
         property: bool = False,
         include_metadata: bool = False,
+        query_name: str | None = None,
         **kwargs: Any,
     ) -> InfrahubNodeSync | SchemaTypeSync | None:
         branch = branch or self.default_branch
         schema = self.schema.get(kind=kind, branch=branch)
+        if query_name is None:
+            query_name = f"Get_{schema.kind}"
 
         filters: MutableMapping[str, Any] = {}
 
@@ -2526,6 +2575,7 @@ class InfrahubClientSync(BaseClient):
             prefetch_relationships=prefetch_relationships,
             property=property,
             include_metadata=include_metadata,
+            query_name=query_name,
             **filters,
         )
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -717,7 +717,7 @@ class InfrahubClient(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else All_{str(kind)} is used.
+            query_name (str, optional): If provided is used a the GraphQL operation name else All_<kind> is used.
 
         Returns:
             list[InfrahubNode]: List of Nodes
@@ -828,7 +828,7 @@ class InfrahubClient(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
+            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_<kind> is used.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:
@@ -2152,7 +2152,7 @@ class InfrahubClientSync(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else All_{str(kind)} is used.
+            query_name (str, optional): If provided is used a the GraphQL operation name else All_<kind> is used.
 
         Returns:
             list[InfrahubNodeSync]: List of Nodes
@@ -2304,7 +2304,7 @@ class InfrahubClientSync(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
+            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_<kind> is used.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -717,6 +717,7 @@ class InfrahubClient(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
+            query_name (str, optional): If provided is used a the GraphQL operation name else All_{str(kind)} is used.
 
         Returns:
             list[InfrahubNode]: List of Nodes
@@ -827,6 +828,7 @@ class InfrahubClient(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
+            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:
@@ -2150,6 +2152,7 @@ class InfrahubClientSync(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
+            query_name (str, optional): If provided is used a the GraphQL operation name else All_{str(kind)} is used.
 
         Returns:
             list[InfrahubNodeSync]: List of Nodes
@@ -2301,6 +2304,7 @@ class InfrahubClientSync(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
+            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_{str(kind)} is used.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import AsyncIterator, Callable, Coroutine, Iterator, Mapping, MutableMapping
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
+from enum import Enum
 from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TypedDict, TypeVar, overload
@@ -106,6 +107,14 @@ def handle_relogin_sync(func: Callable[..., httpx.Response]) -> Callable[..., ht
         return response
 
     return wrapper
+
+
+def get_kind_as_string(kind: str | type[SchemaType | SchemaTypeSync]) -> str:
+    if isinstance(kind, Enum):
+        return str(kind.value)
+    if isinstance(kind, str):
+        return kind
+    return kind.__name__
 
 
 class BaseClient:
@@ -713,8 +722,7 @@ class InfrahubClient(BaseClient):
             list[InfrahubNode]: List of Nodes
         """
         if query_name is None:
-            kind_str = kind if isinstance(kind, str) else kind.__name__
-            query_name = f"All_{kind_str}"
+            query_name = f"All_{get_kind_as_string(kind=kind)}"
         return await self.filters(
             kind=kind,
             at=at,
@@ -2147,8 +2155,7 @@ class InfrahubClientSync(BaseClient):
             list[InfrahubNodeSync]: List of Nodes
         """
         if query_name is None:
-            kind_str = kind if isinstance(kind, str) else kind.__name__
-            query_name = f"All_{kind_str}"
+            query_name = f"All_{get_kind_as_string(kind=kind)}"
         return self.filters(
             kind=kind,
             at=at,

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -717,7 +717,7 @@ class InfrahubClient(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else All_<kind> is used.
+            query_name (str, optional): If provided is used as the GraphQL operation name else All_<kind> is used.
 
         Returns:
             list[InfrahubNode]: List of Nodes
@@ -828,7 +828,7 @@ class InfrahubClient(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_<kind> is used.
+            query_name (str, optional): If provided is used as the GraphQL operation name else Filters_<kind> is used.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:
@@ -2152,7 +2152,7 @@ class InfrahubClientSync(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else All_<kind> is used.
+            query_name (str, optional): If provided is used as the GraphQL operation name else All_<kind> is used.
 
         Returns:
             list[InfrahubNodeSync]: List of Nodes
@@ -2304,7 +2304,7 @@ class InfrahubClientSync(BaseClient):
             parallel (bool, optional): Whether to use parallel processing for the query.
             order (Order, optional): Ordering related options. Setting `disable=True` enhances performances.
             include_metadata (bool, optional): If True, includes node_metadata and relationship_metadata in the query.
-            query_name (str, optional): If provided is used a the GraphQL operation name else Filters_<kind> is used.
+            query_name (str, optional): If provided is used as the GraphQL operation name else Filters_<kind> is used.
             **kwargs (Any): Additional filter criteria for the query.
 
         Returns:

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import ssl
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -723,3 +724,125 @@ async def test_clone_define_branch(clients: BothClients, client_type: str) -> No
     assert clone.default_branch == clone_branch
     assert original_branch != clone_branch
     assert clone.store._default_branch == clone_branch
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_count(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_count: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.count(kind="CoreRepository", query_name="MyCountQuery")
+    else:
+        clients.sync.count(kind="CoreRepository", query_name="MyCountQuery")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query MyCountQuery {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_all(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_page1_empty: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.all(kind="CoreRepository", query_name="MyAllQuery")
+    else:
+        clients.sync.all(kind="CoreRepository", query_name="MyAllQuery")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query MyAllQuery {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_filters(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_page1_empty: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.filters(kind="CoreRepository", query_name="MyFiltersQuery")
+    else:
+        clients.sync.filters(kind="CoreRepository", query_name="MyFiltersQuery")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query MyFiltersQuery {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_get(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_page1_empty: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.get(
+            kind="CoreRepository", name__value="test", raise_when_missing=False, query_name="MyGetQuery"
+        )
+    else:
+        clients.sync.get(kind="CoreRepository", name__value="test", raise_when_missing=False, query_name="MyGetQuery")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query MyGetQuery {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_for_count_ommitted(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_count: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.count(kind="CoreRepository")
+    else:
+        clients.sync.count(kind="CoreRepository")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query Count_CoreRepository {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_for_all_ommitted(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_page1_empty: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.all(kind="CoreRepository")
+    else:
+        clients.sync.all(kind="CoreRepository")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query All_CoreRepository {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_for_filters_ommitted(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_page1_empty: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.filters(kind="CoreRepository")
+    else:
+        clients.sync.filters(kind="CoreRepository")
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query Filters_CoreRepository {" in query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_query_name_for_get_ommitted(
+    httpx_mock: HTTPXMock, clients: BothClients, mock_query_repository_page1_empty: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.get(kind="CoreRepository", name__value="test", raise_when_missing=False)
+    else:
+        clients.sync.get(kind="CoreRepository", name__value="test", raise_when_missing=False)
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    query = json.loads(post_requests[0].content)["query"]
+    assert "query Get_CoreRepository {" in query


### PR DESCRIPTION
# Why

When the SDK issues GraphQL queries internally, they are anonymous (`query { ... }`), making it impossible to correlate a slow backend trace span back to a specific call site. Developers debugging performance issues have no way to tell which `all()` or `filters()` call produced a given trace.

Goal: give every SDK-generated query a meaningful GraphQL operation name so trace spans are identifiable without custom instrumentation.

Closes https://github.com/opsmill/infrahub-sdk-python/issues/923

## What changed

- `all()`, `filters()`, `get()`, and `count()` on both `InfrahubClient` and `InfrahubClientSync` now accept an optional `query_name: str | None = None` parameter.
- When `query_name` is supplied it becomes the GraphQL operation name (e.g. `query GetAllEdgeDevices { ... }`).
- When omitted, a default name is auto-generated from the method and kind: `All_CoreRepository`, `Filters_CoreRepository`, `Get_CoreRepository`, `Count_CoreRepository`. This means **all queries now have an operation name** — previously they were anonymous.


## How to test

```bash
uv run pytest tests/unit/sdk/test_client.py -k "query_name" -v
```

## Impact & rollout

- **Backward compatibility:** fully backward-compatible. `query_name` defaults to an auto-generated value, so existing call sites need no changes.
- **Performance:** no measurable impact — the name is a short string prepended to the query.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy independently.

## Checklist

- [x] Tests added/updated
- [ ] Changelog entry added (`uv run towncrier create ...`)
- [ ] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)
