### PR TITLE
Send operationName for GraphQL queries

### DIFF
--- a/changelog/+operation-name-payload.fixed.md
+++ b/changelog/+operation-name-payload.fixed.md
@@ -1,0 +1,1 @@
+Send the GraphQL operation name as `operationName` in the request payload so tracing and observability tools can identify each query.

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -224,7 +224,7 @@ Return a cloned version of the client using the same configuration.
 #### `execute_graphql`
 
 ```python
-execute_graphql(self, query: str, variables: dict | None = None, branch_name: str | None = None, at: str | Timestamp | None = None, timeout: int | None = None, tracker: str | None = None) -> dict
+execute_graphql(self, query: str, variables: dict | None = None, branch_name: str | None = None, at: str | Timestamp | None = None, timeout: int | None = None, tracker: str | None = None, operation_name: str | None = None) -> dict
 ```
 
 Execute a GraphQL query (or mutation).
@@ -238,6 +238,8 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 - `branch_name`: Name of the branch on which the query will be executed. Defaults to None.
 - `at`: Time when the query should be executed. Defaults to None.
 - `timeout`: Timeout in second for the query. Defaults to None.
+- `operation_name`: GraphQL operation name, sent as `operationName` in the request payload
+so tracing/observability tools can identify the operation. Defaults to None.
 
 **Returns:**
 
@@ -525,7 +527,7 @@ Return a cloned version of the client using the same configuration.
 #### `execute_graphql`
 
 ```python
-execute_graphql(self, query: str, variables: dict | None = None, branch_name: str | None = None, at: str | Timestamp | None = None, timeout: int | None = None, tracker: str | None = None) -> dict
+execute_graphql(self, query: str, variables: dict | None = None, branch_name: str | None = None, at: str | Timestamp | None = None, timeout: int | None = None, tracker: str | None = None, operation_name: str | None = None) -> dict
 ```
 
 Execute a GraphQL query (or mutation).
@@ -539,6 +541,8 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 - `branch_name`: Name of the branch on which the query will be executed. Defaults to None.
 - `at`: Time when the query should be executed. Defaults to None.
 - `timeout`: Timeout in second for the query. Defaults to None.
+- `operation_name`: GraphQL operation name, sent as `operationName` in the request payload
+so tracing/observability tools can identify the operation. Defaults to None.
 
 **Returns:**
 

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -186,7 +186,9 @@ class InfrahubBranchManager(InfraHubBranchManagerBase):
 
     async def all(self) -> dict[str, BranchData]:
         query = Query(name="GetAllBranch", query=QUERY_ALL_BRANCHES_DATA)
-        data = await self.client.execute_graphql(query=query.render(), tracker="query-branch-all")
+        data = await self.client.execute_graphql(
+            query=query.render(), tracker="query-branch-all", operation_name=query.name
+        )
 
         return {branch["name"]: BranchData(**branch) for branch in data["Branch"]}
 
@@ -196,6 +198,7 @@ class InfrahubBranchManager(InfraHubBranchManagerBase):
             query=query.render(),
             variables={"branch_name": branch_name},
             tracker="query-branch",
+            operation_name=query.name,
         )
 
         if not data["Branch"]:
@@ -226,7 +229,7 @@ class InfrahubBranchManagerSync(InfraHubBranchManagerBase):
 
     def all(self) -> dict[str, BranchData]:
         query = Query(name="GetAllBranch", query=QUERY_ALL_BRANCHES_DATA)
-        data = self.client.execute_graphql(query=query.render(), tracker="query-branch-all")
+        data = self.client.execute_graphql(query=query.render(), tracker="query-branch-all", operation_name=query.name)
 
         return {branch["name"]: BranchData(**branch) for branch in data["Branch"]}
 
@@ -236,6 +239,7 @@ class InfrahubBranchManagerSync(InfraHubBranchManagerBase):
             query=query.render(),
             variables={"branch_name": branch_name},
             tracker="query-branch",
+            operation_name=query.name,
         )
 
         if not data["Branch"]:

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -321,7 +321,7 @@ class InfrahubClient(BaseClient):
 
     async def get_user(self) -> dict:
         """Return user information."""
