### PR TITLE
fix(ctl): handle extensions paths in display_schema_load_errors (#1007)

### DIFF
--- a/changelog/1007.fixed.md
+++ b/changelog/1007.fixed.md
@@ -1,0 +1,1 @@
+Render schema rejections originating in an `extensions:` block as a readable one-line message in `infrahubctl schema load`, instead of crashing with `ValueError: invalid literal for int()`.

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -101,15 +101,17 @@ def _render_schema_error(
     )
     path_suffix = f" (extensions/{container})" if is_extension else ""
     input_str = error.get("input")
+    err_msg = error.get("msg", "No error message")
+    err_type = error.get("type", "unknown")
 
     if len(tail) == 1:
         loc_type = tail[0]
-        error_message = f"{loc_type} ({input_str}) | {error['msg']} ({error['type']})"
+        error_message = f"{loc_type} ({input_str}) | {err_msg} ({err_type})"
     elif len(tail) > 1:
         loc_type = tail[0]
         attribute = tail[1]
         input_label = _resolve_attribute_label(error_data=node.get(loc_type, []), attribute=attribute)
-        error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
+        error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {err_msg} ({err_type})"
     else:
         return
 

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -4,7 +4,7 @@ import asyncio
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import typer
 import yaml
@@ -148,11 +148,14 @@ def valid_error_path(loc_path: list[Any]) -> bool:
     return loc_path[3] in {"nodes", "generics"} and isinstance(loc_path[4], int)
 
 
+SchemaContainer = Literal["nodes", "generics", "relationships"]
+
+
 def get_node(
     schemas_data: list[SchemaFile],
     schema_index: int,
     node_index: int,
-    container: str = "nodes",
+    container: SchemaContainer = "nodes",
     is_extension: bool = False,
 ) -> dict | None:
     if schema_index >= len(schemas_data):

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -94,6 +94,7 @@ def _render_schema_error(
         output.print("Node data not found.")
         return
 
+    # Extensions reference an existing node by `kind`; new top-level nodes are identified by `namespace+name`.
     node_label = (
         (node.get("kind") or node.get("name") or "")
         if is_extension
@@ -105,12 +106,16 @@ def _render_schema_error(
     err_type = error.get("type", "unknown")
 
     if len(tail) == 1:
+        # Error on a direct field of the node (e.g. `name`, `namespace`).
         loc_type = tail[0]
         error_message = f"{loc_type} ({input_str}) | {err_msg} ({err_type})"
     elif len(tail) > 1:
+        # Error nested inside a collection (e.g. attributes[2].kind, relationships[0].peer).
+        # loc_type is the collection name; attribute is either its index or the failing field name.
         loc_type = tail[0]
         attribute = tail[1]
         input_label = _resolve_attribute_label(error_data=node.get(loc_type, []), attribute=attribute)
+        # Trim the trailing 's' so "attributes" → "Attribute" in the rendered label.
         error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {err_msg} ({err_type})"
     else:
         return
@@ -124,7 +129,9 @@ def _resolve_attribute_label(error_data: list[dict[str, Any]], attribute: Any) -
             if data.get(attribute) is not None:
                 return data.get("name", None)
         return None
-    return error_data[attribute].get("name", None)
+    if isinstance(attribute, int) and 0 <= attribute < len(error_data):
+        return error_data[attribute].get("name", None)
+    return None
 
 
 def handle_non_detail_errors(response: dict[str, Any], output: Console | None = None) -> None:

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -59,44 +59,65 @@ def display_schema_load_errors(response: dict[str, Any], schemas_data: list[Sche
         loc_path = error.get("loc", [])
         if not valid_error_path(loc_path=loc_path):
             continue
+        _render_schema_error(error=error, loc_path=loc_path, schemas_data=schemas_data)
 
-        # if the len of the path is equal to 6, the error is at the root of the object
-        # if the len of the path is higher than 6, the error is in an attribute or a relationships
-        schema_index = int(loc_path[2])
+
+def _render_schema_error(error: dict[str, Any], loc_path: list[Any], schemas_data: list[SchemaFile]) -> None:
+    # Two layout shapes for loc_path. tail is the part after the node index.
+    # Top-level: body / schemas / <si> / (nodes|generics) / <ni> / [<subtype> / <attr>]
+    # Extensions: body / schemas / <si> / extensions / (nodes|generics|relationships) / <ni> / [<subtype> / <attr>]
+    schema_index = int(loc_path[2])
+    is_extension = loc_path[3] == "extensions"
+    if is_extension:
+        container = loc_path[4]
+        node_index = int(loc_path[5])
+        tail = loc_path[6:]
+    else:
+        container = loc_path[3]
         node_index = int(loc_path[4])
-        node = get_node(schemas_data=schemas_data, schema_index=schema_index, node_index=node_index)
+        tail = loc_path[5:]
 
-        if not node:
-            console.print("Node data not found.")
-            continue
+    node = get_node(
+        schemas_data=schemas_data,
+        schema_index=schema_index,
+        node_index=node_index,
+        container=container,
+        is_extension=is_extension,
+    )
 
-        if len(loc_path) == 6:
-            loc_type = loc_path[-1]
-            input_str = error.get("input", None)
-            error_message = f"{loc_type} ({input_str}) | {error['msg']} ({error['type']})"
-            console.print(
-                f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}", markup=False
-            )
+    if not node:
+        console.print("Node data not found.")
+        return
 
-        elif len(loc_path) > 6:
-            loc_type = loc_path[5]
-            error_data = node[loc_type]
-            attribute = loc_path[6]
+    node_label = (
+        (node.get("kind") or node.get("name") or "")
+        if is_extension
+        else f"{node.get('namespace', None)}{node.get('name', None)}"
+    )
+    path_suffix = f" (extensions/{container})" if is_extension else ""
+    input_str = error.get("input")
 
-            if isinstance(attribute, str):
-                input_label = None
-                for data in error_data:
-                    if data.get(attribute) is not None:
-                        input_label = data.get("name", None)
-                        break
-            else:
-                input_label = error_data[attribute].get("name", None)
+    if len(tail) == 1:
+        loc_type = tail[0]
+        error_message = f"{loc_type} ({input_str}) | {error['msg']} ({error['type']})"
+    elif len(tail) > 1:
+        loc_type = tail[0]
+        attribute = tail[1]
+        input_label = _resolve_attribute_label(error_data=node.get(loc_type, []), attribute=attribute)
+        error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
+    else:
+        return
 
-            input_str = error.get("input", None)
-            error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
-            console.print(
-                f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}", markup=False
-            )
+    console.print(f"  Node: {node_label}{path_suffix} | {error_message}", markup=False)
+
+
+def _resolve_attribute_label(error_data: list[dict[str, Any]], attribute: Any) -> str | None:
+    if isinstance(attribute, str):
+        for data in error_data:
+            if data.get(attribute) is not None:
+                return data.get("name", None)
+        return None
+    return error_data[attribute].get("name", None)
 
 
 def handle_non_detail_errors(response: dict[str, Any]) -> None:
@@ -110,12 +131,30 @@ def handle_non_detail_errors(response: dict[str, Any]) -> None:
 
 
 def valid_error_path(loc_path: list[Any]) -> bool:
-    return len(loc_path) >= 6 and loc_path[0] == "body" and loc_path[1] == "schemas"
+    if len(loc_path) < 6 or loc_path[0] != "body" or loc_path[1] != "schemas" or not isinstance(loc_path[2], int):
+        return False
+    if loc_path[3] == "extensions":
+        return (
+            len(loc_path) >= 7
+            and loc_path[4] in {"nodes", "generics", "relationships"}
+            and isinstance(loc_path[5], int)
+        )
+    return loc_path[3] in {"nodes", "generics"} and isinstance(loc_path[4], int)
 
 
-def get_node(schemas_data: list[SchemaFile], schema_index: int, node_index: int) -> dict | None:
-    if schema_index < len(schemas_data) and node_index < len(schemas_data[schema_index].payload["nodes"]):
-        return schemas_data[schema_index].payload["nodes"][node_index]
+def get_node(
+    schemas_data: list[SchemaFile],
+    schema_index: int,
+    node_index: int,
+    container: str = "nodes",
+    is_extension: bool = False,
+) -> dict | None:
+    if schema_index >= len(schemas_data):
+        return None
+    payload = schemas_data[schema_index].payload
+    items = payload.get("extensions", {}).get(container, []) if is_extension else payload.get(container, [])
+    if node_index < len(items):
+        return items[node_index]
     return None
 
 

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -24,6 +24,8 @@ from .utils import load_yamlfile_from_disk_and_exit
 if TYPE_CHECKING:
     from .. import InfrahubClient
 
+SchemaContainer = Literal["nodes", "generics", "relationships"]
+
 app = AsyncTyper()
 console = Console()
 
@@ -155,9 +157,6 @@ def valid_error_path(loc_path: list[Any]) -> bool:
             and isinstance(loc_path[5], int)
         )
     return loc_path[3] in {"nodes", "generics"} and isinstance(loc_path[4], int)
-
-
-SchemaContainer = Literal["nodes", "generics", "relationships"]
 
 
 def get_node(

--- a/infrahub_sdk/ctl/schema.py
+++ b/infrahub_sdk/ctl/schema.py
@@ -49,20 +49,25 @@ def validate_schema_content_and_exit(client: InfrahubClient, schemas: list[Schem
         raise typer.Exit(1)
 
 
-def display_schema_load_errors(response: dict[str, Any], schemas_data: list[SchemaFile]) -> None:
-    console.print("[red]Unable to load the schema:")
+def display_schema_load_errors(
+    response: dict[str, Any], schemas_data: list[SchemaFile], output: Console | None = None
+) -> None:
+    out = output or console
+    out.print("[red]Unable to load the schema:")
     if "detail" not in response:
-        handle_non_detail_errors(response=response)
+        handle_non_detail_errors(response=response, output=out)
         return
 
     for error in response["detail"]:
         loc_path = error.get("loc", [])
         if not valid_error_path(loc_path=loc_path):
             continue
-        _render_schema_error(error=error, loc_path=loc_path, schemas_data=schemas_data)
+        _render_schema_error(error=error, loc_path=loc_path, schemas_data=schemas_data, output=out)
 
 
-def _render_schema_error(error: dict[str, Any], loc_path: list[Any], schemas_data: list[SchemaFile]) -> None:
+def _render_schema_error(
+    error: dict[str, Any], loc_path: list[Any], schemas_data: list[SchemaFile], output: Console
+) -> None:
     # Two layout shapes for loc_path. tail is the part after the node index.
     # Top-level: body / schemas / <si> / (nodes|generics) / <ni> / [<subtype> / <attr>]
     # Extensions: body / schemas / <si> / extensions / (nodes|generics|relationships) / <ni> / [<subtype> / <attr>]
@@ -86,7 +91,7 @@ def _render_schema_error(error: dict[str, Any], loc_path: list[Any], schemas_dat
     )
 
     if not node:
-        console.print("Node data not found.")
+        output.print("Node data not found.")
         return
 
     node_label = (
@@ -108,7 +113,7 @@ def _render_schema_error(error: dict[str, Any], loc_path: list[Any], schemas_dat
     else:
         return
 
-    console.print(f"  Node: {node_label}{path_suffix} | {error_message}", markup=False)
+    output.print(f"  Node: {node_label}{path_suffix} | {error_message}", markup=False)
 
 
 def _resolve_attribute_label(error_data: list[dict[str, Any]], attribute: Any) -> str | None:
@@ -120,14 +125,15 @@ def _resolve_attribute_label(error_data: list[dict[str, Any]], attribute: Any) -
     return error_data[attribute].get("name", None)
 
 
-def handle_non_detail_errors(response: dict[str, Any]) -> None:
+def handle_non_detail_errors(response: dict[str, Any], output: Console | None = None) -> None:
+    out = output or console
     if "error" in response:
-        console.print(f"  {response.get('error')}")
+        out.print(f"  {response.get('error')}")
     elif "errors" in response:
         for error in response["errors"]:
-            console.print(f"  {error.get('message')}")
+            out.print(f"  {error.get('message')}")
     else:
-        console.print(f"  '{response}'")
+        out.print(f"  '{response}'")
 
 
 def valid_error_path(loc_path: list[Any]) -> bool:

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,11 +1,16 @@
+from io import StringIO
+from pathlib import Path
 from typing import Any
 
 import pytest
+from rich.console import Console
 
 from infrahub_sdk import InfrahubClient
+from infrahub_sdk.ctl.schema import display_schema_load_errors
 from infrahub_sdk.exceptions import BranchNotFoundError
 from infrahub_sdk.schema import NodeSchemaAPI
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+from infrahub_sdk.yaml import SchemaFile
 
 
 class TestInfrahubSchema(TestInfrahubDockerClient):
@@ -43,3 +48,71 @@ class TestInfrahubSchemaLoad(TestInfrahubDockerClient):
         schema_nodes = await client.schema.all(refresh=True)
         assert "InfraRack" in schema_nodes
         assert "ProcurementContract" in schema_nodes
+
+
+class TestInfrahubSchemaLoadErrorRendering(TestInfrahubDockerClient):
+    """Render real server error responses through display_schema_load_errors.
+
+    These exist as integration tests so we catch any drift between the server's
+    validation error payload shape and the CLI renderer, particularly for
+    `extensions` paths which previously went unhandled.
+    """
+
+    async def test_extension_top_level_field_error(self, client: InfrahubClient) -> None:
+        broken_schema = {
+            "version": "1.0",
+            "extensions": {
+                "nodes": [
+                    {
+                        "kind": "BuiltinTag",
+                        "namespace": "Forbidden",
+                    }
+                ]
+            },
+        }
+
+        response = await client.schema.load(schemas=[broken_schema])
+
+        assert response.errors, "Server should reject a forbidden field on an extensions/nodes entry"
+        assert "detail" in response.errors
+
+        schemas_data = [SchemaFile(location=Path("broken.yml"), content=broken_schema)]
+        buffer = StringIO()
+        output = Console(file=buffer, width=1000, force_terminal=False)
+        display_schema_load_errors(response=response.errors, schemas_data=schemas_data, output=output)
+        rendered = buffer.getvalue()
+
+        assert "Unable to load the schema" in rendered
+        assert "BuiltinTag" in rendered
+        assert "extensions/nodes" in rendered
+
+    async def test_extension_nested_attribute_error(self, client: InfrahubClient) -> None:
+        broken_schema = {
+            "version": "1.0",
+            "extensions": {
+                "nodes": [
+                    {
+                        "kind": "BuiltinTag",
+                        "attributes": [
+                            {"name": "speed", "kind": "Number", "made_up": True},
+                        ],
+                    }
+                ]
+            },
+        }
+
+        response = await client.schema.load(schemas=[broken_schema])
+
+        assert response.errors, "Server should reject a forbidden field on an extensions attribute entry"
+        assert "detail" in response.errors
+
+        schemas_data = [SchemaFile(location=Path("broken.yml"), content=broken_schema)]
+        buffer = StringIO()
+        output = Console(file=buffer, width=1000, force_terminal=False)
+        display_schema_load_errors(response=response.errors, schemas_data=schemas_data, output=output)
+        rendered = buffer.getvalue()
+
+        assert "Unable to load the schema" in rendered
+        assert "BuiltinTag" in rendered
+        assert "extensions/nodes" in rendered
+        assert "speed" in rendered

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,4 +1,3 @@
-from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -77,10 +76,10 @@ class TestInfrahubSchemaLoadErrorRendering(TestInfrahubDockerClient):
         assert "detail" in response.errors
 
         schemas_data = [SchemaFile(location=Path("broken.yml"), content=broken_schema)]
-        buffer = StringIO()
-        output = Console(file=buffer, width=1000, force_terminal=False)
-        display_schema_load_errors(response=response.errors, schemas_data=schemas_data, output=output)
-        rendered = buffer.getvalue()
+        console = Console(width=1000)
+        with console.capture() as capture:
+            display_schema_load_errors(response=response.errors, schemas_data=schemas_data, output=console)
+        rendered = capture.get()
 
         assert "Unable to load the schema" in rendered
         assert "BuiltinTag" in rendered
@@ -107,10 +106,10 @@ class TestInfrahubSchemaLoadErrorRendering(TestInfrahubDockerClient):
         assert "detail" in response.errors
 
         schemas_data = [SchemaFile(location=Path("broken.yml"), content=broken_schema)]
-        buffer = StringIO()
-        output = Console(file=buffer, width=1000, force_terminal=False)
-        display_schema_load_errors(response=response.errors, schemas_data=schemas_data, output=output)
-        rendered = buffer.getvalue()
+        console = Console(width=1000)
+        with console.capture() as capture:
+            display_schema_load_errors(response=response.errors, schemas_data=schemas_data, output=console)
+        rendered = capture.get()
 
         assert "Unable to load the schema" in rendered
         assert "BuiltinTag" in rendered

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -8,7 +8,7 @@ from pytest_httpx import HTTPXMock
 from rich.console import Console
 
 from infrahub_sdk import Config, InfrahubClient, InfrahubClientSync
-from infrahub_sdk.ctl.schema import display_schema_load_errors
+from infrahub_sdk.ctl.schema import display_schema_load_errors, valid_error_path
 from infrahub_sdk.exceptions import SchemaNotFoundError, ValidationError
 from infrahub_sdk.protocols import BuiltinIPAddress, BuiltinIPAddressSync, BuiltinTag, BuiltinTagSync
 from infrahub_sdk.schema import BranchSchema, InfrahubSchema, InfrahubSchemaBase, InfrahubSchemaSync, NodeSchemaAPI
@@ -490,97 +490,33 @@ async def test_display_schema_load_errors_details_when_error_is_in_attribute_or_
         assert output == expected_console
 
 
-@mock.patch(
-    "infrahub_sdk.ctl.schema.get_node",
-    return_value={"kind": "DcimGenericDevice", "include_in_menu": False},
+@pytest.mark.parametrize(
+    "loc_path",
+    [
+        pytest.param(["body", "schemas", 0, "nodes", 0, "name"], id="top-level-nodes"),
+        pytest.param(["body", "schemas", 0, "generics", 1, "attributes", 0], id="top-level-generics"),
+        pytest.param(["body", "schemas", 0, "extensions", "nodes", 0, "kind"], id="extension-nodes"),
+        pytest.param(["body", "schemas", 0, "extensions", "generics", 0, "name"], id="extension-generics"),
+        pytest.param(["body", "schemas", 0, "extensions", "relationships", 2, "peer"], id="extension-relationships"),
+    ],
 )
-async def test_display_schema_load_errors_details_extensions_top_level(mock_get_node: MagicMock) -> None:
-    """Validate error rendering when the failing path is inside an extensions block at field level."""
-    error = {
-        "detail": [
-            {
-                "type": "extra_forbidden",
-                "loc": ["body", "schemas", 0, "extensions", "generics", 0, "include_in_menu"],
-                "msg": "Extra inputs are not permitted",
-                "input": False,
-            },
-        ]
-    }
-
-    with mock.patch("infrahub_sdk.ctl.schema.console", Console(file=StringIO(), width=1000)) as console:
-        display_schema_load_errors(response=error, schemas_data=[])
-        mock_get_node.assert_called_once()
-        output = console.file.getvalue()
-        expected_console = """Unable to load the schema:
-  Node: DcimGenericDevice (extensions/generics) | include_in_menu (False) | Extra inputs are not permitted (extra_forbidden)
-"""
-        assert output == expected_console
+def test_valid_error_path_accepts_known_shapes(loc_path: list) -> None:
+    assert valid_error_path(loc_path=loc_path)
 
 
-@mock.patch(
-    "infrahub_sdk.ctl.schema.get_node",
-    return_value={
-        "kind": "DcimGenericDevice",
-        "attributes": [{"name": "speed", "kind": "Number", "min_value": 0}],
-    },
+@pytest.mark.parametrize(
+    "loc_path",
+    [
+        pytest.param(["body", "headers", "x-test"], id="wrong-root"),
+        pytest.param(["body", "schemas", "not-an-int", "nodes", 0, "name"], id="non-int-schema-index"),
+        pytest.param(["body", "schemas", 0, "wat", 0, "name"], id="unknown-container"),
+        pytest.param(["body", "schemas", 0, "extensions", "generics", "include_in_menu"], id="non-int-extension-index"),
+        pytest.param(["body", "schemas", 0, "extensions", "wat", 0, "name"], id="unknown-extension-container"),
+        pytest.param(["body", "schemas", 0, "nodes"], id="too-short"),
+    ],
 )
-async def test_display_schema_load_errors_details_extensions_nested_attribute(mock_get_node: MagicMock) -> None:
-    """Validate error rendering for a nested attribute error inside an extensions block."""
-    error = {
-        "detail": [
-            {
-                "type": "extra_forbidden",
-                "loc": ["body", "schemas", 0, "extensions", "generics", 0, "attributes", "min_value"],
-                "msg": "Extra inputs are not permitted",
-                "input": 0,
-            },
-        ]
-    }
-
-    with mock.patch("infrahub_sdk.ctl.schema.console", Console(file=StringIO(), width=1000)) as console:
-        display_schema_load_errors(response=error, schemas_data=[])
-        mock_get_node.assert_called_once()
-        output = console.file.getvalue()
-        expected_console = """Unable to load the schema:
-  Node: DcimGenericDevice (extensions/generics) | Attribute: speed (0) | Extra inputs are not permitted (extra_forbidden)
-"""
-        assert output == expected_console
-
-
-async def test_display_schema_load_errors_skips_unknown_path_shapes() -> None:
-    """Unknown or malformed loc_path shapes are skipped silently, never crash the renderer."""
-    error = {
-        "detail": [
-            # Wrong root prefix
-            {"type": "value_error", "loc": ["body", "headers", "x-test"], "msg": "bad", "input": "x"},
-            # schema_index is not an int
-            {
-                "type": "value_error",
-                "loc": ["body", "schemas", "not-an-int", "nodes", 0, "name"],
-                "msg": "bad",
-                "input": "x",
-            },
-            # Unknown container
-            {
-                "type": "value_error",
-                "loc": ["body", "schemas", 0, "wat", 0, "name"],
-                "msg": "bad",
-                "input": "x",
-            },
-            # Extensions path with non-int node index — was the original crash
-            {
-                "type": "value_error",
-                "loc": ["body", "schemas", 0, "extensions", "generics", "include_in_menu"],
-                "msg": "bad",
-                "input": "x",
-            },
-        ]
-    }
-
-    with mock.patch("infrahub_sdk.ctl.schema.console", Console(file=StringIO(), width=1000)) as console:
-        display_schema_load_errors(response=error, schemas_data=[])
-        output = console.file.getvalue()
-        assert output == "Unable to load the schema:\n"
+def test_valid_error_path_rejects_unknown_shapes(loc_path: list) -> None:
+    assert not valid_error_path(loc_path=loc_path)
 
 
 def test_schema_base__get_schema_name__returns_correct_schema_name_for_protocols() -> None:

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -490,6 +490,99 @@ async def test_display_schema_load_errors_details_when_error_is_in_attribute_or_
         assert output == expected_console
 
 
+@mock.patch(
+    "infrahub_sdk.ctl.schema.get_node",
+    return_value={"kind": "DcimGenericDevice", "include_in_menu": False},
+)
+async def test_display_schema_load_errors_details_extensions_top_level(mock_get_node: MagicMock) -> None:
+    """Validate error rendering when the failing path is inside an extensions block at field level."""
+    error = {
+        "detail": [
+            {
+                "type": "extra_forbidden",
+                "loc": ["body", "schemas", 0, "extensions", "generics", 0, "include_in_menu"],
+                "msg": "Extra inputs are not permitted",
+                "input": False,
+            },
+        ]
+    }
+
+    with mock.patch("infrahub_sdk.ctl.schema.console", Console(file=StringIO(), width=1000)) as console:
+        display_schema_load_errors(response=error, schemas_data=[])
+        mock_get_node.assert_called_once()
+        output = console.file.getvalue()
+        expected_console = """Unable to load the schema:
+  Node: DcimGenericDevice (extensions/generics) | include_in_menu (False) | Extra inputs are not permitted (extra_forbidden)
+"""
+        assert output == expected_console
+
+
+@mock.patch(
+    "infrahub_sdk.ctl.schema.get_node",
+    return_value={
+        "kind": "DcimGenericDevice",
+        "attributes": [{"name": "speed", "kind": "Number", "min_value": 0}],
+    },
+)
+async def test_display_schema_load_errors_details_extensions_nested_attribute(mock_get_node: MagicMock) -> None:
+    """Validate error rendering for a nested attribute error inside an extensions block."""
+    error = {
+        "detail": [
+            {
+                "type": "extra_forbidden",
+                "loc": ["body", "schemas", 0, "extensions", "generics", 0, "attributes", "min_value"],
+                "msg": "Extra inputs are not permitted",
+                "input": 0,
+            },
+        ]
+    }
+
+    with mock.patch("infrahub_sdk.ctl.schema.console", Console(file=StringIO(), width=1000)) as console:
+        display_schema_load_errors(response=error, schemas_data=[])
+        mock_get_node.assert_called_once()
+        output = console.file.getvalue()
+        expected_console = """Unable to load the schema:
+  Node: DcimGenericDevice (extensions/generics) | Attribute: speed (0) | Extra inputs are not permitted (extra_forbidden)
+"""
+        assert output == expected_console
+
+
+async def test_display_schema_load_errors_skips_unknown_path_shapes() -> None:
+    """Unknown or malformed loc_path shapes are skipped silently, never crash the renderer."""
+    error = {
+        "detail": [
+            # Wrong root prefix
+            {"type": "value_error", "loc": ["body", "headers", "x-test"], "msg": "bad", "input": "x"},
+            # schema_index is not an int
+            {
+                "type": "value_error",
+                "loc": ["body", "schemas", "not-an-int", "nodes", 0, "name"],
+                "msg": "bad",
+                "input": "x",
+            },
+            # Unknown container
+            {
+                "type": "value_error",
+                "loc": ["body", "schemas", 0, "wat", 0, "name"],
+                "msg": "bad",
+                "input": "x",
+            },
+            # Extensions path with non-int node index — was the original crash
+            {
+                "type": "value_error",
+                "loc": ["body", "schemas", 0, "extensions", "generics", "include_in_menu"],
+                "msg": "bad",
+                "input": "x",
+            },
+        ]
+    }
+
+    with mock.patch("infrahub_sdk.ctl.schema.console", Console(file=StringIO(), width=1000)) as console:
+        display_schema_load_errors(response=error, schemas_data=[])
+        output = console.file.getvalue()
+        assert output == "Unable to load the schema:\n"
+
+
 def test_schema_base__get_schema_name__returns_correct_schema_name_for_protocols() -> None:
     assert InfrahubSchemaBase._get_schema_name(schema=BuiltinTagSync) == "BuiltinTag"
     assert InfrahubSchemaBase._get_schema_name(schema=BuiltinTag) == "BuiltinTag"


### PR DESCRIPTION
# Why

  `infrahubctl schema load` crashes with an unhandled `ValueError` when the
  server rejects a schema that uses the `extensions:` block. The traceback replaces the
  human-readable rejection message, so users have no idea what the server
  actually rejected.

  **Goal:** Render extensions-block rejections in the same one-line format as
  top-level rejections.

  **Non-goals:** No new error categories, no changes to `infrahubctl schema
  check` or to the server's rejection format, no broader refactor of the CLI
  schema commands.

  Closes #1007

  ## What changed

  **Behavioral changes**

  - Schema rejections originating inside an `extensions:` block now render as
    `Node: <kind> (extensions/<container>) | <field> (<input>) | <msg> (<type>)`
    instead of crashing with `ValueError: invalid literal for int() with base 10`.
  - Unknown / malformed `loc_path` shapes (non-int schema index, unrecognised
    container) are skipped silently instead of crashing the renderer.
  - Top-level (non-extension) error rendering is byte-for-byte unchanged —
    preserved by the existing tests.

  **Implementation notes**

  - `display_schema_load_errors` now branches on `loc_path[3] == "extensions"`,
    computes `container / node_index / tail` once, and dispatches on `len(tail)`
    instead of `len(loc_path)` so the offset shift doesn't have to be repeated.
  - Per-error rendering extracted into `_render_schema_error` to keep the main
    loop within the project's branch-count limits.
  - `valid_error_path` now whitelists `loc_path[3] in {nodes, generics,
    extensions}` and requires `loc_path[2]` (and the node-index slot) to be `int`.
  - `get_node` gained `container` and `is_extension` kwargs (defaults match the
    old behaviour) and uses `payload.get(...)` so a schema file with only
    `extensions:` no longer raises `KeyError`.

  **What stayed the same**

  - API contract of `display_schema_load_errors` unchanged.
  - `get_node` signature is backward-compatible (new params have defaults).
  - Output format for non-extension errors is unchanged.

  ## How to review

  - `infrahub_sdk/ctl/schema.py` — start with `_render_schema_error`, then
    `valid_error_path`, then `get_node`.
  - `tests/unit/sdk/test_schema.py` — three new tests cover top-level extensions
    errors, nested-attribute extensions errors, and the malformed-path filter.
  - The pre-existing tests for non-extension paths are intentionally untouched
    and still pass — that's the regression guard for the format-stability claim
    above.

  The `valid_error_path` whitelist is the area I'd most want a second opinion
  on: if the server later adds a new top-level container, errors against it
  will now be silently skipped instead of bubbling up. The trade-off is
  intentional for a CLI rendering helper, but worth flagging.

  ## How to test

  ```bash
  # Repro from the issue (requires a running Infrahub 1.5+ with DcimGenericDevice
  # already loaded, e.g. opsmill/schema-library base/dcim.yml):
  cat > /tmp/repro_extension.yml <<'YAML'
  ---
  version: "1.0"
  extensions:
    generics:
      - kind: DcimGenericDevice
        include_in_menu: false
  YAML
  infrahubctl schema load /tmp/repro_extension.yml
  # Before: ValueError traceback. After: one-line "Node: DcimGenericDevice (extensions/generics) | ..." rendering.

  # Unit tests:
  uv run pytest tests/unit/sdk/test_schema.py -k display_schema_load_errors -v

  # Lint:
  uv run invoke format lint-code
  ```

  ## Impact & rollout

  - **Backward compatibility:** No breaking changes. CLI output for non-extension
    errors is unchanged. `get_node` gained two optional kwargs with defaults.
  - **Performance:** N/A — only touched on the error path of `schema load`.
  - **Config/env changes:** None.
  - **Deployment notes:** Safe to deploy. Pure SDK/CLI fix, no server-side change.

  ## Checklist

  - [x] Tests added/updated
  - [ ] Changelog entry added (`uv run towncrier create +fix-schema-load-extensions.fixed.md`)
  - [ ] External docs updated (if user-facing or ops-facing change)
  - [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)

