### PR TITLE
docs: adjust links following doc migration

### DIFF
--- a/docs/docs/python-sdk/guides/object-storage.mdx
+++ b/docs/docs/python-sdk/guides/object-storage.mdx
@@ -2,7 +2,7 @@
 title: Using the object-storage
 ---
 
-The Python SDK can be used to interface with Infrahub's [object-storage]($(base_url)topics/object-storage).
+The Python SDK can be used to interface with Infrahub's [object-storage]($(base_url)artifact-file-storage/).
 
 ## Storing string objects to the object-storage
 

--- a/docs/docs/python-sdk/guides/object-storage.mdx
+++ b/docs/docs/python-sdk/guides/object-storage.mdx
@@ -2,7 +2,7 @@
 title: Using the object-storage
 ---
 
-The Python SDK can be used to interface with Infrahub's [object-storage]($(base_url)artifact-file-storage/).
+The Python SDK can be used to interface with Infrahub's [object-storage]($(base_url)artifact-file-storage/overview).
 
 ## Storing string objects to the object-storage
 

--- a/docs/docs/python-sdk/guides/query_data.mdx
+++ b/docs/docs/python-sdk/guides/query_data.mdx
@@ -504,7 +504,7 @@ Values of type `str` will be parsed using the [Pendulum](https://pendulum.eustac
 
 ### Properties of attributes and relationships
 
-By default, the [meta data or properties]($(base_url)topics/metadata) of attributes and relationships are not included. We can include these properties using the `property` argument of the SDK client's `all`, `filters` or `get` method.
+By default, the [meta data or properties]($(base_url)objects/metadata) of attributes and relationships are not included. We can include these properties using the `property` argument of the SDK client's `all`, `filters` or `get` method.
 
 <Tabs groupId="async-sync">
   <TabItem value="Async" default>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated internal links in Python SDK guides after the docs migration. The object storage link now points to artifact-file-storage/overview, and the metadata link now points to objects/metadata.

<sup>Written for commit 04ad71238b0dc7cf2f8c71c75fc2c2857306da18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