-        return await self.execute_graphql(query=QUERY_USER)
+        return await self.execute_graphql(query=QUERY_USER, operation_name="GET_PROFILE_DETAILS")
 
     async def get_user_permissions(self) -> dict:
         """Return user permissions."""
@@ -636,6 +636,7 @@ class InfrahubClient(BaseClient):
             branch_name=branch,
             at=at,
             timeout=timeout,
+            operation_name=query_name,
         )
         return int(response.get(schema.kind, {}).get("count", 0))
 
@@ -868,6 +869,7 @@ class InfrahubClient(BaseClient):
                 at=at,
                 tracker=f"query-{str(schema.kind).lower()}-page{page_number}",
                 timeout=timeout,
+                operation_name=query.name,
             )
 
             process_result: ProcessRelationsNode = await self._process_nodes_and_relationships(
@@ -943,6 +945,7 @@ class InfrahubClient(BaseClient):
         at: str | Timestamp | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
+        operation_name: str | None = None,
     ) -> dict:
         """Execute a GraphQL query (or mutation).
 
@@ -954,6 +957,8 @@ class InfrahubClient(BaseClient):
             branch_name (str, optional): Name of the branch on which the query will be executed. Defaults to None.
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
+            operation_name (str, optional): GraphQL operation name, sent as `operationName` in the request payload
+                so tracing/observability tools can identify the operation. Defaults to None.
 
         Returns:
             dict: The GraphQL data payload (response["data"]).
@@ -972,6 +977,8 @@ class InfrahubClient(BaseClient):
         payload: dict[str, str | dict] = {"query": query}
         if variables:
             payload["variables"] = variables
+        if operation_name:
+            payload["operationName"] = operation_name
 
         headers = copy.copy(self.headers or {})
         if self.insert_tracker and tracker:
@@ -1028,6 +1035,7 @@ class InfrahubClient(BaseClient):
         branch_name: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
+        operation_name: str | None = None,
     ) -> dict:
         """Execute a GraphQL mutation with a file upload using multipart/form-data.
 
@@ -1073,6 +1081,7 @@ class InfrahubClient(BaseClient):
             file_name=file_name or "upload",
             headers=headers,
             timeout=timeout,
+            operation_name=operation_name,
         )
 
         resp.raise_for_status()
@@ -1093,6 +1102,7 @@ class InfrahubClient(BaseClient):
         file_name: str,
         headers: dict | None = None,
         timeout: int | None = None,
+        operation_name: str | None = None,
     ) -> httpx.Response:
         """Execute a HTTP POST with multipart/form-data for GraphQL file uploads.
 
@@ -1108,7 +1118,11 @@ class InfrahubClient(BaseClient):
 
         # Build the multipart form data according to GraphQL Multipart Request Spec
         files = MultipartBuilder.build_payload(
-            query=query, variables=variables, file_content=file_content, file_name=file_name
+            query=query,
+            variables=variables,
+            file_content=file_content,
+            file_name=file_name,
+            operation_name=operation_name,
         )
 
         return await self._request_multipart(
@@ -1441,6 +1455,7 @@ class InfrahubClient(BaseClient):
             timeout=timeout,
             tracker=tracker,
             variables=input_data,
+            operation_name="GetDiffTree",
         )
 
         node_diffs: list[NodeDiff] = []
@@ -1488,6 +1503,7 @@ class InfrahubClient(BaseClient):
             timeout=timeout,
             tracker=tracker,
             variables=input_data,
+            operation_name=query.name,
         )
 
         diff_tree = response["DiffTree"]
@@ -1819,7 +1835,7 @@ class InfrahubClientSync(BaseClient):
 
     def get_user(self) -> dict:
         """Return user information."""
-        return self.execute_graphql(query=QUERY_USER)
+        return self.execute_graphql(query=QUERY_USER, operation_name="GET_PROFILE_DETAILS")
 
     def get_user_permissions(self) -> dict:
         """Return user permissions."""
@@ -1879,6 +1895,7 @@ class InfrahubClientSync(BaseClient):
         at: str | Timestamp | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
+        operation_name: str | None = None,
     ) -> dict:
         """Execute a GraphQL query (or mutation).
 
