### PR TITLE
refactor(pytest_plugin): migrate session state to pytest.Stash

### DIFF
--- a/changelog/+pytest-stash-migration.housekeeping.md
+++ b/changelog/+pytest-stash-migration.housekeeping.md
@@ -1,0 +1,1 @@
+Migrate the pytest plugin's session state to `pytest.Stash`. Internal change with no impact on external test files; removes inline `# type: ignore[attr-defined]` comments from `infrahub_sdk/pytest_plugin/`. Adds a `pytest>=7.0` floor to the `all` extra to make the requirement explicit.

--- a/infrahub_sdk/pytest_plugin/_stash.py
+++ b/infrahub_sdk/pytest_plugin/_stash.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from .. import InfrahubClientSync
+    from ..schema.repository import InfrahubRepositoryConfig
+
+
+INFRAHUB_CLIENT_KEY: pytest.StashKey[InfrahubClientSync] = pytest.StashKey()
+INFRAHUB_CONFIG_PATH_KEY: pytest.StashKey[Path] = pytest.StashKey()
+INFRAHUB_REPO_CONFIG_KEY: pytest.StashKey[InfrahubRepositoryConfig] = pytest.StashKey()

--- a/infrahub_sdk/pytest_plugin/items/base.py
+++ b/infrahub_sdk/pytest_plugin/items/base.py
@@ -7,14 +7,13 @@ from typing import TYPE_CHECKING, Any
 import pytest
 import ujson
 
+from .._stash import INFRAHUB_CONFIG_PATH_KEY
 from ..exceptions import InvalidResourceConfigError
 from ..models import InfrahubInputOutputTest
 
 if TYPE_CHECKING:
     from ...schema.repository import InfrahubRepositoryConfigElement
     from ..models import InfrahubTest
-
-_infrahub_config_path_attribute = "infrahub_config_path"
 
 
 class InfrahubItem(pytest.Item):
