### PR TITLE
IHS-217: Fix object profile file validation for mandatory field

### DIFF
--- a/changelog/908.fixed.md
+++ b/changelog/908.fixed.md
@@ -1,0 +1,1 @@
+Skip mandatory field validation during object loading when `object_profile` is specified.

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -267,9 +267,9 @@ class InfrahubObjectFileData(BaseModel):
         context = context.copy() if context else {}
 
         # First validate if all mandatory fields are present
-        # Skip mandatory check when an object_template is specified, as the template provides defaults, we expect the API server to just send a
-        # response with a failure if the template is not valid or doesn't provide all mandatory fields
-        if "object_template" not in data:
+        # Skip mandatory check when an object_template or object_profile is specified, as the template/profile provides defaults;
+        # we expect the API server to return a failure if the template/profile is not valid or doesn't provide all mandatory fields
+        if "object_template" not in data and "object_profile" not in data:
             errors.extend(
                 ObjectValidationError(position=[*position, element], message=f"{element} is mandatory")
                 for element in schema.mandatory_input_names

--- a/tests/unit/sdk/spec/test_object.py
+++ b/tests/unit/sdk/spec/test_object.py
@@ -472,3 +472,18 @@ async def test_validate_object_skips_mandatory_check_with_object_template(
 
     mandatory_errors = [e for e in errors if e.message == "type is mandatory"]
     assert mandatory_errors == []
+
+
+async def test_validate_object_skips_mandatory_check_with_object_profile(
+    client_with_schema_01: InfrahubClient,
+) -> None:
+    """When object_profile is present, mandatory field validation should be skipped."""
+    schema = await client_with_schema_01.schema.get(kind="BuiltinLocation")
+
+    data = {"name": "Site1", "object_profile": "Standard Site"}
+    errors = await InfrahubObjectFileData.validate_object(
+        client=client_with_schema_01, position=[1], schema=schema, data=data
+    )
+
+    mandatory_errors = [e for e in errors if e.message == "type is mandatory"]
+    assert mandatory_errors == []


### PR DESCRIPTION
Skip mandatory field validation during object loading when `object_profile` is specified.

Closes https://github.com/opsmill/infrahub-sdk-python/issues/908