@@ -1890,6 +1907,8 @@ class InfrahubClientSync(BaseClient):
             branch_name (str, optional): Name of the branch on which the query will be executed. Defaults to None.
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
+            operation_name (str, optional): GraphQL operation name, sent as `operationName` in the request payload
+                so tracing/observability tools can identify the operation. Defaults to None.
 
         Returns:
             dict: The GraphQL data payload (`response["data"]`).
@@ -1908,6 +1927,8 @@ class InfrahubClientSync(BaseClient):
         payload: dict[str, str | dict] = {"query": query}
         if variables:
             payload["variables"] = variables
+        if operation_name:
+            payload["operationName"] = operation_name
 
         headers = copy.copy(self.headers or {})
         if self.insert_tracker and tracker:
@@ -1964,6 +1985,7 @@ class InfrahubClientSync(BaseClient):
         branch_name: str | None = None,
         timeout: int | None = None,
         tracker: str | None = None,
+        operation_name: str | None = None,
     ) -> dict:
         """Execute a GraphQL mutation with a file upload using multipart/form-data.
 
@@ -2009,6 +2031,7 @@ class InfrahubClientSync(BaseClient):
             file_name=file_name or "upload",
             headers=headers,
             timeout=timeout,
+            operation_name=operation_name,
         )
 
         resp.raise_for_status()
@@ -2029,6 +2052,7 @@ class InfrahubClientSync(BaseClient):
         file_name: str,
         headers: dict | None = None,
         timeout: int | None = None,
+        operation_name: str | None = None,
     ) -> httpx.Response:
         """Execute a HTTP POST with multipart/form-data for GraphQL file uploads.
 
@@ -2044,7 +2068,11 @@ class InfrahubClientSync(BaseClient):
 
         # Build the multipart form data according to GraphQL Multipart Request Spec
         files = MultipartBuilder.build_payload(
-            query=query, variables=variables, file_content=file_content, file_name=file_name
+            query=query,
+            variables=variables,
+            file_content=file_content,
+            file_name=file_name,
+            operation_name=operation_name,
         )
 
         return self._request_multipart(url=url, headers=headers, timeout=timeout or self.default_timeout, files=files)
@@ -2115,6 +2143,7 @@ class InfrahubClientSync(BaseClient):
             branch_name=branch,
             at=at,
             timeout=timeout,
+            operation_name=query_name,
         )
         return int(response.get(schema.kind, {}).get("count", 0))
 
@@ -2388,6 +2417,7 @@ class InfrahubClientSync(BaseClient):
                 at=at,
                 timeout=timeout,
                 tracker=f"query-{str(schema.kind).lower()}-page{page_number}",
+                operation_name=query.name,
             )
 
             process_result: ProcessRelationsNodeSync = self._process_nodes_and_relationships(
@@ -2777,6 +2807,7 @@ class InfrahubClientSync(BaseClient):
             timeout=timeout,
             tracker=tracker,
             variables=input_data,
+            operation_name="GetDiffTree",
         )
 
         node_diffs: list[NodeDiff] = []
@@ -2824,6 +2855,7 @@ class InfrahubClientSync(BaseClient):
             timeout=timeout,
             tracker=tracker,
             variables=input_data,
+            operation_name=query.name,
         )
 
         diff_tree = response["DiffTree"]

--- a/infrahub_sdk/graphql/multipart.py
+++ b/infrahub_sdk/graphql/multipart.py
@@ -28,18 +28,22 @@ class MultipartBuilder:
     """
 
     @staticmethod
-    def build_operations(query: str, variables: dict[str, Any]) -> str:
+    def build_operations(query: str, variables: dict[str, Any], operation_name: str | None = None) -> str:
         """Build the operations JSON string.
 
         Args:
             query: The GraphQL query string.
             variables: The variables dict (file variable should be null).