@@ -78,7 +77,7 @@ class InfrahubItem(pytest.Item):
         This will be an absolute path if --infrahub-config-path is an absolute path as happens when
         tests are started from within Infrahub server.
         """
-        config_path: Path = getattr(self.session, _infrahub_config_path_attribute)
+        config_path = self.session.stash[INFRAHUB_CONFIG_PATH_KEY]
         if config_path.is_absolute():
             return str(config_path.parent)
 

--- a/infrahub_sdk/pytest_plugin/items/check.py
+++ b/infrahub_sdk/pytest_plugin/items/check.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import ujson
 from httpx import HTTPStatusError
 
+from .._stash import INFRAHUB_CLIENT_KEY
 from ..exceptions import CheckDefinitionError, CheckResultError
 from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
@@ -83,7 +84,7 @@ class InfrahubCheckUnitProcessItem(InfrahubCheckItem):
 
 class InfrahubCheckIntegrationItem(InfrahubCheckItem):
     def runtest(self) -> None:
-        input_data = self.session.infrahub_client.query_gql_query(  # type: ignore[attr-defined]
+        input_data = self.session.stash[INFRAHUB_CLIENT_KEY].query_gql_query(
             self.check_instance.query,
             variables=self.test.spec.get_variables_data(),  # type: ignore[union-attr]
         )

--- a/infrahub_sdk/pytest_plugin/items/graphql_query.py
+++ b/infrahub_sdk/pytest_plugin/items/graphql_query.py
@@ -6,6 +6,7 @@ import ujson
 from httpx import HTTPStatusError
 
 from ...analyzer import GraphQLQueryAnalyzer
+from .._stash import INFRAHUB_CLIENT_KEY, INFRAHUB_CONFIG_PATH_KEY
 from ..exceptions import OutputMatchError
 from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
@@ -20,7 +21,7 @@ class InfrahubGraphQLQueryItem(InfrahubItem):
         return
 
     def execute_query(self) -> Any:
-        return self.session.infrahub_client.query_gql_query(  # type: ignore[attr-defined]
+        return self.session.stash[INFRAHUB_CLIENT_KEY].query_gql_query(
             self.test.spec.query,  # type: ignore[union-attr]
             variables=self.test.spec.get_variables_data(),  # type: ignore[union-attr]
         )
@@ -47,7 +48,7 @@ class InfrahubGraphQLQueryItem(InfrahubItem):
 
 class InfrahubGraphQLQuerySmokeItem(InfrahubGraphQLQueryItem):
     def runtest(self) -> None:
-        query = (self.session.infrahub_config_path.parent / self.test.spec.path).read_text()  # type: ignore[attr-defined,union-attr]
+        query = (self.session.stash[INFRAHUB_CONFIG_PATH_KEY].parent / self.test.spec.path).read_text()  # type: ignore[union-attr]
         GraphQLQueryAnalyzer(query)
 
 

--- a/infrahub_sdk/pytest_plugin/items/jinja2_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/jinja2_transform.py
@@ -11,6 +11,7 @@ from httpx import HTTPStatusError
 
 from ...template import Jinja2Template
 from ...template.exceptions import JinjaTemplateError
+from .._stash import INFRAHUB_CLIENT_KEY, INFRAHUB_CONFIG_PATH_KEY
 from ..exceptions import OutputMatchError
 from ..models import InfrahubInputOutputTest, InfrahubTestExpectedResult
 from .base import InfrahubItem
@@ -23,7 +24,7 @@ class InfrahubJinja2Item(InfrahubItem):
     def _get_jinja2(self) -> Jinja2Template:
         return Jinja2Template(
             template=Path(self.resource_config.template_path),  # type: ignore[attr-defined]
-            template_directory=Path(self.session.infrahub_config_path.parent),  # type: ignore[attr-defined]
+            template_directory=Path(self.session.stash[INFRAHUB_CONFIG_PATH_KEY].parent),
         )
 
     def get_jinja2_environment(self) -> jinja2.Environment:
@@ -82,7 +83,7 @@ class InfrahubJinja2Item(InfrahubItem):
 
 class InfrahubJinja2TransformSmokeItem(InfrahubJinja2Item):
     def runtest(self) -> None:
-        file_path: Path = self.session.infrahub_config_path.parent / self.resource_config.template_path  # type: ignore[attr-defined]
+        file_path: Path = self.session.stash[INFRAHUB_CONFIG_PATH_KEY].parent / self.resource_config.template_path  # type: ignore[attr-defined]
         self.get_jinja2_environment().parse(file_path.read_text(encoding="utf-8"), filename=file_path.name)
 
 
@@ -103,7 +104,7 @@ class InfrahubJinja2TransformUnitRenderItem(InfrahubJinja2Item):
 
 class InfrahubJinja2TransformIntegrationItem(InfrahubJinja2Item):
     def runtest(self) -> None:
-        graphql_result = self.session.infrahub_client.query_gql_query(  # type: ignore[attr-defined]
+        graphql_result = self.session.stash[INFRAHUB_CLIENT_KEY].query_gql_query(
             self.resource_config.query,  # type: ignore[attr-defined]
             variables=self.test.spec.get_variables_data(),  # type: ignore[union-attr]
         )

--- a/infrahub_sdk/pytest_plugin/items/python_transform.py
+++ b/infrahub_sdk/pytest_plugin/items/python_transform.py
@@ -8,6 +8,7 @@ import ujson
 from httpx import HTTPStatusError
 
 from ...node import InfrahubNode
+from .._stash import INFRAHUB_CLIENT_KEY
 from ..exceptions import OutputMatchError, PythonTransformDefinitionError
 from ..models import InfrahubTestExpectedResult
 from .base import InfrahubItem
@@ -40,7 +41,7 @@ class InfrahubPythonTransformItem(InfrahubItem):
         transform_class = self.resource_config.load_class(  # type: ignore[attr-defined]
             import_root=self.repository_base, relative_path=relative_path
         )
-        client = self.session.infrahub_client  # type: ignore[attr-defined]
+        client = self.session.stash[INFRAHUB_CLIENT_KEY]
         # TODO: Look into seeing how a transform class may use the branch, but set as a empty string for the time being to keep current behaviour
         self.transform_instance = transform_class(branch="", client=client, infrahub_node=InfrahubNode)
 
@@ -90,7 +91,7 @@ class InfrahubPythonTransformUnitProcessItem(InfrahubPythonTransformItem):
 class InfrahubPythonTransformIntegrationItem(InfrahubPythonTransformItem):
     def runtest(self) -> None:
         self.instantiate_transform()
-        input_data = self.session.infrahub_client.query_gql_query(  # type: ignore[attr-defined]
+        input_data = self.session.stash[INFRAHUB_CLIENT_KEY].query_gql_query(
             self.transform_instance.query,
             variables=self.test.spec.get_variables_data(),  # type: ignore[union-attr]
         )

--- a/infrahub_sdk/pytest_plugin/loader.py
+++ b/infrahub_sdk/pytest_plugin/loader.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import yaml
 
+from ._stash import INFRAHUB_REPO_CONFIG_KEY
 from .exceptions import InvalidResourceConfigError
 from .items import (
     InfrahubCheckIntegrationItem,
@@ -59,7 +60,8 @@ class InfrahubYamlFile(pytest.File):
 
         resource_config = None
         if resource_config_function is not None:
-            func = getattr(self.session.infrahub_repo_config, resource_config_function)  # type:ignore[attr-defined]
+            repo_config = self.session.stash[INFRAHUB_REPO_CONFIG_KEY]
+            func = getattr(repo_config, resource_config_function)
             with contextlib.suppress(KeyError):
                 resource_config = func(group.resource_name)
 

--- a/infrahub_sdk/pytest_plugin/plugin.py
+++ b/infrahub_sdk/pytest_plugin/plugin.py
@@ -7,6 +7,7 @@ import pytest
 
 from .. import InfrahubClientSync
 from ..utils import is_valid_url
+from ._stash import INFRAHUB_CLIENT_KEY, INFRAHUB_CONFIG_PATH_KEY, INFRAHUB_REPO_CONFIG_KEY
 from .loader import InfrahubYamlFile
 from .utils import find_repository_config_file, load_repository_config
 
@@ -62,13 +63,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    if session.config.option.infrahub_repo_config:
-        session.infrahub_config_path = Path(session.config.option.infrahub_repo_config)  # type: ignore[attr-defined]
-    else:
-        session.infrahub_config_path = find_repository_config_file()  # type: ignore[attr-defined]
+    config_path = (
+        Path(session.config.option.infrahub_repo_config)
+        if session.config.option.infrahub_repo_config
+        else find_repository_config_file()
+    )
+    session.stash[INFRAHUB_CONFIG_PATH_KEY] = config_path
 
-    if session.infrahub_config_path.is_file():  # type: ignore[attr-defined]
-        session.infrahub_repo_config = load_repository_config(repo_config_file=session.infrahub_config_path)  # type: ignore[attr-defined]
+    if config_path.is_file():
+        session.stash[INFRAHUB_REPO_CONFIG_KEY] = load_repository_config(repo_config_file=config_path)
 
     if not is_valid_url(session.config.option.infrahub_address):
         pytest.exit("Infrahub test instance address is not a valid URL", returncode=1)
@@ -84,8 +87,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         client_config["username"] = session.config.option.infrahub_username
         client_config["password"] = session.config.option.infrahub_password
 
-    infrahub_client = InfrahubClientSync(config=client_config)
-    session.infrahub_client = infrahub_client  # type: ignore[attr-defined]
+    session.stash[INFRAHUB_CLIENT_KEY] = InfrahubClientSync(config=client_config)
 
 
 def pytest_collect_file(parent: pytest.Collector | pytest.Item, file_path: Path) -> InfrahubYamlFile | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ all = [
     "numpy>=1.24.2; python_version<'3.12'",
     "numpy>=1.26.2; python_version>='3.12'",
     "pyarrow>=14",
-    "pytest",
+    "pytest>=7.0",
     "pyyaml>=6",
     "rich>=12,<14",
     "typer>=0.12.5",

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
 
 
 def test_help_message(pytester: pytest.Pytester) -> None:
@@ -287,6 +294,288 @@ def test_python_transform(pytester: pytest.Pytester) -> None:
     pytester.run("mv", test_input, test_dir)
     pytester.run("mv", test_output, test_dir)
 
+    transform_dir = pytester.mkdir("transforms")
+    pytester.run("mv", test_template, transform_dir)
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml")
+    result.assert_outcomes(passed=1)
+
+
+def test_graphql_query_smoke(pytester: pytest.Pytester) -> None:
+    """Smoke item should pass when the query file exists and parses successfully."""
+    pytester.makefile(
+        ".yml",
+        test_graphql_query="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "GraphQLQuery"
+            resource_name: "device_query"
+            tests:
+              - name: "smoke"
+                expect: PASS
+                spec:
+                  kind: "graphql-query-smoke"
+                  path: "queries/device.gql"
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        schemas: []
+    """,
+    )
+    queries_dir = pytester.mkdir("queries")
+    query_file = pytester.makefile(
+        ".gql",
+        device="""
+        query DeviceQuery {
+            InfraDevice {
+                edges {
+                    node {
+                        name { value }
+                    }
+                }
+            }
+        }
+        """,
+    )
+    pytester.run("mv", query_file, queries_dir)
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml")
+    result.assert_outcomes(passed=1)
+
+
+def test_graphql_query_smoke_invalid(pytester: pytest.Pytester) -> None:
+    """Smoke item should fail when the query file contains invalid GraphQL."""
+    pytester.makefile(
+        ".yml",
+        test_graphql_query="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "GraphQLQuery"
+            resource_name: "device_query"
+            tests:
+              - name: "smoke"
+                expect: PASS
+                spec:
+                  kind: "graphql-query-smoke"
+                  path: "queries/broken.gql"
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        schemas: []
+    """,
+    )
+    queries_dir = pytester.mkdir("queries")
+    query_file = pytester.makefile(
+        ".gql",
+        broken="this is not a valid graphql query {",
+    )
+    pytester.run("mv", query_file, queries_dir)
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml")
+    result.assert_outcomes(failed=1)
+
+
+def test_jinja2_transform_smoke(pytester: pytest.Pytester) -> None:
+    """Smoke item should pass when the template parses successfully."""
+    pytester.makefile(
+        ".yml",
+        test_jinja2_transform="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "Jinja2Transform"
+            resource_name: "bgp_config"
+            tests:
+              - name: "smoke"
+                expect: PASS
+                spec:
+                  kind: "jinja2-transform-smoke"
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        schemas: []
+
+        jinja2_transforms:
+          - name: bgp_config
+            description: "Template for BGP config base"
+            query: "bgp_sessions"
+            template_path: "templates/bgp_config.j2"
+    """,
+    )
+    template_dir = pytester.mkdir("templates")
+    template = pytester.makefile(
+        ".j2",
+        bgp_config="""
+    protocols {
+        bgp {
+            log-up-down;
+            bgp-error-tolerance;
+        }
+    }
+    """,
+    )
+    pytester.run("mv", template, template_dir)
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+def test_graphql_query_integration(pytester: pytest.Pytester, httpx_mock: HTTPXMock) -> None:
+    """Integration item should pass when the mocked GraphQL response matches the expected output."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:8000/api/query/device_query?branch=main&update_group=false&",
+        json={"data": {"InfraDevice": {"edges": [{"node": {"name": {"value": "atl1-edge1"}}}]}}},
+        is_reusable=True,
+    )
+
+    pytester.makefile(
+        ".yml",
+        test_graphql_query="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "GraphQLQuery"
+            resource_name: "device_query"
+            tests:
+              - name: "integration"
+                expect: PASS
+                spec:
+                  kind: "graphql-query-integration"
+                  query: "device_query"
+                  variables: {}
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        schemas: []
+    """,
+    )
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+def test_jinja2_transform_integration(pytester: pytest.Pytester, httpx_mock: HTTPXMock) -> None:
+    """Integration item should render the template using data from a mocked GraphQL response."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:8000/api/query/bgp_sessions?branch=main&update_group=false&",
+        json={"data": {"BgpSession": {"edges": []}}},
+        is_reusable=True,
+    )
+
+    pytester.makefile(
+        ".yml",
+        test_jinja2_transform="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "Jinja2Transform"
+            resource_name: "bgp_config"
+            tests:
+              - name: "integration"
+                expect: PASS
+                spec:
+                  kind: "jinja2-transform-integration"
+                  variables: {}
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        schemas: []
+
+        jinja2_transforms:
+          - name: bgp_config
+            description: "Template for BGP config base"
+            query: "bgp_sessions"
+            template_path: "templates/bgp_config.j2"
+    """,
+    )
+    template_dir = pytester.mkdir("templates")
+    template = pytester.makefile(
+        ".j2",
+        bgp_config="""
+    protocols {
+        bgp {
+            log-up-down;
+            bgp-error-tolerance;
+        }
+    }
+    """,
+    )
+    pytester.run("mv", template, template_dir)
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml")
+    result.assert_outcomes(passed=1)
+
+
+@pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+def test_python_transform_integration(pytester: pytest.Pytester, httpx_mock: HTTPXMock) -> None:
+    """Integration item should run the transform using data from a mocked GraphQL response."""
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:8000/api/query/device_config?branch=main&update_group=false&",
+        json={"data": {"InfraDevice": {"edges": [{"node": {"name": {"value": "atl1-edge1"}}}]}}},
+        is_reusable=True,
+    )
+
+    pytester.makefile(
+        ".yml",
+        test_python_transform="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "PythonTransform"
+            resource_name: "device_config"
+            tests:
+              - name: "integration"
+                expect: PASS
+                spec:
+                  kind: "python-transform-integration"
+                  variables: {}
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        schemas: []
+
+        python_transforms:
+          - name: device_config
+            class_name: "DeviceConfig"
+            file_path: "transforms/device_config.py"
+    """,
+    )
+    test_template = pytester.makefile(
+        ".py",
+        device_config="""
+        from infrahub_sdk.transforms import InfrahubTransform
+
+        class DeviceConfig(InfrahubTransform):
+            query = "device_config"
+            async def transform(self, data):
+                return {"hostname": data["InfraDevice"]["edges"][0]["node"]["name"]["value"]}
+    """,
+    )
     transform_dir = pytester.mkdir("transforms")
     pytester.run("mv", test_template, transform_dir)
 

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'ctl'", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2.0.0,!=2.0.1,!=2.1.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "pytest", marker = "extra == 'all'" },
+    { name = "pytest", marker = "extra == 'all'", specifier = ">=7.0" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6" },
     { name = "pyyaml", marker = "extra == 'ctl'", specifier = ">=6" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=12,<14" },


### PR DESCRIPTION
# Why

Found when analyzing the codebase for areas where we could improve typing. Use a new pytest.Stash feature to allow for correct typing within our pytest plugin

## What changed

* Migrate the pytest plugin's session state from dynamic attribute assignment to `pytest.StashKey`
