### PR TITLE
chore: bump invoke 2.2.0 -> 2.2.1 for Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ dev = [
     "requests",
     "prek>=0.3.0",
     "codecov",
-    "invoke>=2.2.0",
+    "invoke>=2.2.1",
     "towncrier>=24.8.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -835,7 +835,7 @@ dev = [
     { name = "astroid", specifier = ">=3.1,<4.0" },
     { name = "codecov" },
     { name = "infrahub-testcontainers", specifier = ">=1.7.3" },
-    { name = "invoke", specifier = ">=2.2.0" },
+    { name = "invoke", specifier = ">=2.2.1" },
     { name = "ipython" },
     { name = "mypy", specifier = "==1.11.2" },
     { name = "prek", specifier = ">=0.3.0" },


### PR DESCRIPTION
# Why

`invoke` 2.2.0 raises `SystemError: buffer overflow` on Python 3.14: 3.14 tightened `fcntl` buffer-overflow detection, and invoke's `termios.TIOCGWINSZ` probe in `terminals.py` was reading too few fields of the 4-field `winsize` struct. When `sys.stdout` is a TTY, any `uv run invoke <task>` (or `--list`/`--help`) aborts before the task body.

invoke 2.2.1 (2025-10-10) unpacks all four fields and discards the unused two — pure compat fix, no behavior change. Upstream fix: [pyinvoke/invoke#1040](https://github.com/pyinvoke/invoke/pull/1040). Equivalent bump on the main repo: [opsmill/infrahub#9128](https://github.com/opsmill/infrahub/pull/9128).

## What changed

- `pyproject.toml`: `invoke>=2.2.0` → `invoke>=2.2.1`
- `uv.lock`: regenerated; `invoke` resolves to `2.2.1`

## How to test

```bash
uv sync --all-groups
uv run invoke --list          # was failing on Python 3.14 with SystemError; now succeeds
uv run invoke format
uv run invoke lint
```

Reproduce the original bug (before the bump) on Python 3.14 with a real TTY:

```bash
uv pip install invoke==2.2.0
.venv/bin/invoke --list       # SystemError: buffer overflow at terminals.py:96
```

## Impact & rollout

- **Backward compatibility:** none — patch-level bump, no API change.
- **Deployment notes:** safe to deploy.