+            operation_name: Optional GraphQL operation name, included as `operationName` when set.
 
         Returns:
-            JSON string containing the query and variables.
+            JSON string containing the query, variables, and optional operation name.
 
         """
-        return ujson.dumps({"query": query, "variables": variables})
+        operations: dict[str, Any] = {"query": query, "variables": variables}
+        if operation_name:
+            operations["operationName"] = operation_name
+        return ujson.dumps(operations)
 
     @staticmethod
     def build_file_map(file_key: str = "0", variable_path: str = "variables.file") -> str:
@@ -61,6 +65,7 @@ class MultipartBuilder:
         variables: dict[str, Any],
         file_content: BinaryIO | None = None,
         file_name: str = "upload",
+        operation_name: str | None = None,
     ) -> dict[str, Any]:
         """Build the complete multipart form data payload.
 
@@ -91,7 +96,7 @@ class MultipartBuilder:
         # Ensure file variable is null (spec requirement)
         variables = {**variables, "file": None}
 
-        operations = MultipartBuilder.build_operations(query=query, variables=variables)
+        operations = MultipartBuilder.build_operations(query=query, variables=variables, operation_name=operation_name)
         file_map = MultipartBuilder.build_file_map()
 
         files: dict[str, Any] = {"operations": (None, operations), "map": (None, file_map)}

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -737,8 +737,9 @@ async def test_query_name_count(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query MyCountQuery {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query MyCountQuery {" in payload["query"]
+    assert payload["operationName"] == "MyCountQuery"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -752,8 +753,9 @@ async def test_query_name_all(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query MyAllQuery {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query MyAllQuery {" in payload["query"]
+    assert payload["operationName"] == "MyAllQuery"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -767,8 +769,9 @@ async def test_query_name_filters(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query MyFiltersQuery {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query MyFiltersQuery {" in payload["query"]
+    assert payload["operationName"] == "MyFiltersQuery"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -784,8 +787,9 @@ async def test_query_name_get(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query MyGetQuery {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query MyGetQuery {" in payload["query"]
+    assert payload["operationName"] == "MyGetQuery"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -799,8 +803,9 @@ async def test_query_name_for_count_ommitted(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query Count_CoreRepository {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query Count_CoreRepository {" in payload["query"]
+    assert payload["operationName"] == "Count_CoreRepository"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -814,8 +819,9 @@ async def test_query_name_for_all_ommitted(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query All_CoreRepository {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query All_CoreRepository {" in payload["query"]
+    assert payload["operationName"] == "All_CoreRepository"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -829,8 +835,9 @@ async def test_query_name_for_filters_ommitted(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query Filters_CoreRepository {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query Filters_CoreRepository {" in payload["query"]
+    assert payload["operationName"] == "Filters_CoreRepository"
 
 
 @pytest.mark.parametrize("client_type", client_types)
@@ -844,5 +851,24 @@ async def test_query_name_for_get_ommitted(
 
     post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
     assert len(post_requests) == 1
-    query = json.loads(post_requests[0].content)["query"]
-    assert "query Get_CoreRepository {" in query
+    payload = json.loads(post_requests[0].content)
+    assert "query Get_CoreRepository {" in payload["query"]
+    assert payload["operationName"] == "Get_CoreRepository"
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_execute_graphql_omits_operation_name_when_unset(
+    httpx_mock: HTTPXMock, clients: BothClients, client_type: str
+) -> None:
+    httpx_mock.add_response(method="POST", json={"data": {"InfrahubInfo": {"version": "1.0"}}})
+
+    raw_query = "query { InfrahubInfo { version }}"
+    if client_type == "standard":
+        await clients.standard.execute_graphql(query=raw_query)
+    else:
+        clients.sync.execute_graphql(query=raw_query)
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    payload = json.loads(post_requests[0].content)
+    assert "operationName" not in payload


### PR DESCRIPTION
# Why

Fatih requested to have the operationName sent by the SDK as it's useful for the observability stack when tracking individual requests, for example to troubleshoot long running generators

## What changed

* Various updates to send a `operationName` key in the payload