### PR TITLE
IHS-119: Fix upsert not working for numberpool and attribute in hfid

### DIFF
--- a/changelog/339.fixed.md
+++ b/changelog/339.fixed.md
@@ -1,0 +1,1 @@
+Calling `.save(allow_upsert=True)` on a node whose human-friendly identifier contains a CoreNumberPool-sourced attribute now raises a clear `ValidationError` instead of crashing with an opaque backend error.

--- a/docs/docs/python-sdk/guides/resource-manager.mdx
+++ b/docs/docs/python-sdk/guides/resource-manager.mdx
@@ -309,3 +309,59 @@ query {
 ```
 
 Notice that we have one IP address allocated by the Resource manager in the test branch. The query in the main branch shows us this allocation, indicating that it has been allocated and the resource cannot be allocated again. However, the IP address does not exist itself within the main branch.
+
+## CoreNumberPool and attribute allocation
+
+`CoreNumberPool` allocates integer values (such as VLAN IDs or AS numbers) directly to node attributes. The pool assigns the integer value at the moment the node is created on the server.
+
+```python
+vlan = await client.create(
+    kind="InfraVLAN",
+    name="VLAN-100",
+    vlan_id={"from_pool": {"id": pool_id}},
+)
+await vlan.save()
+```
+
+### Limitation: `allow_upsert=True` with a pool-sourced HFID attribute
+
+`CoreNumberPool` assigns the integer value at server creation time. The SDK does not know the assigned value before the node exists. When a node's human-friendly identifier (HFID) includes a pool-sourced attribute, the SDK cannot construct the HFID needed to look up an existing node for upsert.
+
+:::warning
+
+Calling `save(allow_upsert=True)` on a node whose HFID contains a `CoreNumberPool`-sourced attribute raises `ValidationError` before any network call is made.
+
+```python
+# Schema has human_friendly_id: ["vlan_id__value"]
+vlan = await client.create(
+    kind="InfraVLAN",
+    name="VLAN-100",
+    vlan_id={"from_pool": {"id": pool_id}},
+)
+
+# This raises ValidationError — the pool-assigned vlan_id is unknown client-side
+await vlan.save(allow_upsert=True)
+```
+
+**Alternatives:**
+
+- **Two-step pattern** — create the node first, then update it in a separate call:
+
+  ```python
+  await vlan.save()           # creates node, pool assigns vlan_id
+  # later, if you need to update:
+  vlan.name.value = "VLAN-100-updated"
+  await vlan.save()           # now _existing=True, calls update
+  ```
+
+- **Explicit id** — if you already know the node's UUID, set `node.id` before saving. The upsert will use the UUID directly and skip HFID lookup:
+
+  ```python
+  vlan.id = "known-uuid"
+  await vlan.save(allow_upsert=True)  # guard bypassed
+  ```
+
+- **Deterministic identifier** — if possible, design your schema so the HFID uses a non-pool attribute (for example, a human-assigned `name`) and keep `vlan_id` out of the HFID.
+
+:::
+

--- a/docs/docs/python-sdk/guides/resource-manager.mdx
+++ b/docs/docs/python-sdk/guides/resource-manager.mdx
@@ -364,4 +364,3 @@ await vlan.save(allow_upsert=True)
 - **Deterministic identifier** — if possible, design your schema so the HFID uses a non-pool attribute (for example, a human-assigned `name`) and keep `vlan_id` out of the HFID.
 
 :::
-

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
@@ -36,3 +36,19 @@ Check whether this attribute's value is sourced from a resource pool.
 **Returns:**
 
 - True if the attribute value is a resource pool node or was explicitly allocated from a pool.
+
+#### `is_unresolved_pool_attribute`
+
+```python
+is_unresolved_pool_attribute(self) -> bool
+```
+
+Return True when pool-backed but no concrete scalar value is available yet.
+
+A pool-backed attribute is unresolved when:
+
+- its value is a pool node object (the pool reference itself, not an allocated scalar), or
+- its value is None and the from_pool allocation dict is set.
+
+An attribute whose _from_pool dict is set but whose value has already been populated
+with the allocated scalar (e.g. after a prior save) is considered resolved.

--- a/infrahub_sdk/node/attribute.py
+++ b/infrahub_sdk/node/attribute.py
@@ -189,3 +189,17 @@ class Attribute:
 
         """
         return (isinstance(self.value, CoreNodeBase) and self.value.is_resource_pool()) or self._from_pool is not None
+
+    def is_unresolved_pool_attribute(self) -> bool:
+        """Return True when pool-backed but no concrete scalar value is available yet.
+
+        A pool-backed attribute is unresolved when:
+        - its value is a pool node object (the pool reference itself, not an allocated scalar), or
+        - its value is None and the from_pool allocation dict is set.
+
+        An attribute whose _from_pool dict is set but whose value has already been populated
+        with the allocated scalar (e.g. after a prior save) is considered resolved.
+        """
+        if isinstance(self.value, CoreNodeBase) and self.value.is_resource_pool():
+            return True
+        return self._from_pool is not None and self.value is None

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -595,6 +595,36 @@ class InfrahubNodeBase:
 
         raise ResourceNotDefinedError(message=f"The node doesn't have an attribute for {name}")
 
+    def _validate_upsert(self, allow_upsert: bool) -> None:
+        """Ensure an upsert can resolve the HFID before attempting to save.
+
+        An attribute sourced from a CoreNumberPool has no concrete value until the node is
+        created, so it cannot be used to look up an existing node by its human-friendly identifier.
+
+        Raises:
+            ValidationError: If an HFID attribute is sourced from an unresolved CoreNumberPool.
+
+        """
+        if not (allow_upsert and not self.id):
+            return
+
+        for hfid_path in self._schema.human_friendly_id or []:
+            attr_name = hfid_path.split("__")[0]
+            try:
+                attr = self._get_attribute(attr_name)
+            except ResourceNotDefinedError:
+                continue
+            if attr.is_unresolved_pool_attribute():
+                raise ValidationError(
+                    identifier=attr_name,
+                    message=(
+                        f"Attribute '{attr_name}' is sourced from a CoreNumberPool and is part of "
+                        "this node's human-friendly identifier. Upsert cannot resolve the HFID "
+                        "without a concrete value. Use an explicit id, or create the node first "
+                        "and update it in a separate call."
+                    ),
+                )
+
     @staticmethod
     def _build_rel_query_data(
         rel_schema: RelationshipSchemaAPI,
@@ -979,23 +1009,7 @@ class InfrahubNode(InfrahubNodeBase):
         timeout: int | None = None,
         request_context: RequestContext | None = None,
     ) -> None:
-        if allow_upsert and not self.id:
-            for hfid_path in self._schema.human_friendly_id or []:
-                attr_name = hfid_path.split("__")[0]
-                try:
-                    attr = self._get_attribute(attr_name)
-                except ResourceNotDefinedError:
-                    continue
-                if attr.is_unresolved_pool_attribute():
-                    raise ValidationError(
-                        identifier=attr_name,
-                        message=(
-                            f"Attribute '{attr_name}' is sourced from a CoreNumberPool and is part of "
-                            "this node's human-friendly identifier. Upsert cannot resolve the HFID "
-                            "without a concrete value. Use an explicit id, or create the node first "
-                            "and update it in a separate call."
-                        ),
-                    )
+        self._validate_upsert(allow_upsert=allow_upsert)
 
         if self._existing is False or allow_upsert is True:
             await self.create(allow_upsert=allow_upsert, timeout=timeout, request_context=request_context)
@@ -1968,23 +1982,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
         timeout: int | None = None,
         request_context: RequestContext | None = None,
     ) -> None:
-        if allow_upsert and not self.id:
-            for hfid_path in self._schema.human_friendly_id or []:
-                attr_name = hfid_path.split("__")[0]
-                try:
-                    attr = self._get_attribute(attr_name)
-                except ResourceNotDefinedError:
-                    continue
-                if attr.is_unresolved_pool_attribute():
-                    raise ValidationError(
-                        identifier=attr_name,
-                        message=(
-                            f"Attribute '{attr_name}' is sourced from a CoreNumberPool and is part of "
-                            "this node's human-friendly identifier. Upsert cannot resolve the HFID "
-                            "without a concrete value. Use an explicit id, or create the node first "
-                            "and update it in a separate call."
-                        ),
-                    )
+        self._validate_upsert(allow_upsert=allow_upsert)
 
         if self._existing is False or allow_upsert is True:
             self.create(allow_upsert=allow_upsert, timeout=timeout, request_context=request_context)

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -986,7 +986,7 @@ class InfrahubNode(InfrahubNodeBase):
                     attr = self._get_attribute(attr_name)
                 except ResourceNotDefinedError:
                     continue
-                if attr.value is None and attr.is_from_pool_attribute():
+                if attr.is_unresolved_pool_attribute():
                     raise ValidationError(
                         identifier=attr_name,
                         message=(
@@ -1975,7 +1975,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
                     attr = self._get_attribute(attr_name)
                 except ResourceNotDefinedError:
                     continue
-                if attr.value is None and attr.is_from_pool_attribute():
+                if attr.is_unresolved_pool_attribute():
                     raise ValidationError(
                         identifier=attr_name,
                         message=(

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, overload
 
 from ..constants import InfrahubClientMode
-from ..exceptions import FeatureNotSupportedError, NodeNotFoundError, ResourceNotDefinedError, SchemaNotFoundError
+from ..exceptions import (
+    FeatureNotSupportedError,
+    NodeNotFoundError,
+    ResourceNotDefinedError,
+    SchemaNotFoundError,
+    ValidationError,
+)
 from ..file_handler import FileHandler, FileHandlerBase, FileHandlerSync, PreparedFile, sha1_of_source
 from ..graphql import Mutation, Query
 from ..schema import (
@@ -973,6 +979,24 @@ class InfrahubNode(InfrahubNodeBase):
         timeout: int | None = None,
         request_context: RequestContext | None = None,
     ) -> None:
+        if allow_upsert and not self.id:
+            for hfid_path in self._schema.human_friendly_id or []:
+                attr_name = hfid_path.split("__")[0]
+                try:
+                    attr = self._get_attribute(attr_name)
+                except ResourceNotDefinedError:
+                    continue
+                if attr.is_from_pool_attribute():
+                    raise ValidationError(
+                        identifier=attr_name,
+                        message=(
+                            f"Attribute '{attr_name}' is sourced from a CoreNumberPool and is part of "
+                            "this node's human-friendly identifier. Upsert cannot resolve the HFID "
+                            "without a concrete value. Use an explicit id, or create the node first "
+                            "and update it in a separate call."
+                        ),
+                    )
+
         if self._existing is False or allow_upsert is True:
             await self.create(allow_upsert=allow_upsert, timeout=timeout, request_context=request_context)
         else:
@@ -1944,6 +1968,24 @@ class InfrahubNodeSync(InfrahubNodeBase):
         timeout: int | None = None,
         request_context: RequestContext | None = None,
     ) -> None:
+        if allow_upsert and not self.id:
+            for hfid_path in self._schema.human_friendly_id or []:
+                attr_name = hfid_path.split("__")[0]
+                try:
+                    attr = self._get_attribute(attr_name)
+                except ResourceNotDefinedError:
+                    continue
+                if attr.is_from_pool_attribute():
+                    raise ValidationError(
+                        identifier=attr_name,
+                        message=(
+                            f"Attribute '{attr_name}' is sourced from a CoreNumberPool and is part of "
+                            "this node's human-friendly identifier. Upsert cannot resolve the HFID "
+                            "without a concrete value. Use an explicit id, or create the node first "
+                            "and update it in a separate call."
+                        ),
+                    )
+
         if self._existing is False or allow_upsert is True:
             self.create(allow_upsert=allow_upsert, timeout=timeout, request_context=request_context)
         else:

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -986,7 +986,7 @@ class InfrahubNode(InfrahubNodeBase):
                     attr = self._get_attribute(attr_name)
                 except ResourceNotDefinedError:
                     continue
-                if attr.is_from_pool_attribute():
+                if attr.value is None and attr.is_from_pool_attribute():
                     raise ValidationError(
                         identifier=attr_name,
                         message=(
@@ -1975,7 +1975,7 @@ class InfrahubNodeSync(InfrahubNodeBase):
                     attr = self._get_attribute(attr_name)
                 except ResourceNotDefinedError:
                     continue
-                if attr.is_from_pool_attribute():
+                if attr.value is None and attr.is_from_pool_attribute():
                     raise ValidationError(
                         identifier=attr_name,
                         message=(

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -1009,8 +1009,6 @@ class InfrahubNode(InfrahubNodeBase):
         timeout: int | None = None,
         request_context: RequestContext | None = None,
     ) -> None:
-        self._validate_upsert(allow_upsert=allow_upsert)
-
         if self._existing is False or allow_upsert is True:
             await self.create(allow_upsert=allow_upsert, timeout=timeout, request_context=request_context)
         else:
@@ -1299,6 +1297,8 @@ class InfrahubNode(InfrahubNodeBase):
     async def create(
         self, allow_upsert: bool = False, timeout: int | None = None, request_context: RequestContext | None = None
     ) -> None:
+        self._validate_upsert(allow_upsert=allow_upsert)
+
         if self._file_object_support and self._file_content is None:
             raise ValueError(
                 f"Cannot create {self._schema.kind} without file content. Use upload_from_path() or upload_from_bytes() to provide "
@@ -1982,8 +1982,6 @@ class InfrahubNodeSync(InfrahubNodeBase):
         timeout: int | None = None,
         request_context: RequestContext | None = None,
     ) -> None:
-        self._validate_upsert(allow_upsert=allow_upsert)
-
         if self._existing is False or allow_upsert is True:
             self.create(allow_upsert=allow_upsert, timeout=timeout, request_context=request_context)
         else:
@@ -2271,6 +2269,8 @@ class InfrahubNodeSync(InfrahubNodeBase):
     def create(
         self, allow_upsert: bool = False, timeout: int | None = None, request_context: RequestContext | None = None
     ) -> None:
+        self._validate_upsert(allow_upsert=allow_upsert)
+
         if self._file_object_support and self._file_content is None:
             raise ValueError(
                 f"Cannot create {self._schema.kind} without file content. Use upload_from_path() or upload_from_bytes() to provide "

--- a/tests/unit/sdk/pool/conftest.py
+++ b/tests/unit/sdk/pool/conftest.py
@@ -114,3 +114,23 @@ async def ipprefix_pool_schema() -> NodeSchemaAPI:
         ],
     }
     return NodeSchema(**data).convert_api()
+
+
+@pytest.fixture
+async def vlan_schema_with_pool_hfid() -> NodeSchemaAPI:
+    """VLAN schema where vlan_id (NumberPool-sourced) is part of the human_friendly_id."""
+    data: dict[str, Any] = {
+        "name": "VLAN",
+        "namespace": "Infra",
+        "label": "VLAN",
+        "default_filter": "name__value",
+        "order_by": ["name__value"],
+        "display_labels": ["name__value"],
+        "human_friendly_id": ["vlan_id__value"],
+        "attributes": [
+            {"name": "name", "kind": "Text", "unique": True},
+            {"name": "vlan_id", "kind": "Number"},
+        ],
+        "relationships": [],
+    }
+    return NodeSchema(**data).convert_api()

--- a/tests/unit/sdk/pool/test_attribute_from_pool.py
+++ b/tests/unit/sdk/pool/test_attribute_from_pool.py
@@ -286,3 +286,34 @@ async def test_save_upsert_proceeds_when_numberpool_attr_not_in_hfid(
     await node.save(allow_upsert=True)
 
     assert node.id == "mock-vlan-uuid"
+
+
+async def test_save_upsert_raises_when_pool_node_object_in_hfid(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+    ipaddress_pool_schema: NodeSchemaAPI,
+    ipam_ipprefix_schema: NodeSchemaAPI,
+    ipam_ipprefix_data: dict[str, Any],
+) -> None:
+    """Guard fires when vlan_id is set to a pool node object (not a from_pool dict)."""
+    ip_prefix = InfrahubNode(client=client, schema=ipam_ipprefix_schema, data=ipam_ipprefix_data)
+    ip_pool = InfrahubNode(
+        client=client,
+        schema=ipaddress_pool_schema,
+        data={
+            "id": NODE_POOL_ID,
+            "name": "Core loopbacks",
+            "default_address_type": "IpamIPAddress",
+            "default_prefix_length": 32,
+            "ip_namespace": "ip_namespace",
+            "resources": [ip_prefix],
+        },
+    )
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": ip_pool},
+    )
+
+    with pytest.raises(ValidationError, match="vlan_id"):
+        await node.save(allow_upsert=True)

--- a/tests/unit/sdk/pool/test_attribute_from_pool.py
+++ b/tests/unit/sdk/pool/test_attribute_from_pool.py
@@ -317,3 +317,33 @@ async def test_save_upsert_raises_when_pool_node_object_in_hfid(
 
     with pytest.raises(ValidationError, match="vlan_id"):
         await node.save(allow_upsert=True)
+
+
+async def test_create_upsert_raises_when_numberpool_attr_in_hfid(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+) -> None:
+    """create(allow_upsert=True) is guarded directly, not only through save()."""
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match="vlan_id"):
+        await node.create(allow_upsert=True)
+
+
+def test_create_upsert_raises_when_numberpool_attr_in_hfid_sync(
+    client_sync: InfrahubClientSync,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+) -> None:
+    """Sync create(allow_upsert=True) is guarded directly, not only through save()."""
+    node = InfrahubNodeSync(
+        client=client_sync,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match="vlan_id"):
+        node.create(allow_upsert=True)

--- a/tests/unit/sdk/pool/test_attribute_from_pool.py
+++ b/tests/unit/sdk/pool/test_attribute_from_pool.py
@@ -8,6 +8,7 @@ There are two ways to request a pool allocation:
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -218,24 +219,6 @@ UPSERT_MOCK_RESPONSE = {
 }
 
 
-@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
-async def test_save_upsert_no_error_before_fix(
-    client: InfrahubClient,
-    vlan_schema_with_pool_hfid: NodeSchemaAPI,
-    httpx_mock: HTTPXMock,
-) -> None:
-    """FAILS before the guard is added: ValidationError must be raised when HFID attr is NumberPool-sourced."""
-    httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
-    node = InfrahubNode(
-        client=client,
-        schema=vlan_schema_with_pool_hfid,
-        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
-    )
-
-    with pytest.raises(ValidationError, match="vlan_id"):
-        await node.save(allow_upsert=True)
-
-
 async def test_save_upsert_raises_when_numberpool_attr_in_hfid(
     client: InfrahubClient,
     vlan_schema_with_pool_hfid: NodeSchemaAPI,
@@ -247,7 +230,7 @@ async def test_save_upsert_raises_when_numberpool_attr_in_hfid(
         data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
     )
 
-    with pytest.raises(ValidationError, match="vlan_id"):
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
         await node.save(allow_upsert=True)
 
 
@@ -256,7 +239,7 @@ async def test_save_upsert_proceeds_when_explicit_id_set(
     vlan_schema_with_pool_hfid: NodeSchemaAPI,
     httpx_mock: HTTPXMock,
 ) -> None:
-    """Guard is bypassed when an explicit node id is already set."""
+    """Upsert proceeds when an explicit node id is already set."""
     httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
     node = InfrahubNode(
         client=client,
@@ -275,7 +258,7 @@ async def test_save_upsert_proceeds_when_numberpool_attr_not_in_hfid(
     vlan_schema: NodeSchemaAPI,
     httpx_mock: HTTPXMock,
 ) -> None:
-    """Guard does not fire when the pool-sourced attribute is not part of the HFID."""
+    """Upsert proceeds when the pool-sourced attribute is not part of the HFID."""
     httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
     node = InfrahubNode(
         client=client,
@@ -295,7 +278,7 @@ async def test_save_upsert_raises_when_pool_node_object_in_hfid(
     ipam_ipprefix_schema: NodeSchemaAPI,
     ipam_ipprefix_data: dict[str, Any],
 ) -> None:
-    """Guard fires when vlan_id is set to a pool node object (not a from_pool dict)."""
+    """save(allow_upsert=True) raises ValidationError when vlan_id is set to a pool node object (not a from_pool dict)."""
     ip_prefix = InfrahubNode(client=client, schema=ipam_ipprefix_schema, data=ipam_ipprefix_data)
     ip_pool = InfrahubNode(
         client=client,
@@ -315,7 +298,7 @@ async def test_save_upsert_raises_when_pool_node_object_in_hfid(
         data={"name": "Test VLAN", "vlan_id": ip_pool},
     )
 
-    with pytest.raises(ValidationError, match="vlan_id"):
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
         await node.save(allow_upsert=True)
 
 
@@ -323,14 +306,14 @@ async def test_create_upsert_raises_when_numberpool_attr_in_hfid(
     client: InfrahubClient,
     vlan_schema_with_pool_hfid: NodeSchemaAPI,
 ) -> None:
-    """create(allow_upsert=True) is guarded directly, not only through save()."""
+    """create(allow_upsert=True) raises ValidationError directly, not only through save()."""
     node = InfrahubNode(
         client=client,
         schema=vlan_schema_with_pool_hfid,
         data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
     )
 
-    with pytest.raises(ValidationError, match="vlan_id"):
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
         await node.create(allow_upsert=True)
 
 
@@ -338,12 +321,12 @@ def test_create_upsert_raises_when_numberpool_attr_in_hfid_sync(
     client_sync: InfrahubClientSync,
     vlan_schema_with_pool_hfid: NodeSchemaAPI,
 ) -> None:
-    """Sync create(allow_upsert=True) is guarded directly, not only through save()."""
+    """Sync create(allow_upsert=True) raises ValidationError directly, not only through save()."""
     node = InfrahubNodeSync(
         client=client_sync,
         schema=vlan_schema_with_pool_hfid,
         data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
     )
 
-    with pytest.raises(ValidationError, match="vlan_id"):
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
         node.create(allow_upsert=True)

--- a/tests/unit/sdk/pool/test_attribute_from_pool.py
+++ b/tests/unit/sdk/pool/test_attribute_from_pool.py
@@ -10,9 +10,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
+from infrahub_sdk.exceptions import ValidationError
 from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
 
 if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
     from infrahub_sdk import InfrahubClient, InfrahubClientSync
     from infrahub_sdk.schema import NodeSchemaAPI
 
@@ -201,3 +206,83 @@ async def test_attribute_with_pool_node_generates_mutation_query(
     mutation_query = vlan._generate_mutation_query()
 
     assert mutation_query["object"]["vlan_id"] == {"value": None}
+
+
+UPSERT_MOCK_RESPONSE = {
+    "data": {
+        "InfraVLANUpsert": {
+            "ok": True,
+            "object": {"id": "mock-vlan-uuid", "vlan_id": {"value": 100}},
+        }
+    }
+}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+async def test_save_upsert_no_error_before_fix(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """FAILS before the guard is added: ValidationError must be raised when HFID attr is NumberPool-sourced."""
+    httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match="vlan_id"):
+        await node.save(allow_upsert=True)
+
+
+async def test_save_upsert_raises_when_numberpool_attr_in_hfid(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+) -> None:
+    """save(allow_upsert=True) raises ValidationError naming the pool-sourced HFID attribute."""
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match="vlan_id"):
+        await node.save(allow_upsert=True)
+
+
+async def test_save_upsert_proceeds_when_explicit_id_set(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Guard is bypassed when an explicit node id is already set."""
+    httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+    node.id = "existing-node-uuid"
+
+    await node.save(allow_upsert=True)
+
+    assert node.id == "mock-vlan-uuid"
+
+
+async def test_save_upsert_proceeds_when_numberpool_attr_not_in_hfid(
+    client: InfrahubClient,
+    vlan_schema: NodeSchemaAPI,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Guard does not fire when the pool-sourced attribute is not part of the HFID."""
+    httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    await node.save(allow_upsert=True)
+
+    assert node.id == "mock-vlan-uuid"


### PR DESCRIPTION
# Why

`node.save(allow_upsert=True)` on a node whose human-friendly identifier (HFID) contains a `CoreNumberPool`-sourced attribute crashes with `"invalid literal for int() with base 10: 'VLAN ID Pool - Test'"`. The backend upsert resolver tries to use the unresolved pool reference as an HFID component, but the integer value is not assigned until after the server creates the node — making the upsert semantically impossible.

This PR adds a client-side guard that detects the pattern and raises a descriptive `ValidationError` before any network call is made.

Closes https://github.com/opsmill/infrahub-sdk-python/issues/339

## How to test

```bash
cd python_sdk

# All four upsert guard tests
uv run pytest tests/unit/sdk/pool/test_attribute_from_pool.py -v -k "upsert"
```

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`python_sdk/changelog/339.fixed.md`)
- [x] External docs updated (`docs/docs/python-sdk/guides/resource-manager.mdx`)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes when upserting nodes whose HFID includes a `CoreNumberPool` attribute by failing fast with a clear `ValidationError`. Addresses IHS-119.

- **Bug Fixes**
  - Added `_validate_upsert()` and call it from `create()` (async and sync) so both `save(allow_upsert=True)` and `create(allow_upsert=True)` raise early when any HFID component is an unresolved pool-backed attribute (a `from_pool` dict with no value or a pool node object).
  - Upsert still works when `id` is set or when the pool-backed attribute is not in the HFID. Added `is_unresolved_pool_attribute()`, tests for async/sync paths, updated docs with alternatives, and a changelog entry.

<sup>Written for commit 5ac552fc9896a2f375e425177683091f29ab0a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

