### PR TITLE
Add docstrings to related node

### DIFF
--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/related_node.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/related_node.mdx
@@ -19,6 +19,12 @@ Base class for representing a related node in a relationship.
 id(self) -> str | None
 ```
 
+Return the parsed peer id without triggering a store lookup.
+
+Returns None when the response carried only hfid_str (no id, no peer)
+— in that case .peer.id would resolve through the store and yield a
+non-None id, so .id and .peer.id are NOT interchangeable.
+
 #### `hfid`
 
 ```python
@@ -95,11 +101,24 @@ fetch(self, timeout: int | None = None) -> None
 peer(self) -> InfrahubNode
 ```
 
+Return the peer node, or raise ValueError if no identifier is available.
+
 #### `get`
 
 ```python
 get(self) -> InfrahubNode
 ```
+
+Return the peer node, performing a store lookup if not materialized.
+
+When resolving via hfid_str the returned node has a non-None id even
+when this RelatedNode's .id is None — that is the case in which
+.peer.id and .id diverge.
+
+**Raises:**
+
+- `ValueError`: when neither a peer, (_id,_typename), nor hfid_str
+is available.
 
 ### `RelatedNodeSync`
 
@@ -119,8 +138,21 @@ fetch(self, timeout: int | None = None) -> None
 peer(self) -> InfrahubNodeSync
 ```
 
+Return the peer node, or raise ValueError if no identifier is available.
+
 #### `get`
 
 ```python
 get(self) -> InfrahubNodeSync
 ```
+
+Return the peer node, performing a store lookup if not materialized.
+
+When resolving via hfid_str the returned node has a non-None id even
+when this RelatedNode's .id is None — that is the case in which
+.peer.id and .id diverge.
+
+**Raises:**
+
+- `ValueError`: when neither a peer, (_id,_typename), nor hfid_str
+is available.

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -92,6 +92,12 @@ class RelatedNodeBase:
 
     @property
     def id(self) -> str | None:
+        """Return the parsed peer id without triggering a store lookup.
+
+        Returns None when the response carried only hfid_str (no id, no peer)
+        — in that case .peer.id would resolve through the store and yield a
+        non-None id, so .id and .peer.id are NOT interchangeable.
+        """
         if self._peer:
             return self._peer.id
         return self._id
@@ -247,9 +253,21 @@ class RelatedNode(RelatedNodeBase):
 
     @property
     def peer(self) -> InfrahubNode:
+        """Return the peer node, or raise ValueError if no identifier is available."""
         return self.get()
 
     def get(self) -> InfrahubNode:
+        """Return the peer node, performing a store lookup if not materialized.
+
+        When resolving via hfid_str the returned node has a non-None id even
+        when this RelatedNode's .id is None — that is the case in which
+        .peer.id and .id diverge.
+
+        Raises:
+            ValueError: when neither a peer, (_id, _typename), nor hfid_str
+                is available.
+
+        """
         if self._peer:
             return self._peer  # type: ignore[return-value]
 
@@ -296,9 +314,21 @@ class RelatedNodeSync(RelatedNodeBase):
 
     @property
     def peer(self) -> InfrahubNodeSync:
+        """Return the peer node, or raise ValueError if no identifier is available."""
         return self.get()
 
     def get(self) -> InfrahubNodeSync:
+        """Return the peer node, performing a store lookup if not materialized.
+
+        When resolving via hfid_str the returned node has a non-None id even
+        when this RelatedNode's .id is None — that is the case in which
+        .peer.id and .id diverge.
+
+        Raises:
+            ValueError: when neither a peer, (_id, _typename), nor hfid_str
+                is available.
+
+        """
         if self._peer:
             return self._peer  # type: ignore[return-value]
 


### PR DESCRIPTION
# Why

Adding docstrings, specifically for the `Raises` part to assist linters, people navigating the code and AI agents to understand the code in a quicker way.

Making this change as it was something that confused Claude and had it try to introduce errors.

## What changed

* Added docstrings