### PR TITLE
Fix docstring formatting

### DIFF
--- a/docs/docs/infrahubctl/infrahubctl-graphql.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-graphql.mdx
@@ -37,7 +37,7 @@ $ infrahubctl graphql export-schema [OPTIONS]
 
 ## `infrahubctl graphql generate-return-types`
 
-Create Pydantic Models for GraphQL query return types
+Create Pydantic Models for GraphQL query return types.
 
 **Usage**:
 

--- a/docs/docs/infrahubctl/infrahubctl-validate.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-validate.mdx
@@ -21,7 +21,7 @@ $ infrahubctl validate [OPTIONS] COMMAND [ARGS]...
 
 ## `infrahubctl validate graphql-query`
 
-Validate the format of a GraphQL Query stored locally by executing it on a remote GraphQL endpoint
+Validate the format of a GraphQL Query stored locally by executing it on a remote GraphQL endpoint.
 
 **Usage**:
 
@@ -44,7 +44,7 @@ $ infrahubctl validate graphql-query [OPTIONS] QUERY [VARIABLES]...
 
 ## `infrahubctl validate schema`
 
-Validate the format of a schema file either in JSON or YAML
+Validate the format of a schema file either in JSON or YAML.
 
 **Usage**:
 

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -101,7 +101,7 @@ Return the Infrahub version.
 get_user(self) -> dict
 ```
 
-Return user information
+Return user information.
 
 #### `get_user_permissions`
 
@@ -109,7 +109,7 @@ Return user information
 get_user_permissions(self) -> dict
 ```
 
-Return user permissions
+Return user permissions.
 
 #### `count`
 
@@ -140,7 +140,7 @@ all(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeo
 all(self, kind: str | type[SchemaType], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, query_name: str | None = None) -> list[InfrahubNode] | list[SchemaType]
 ```
 
-Retrieve all nodes of a given kind
+Retrieve all nodes of a given kind.
 
 **Args:**
 
@@ -219,7 +219,7 @@ Retrieve nodes of a given kind based on provided filters.
 clone(self, branch: str | None = None) -> InfrahubClient
 ```
 
-Return a cloned version of the client using the same configuration
+Return a cloned version of the client using the same configuration.
 
 #### `execute_graphql`
 
@@ -228,6 +228,7 @@ execute_graphql(self, query: str, variables: dict | None = None, branch_name: st
 ```
 
 Execute a GraphQL query (or mutation).
+
 If retry_on_failure is True, the query will retry until the server becomes reachable.
 
 **Args:**
@@ -238,6 +239,10 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 - `at`: Time when the query should be executed. Defaults to None.
 - `timeout`: Timeout in second for the query. Defaults to None.
 
+**Returns:**
+
+- The GraphQL data payload (response["data"]).
+
 **Raises:**
 
 - `GraphQLError`: When the GraphQL response contains errors.
@@ -245,10 +250,6 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 - `AuthenticationError`: If the server returns a 401 or 403 response.
 - `URLNotFoundError`: If the server returns a 404 response.
 - `Error`: If the response is unexpectedly missing.
-
-**Returns:**
-
-- The GraphQL data payload (response["data"]).
 
 #### `refresh_login`
 
@@ -405,10 +406,11 @@ repository_update_commit(self, branch_name: str, repository_id: str, commit: str
 convert_object_type(self, node_id: str, target_kind: str, branch: str | None = None, fields_mapping: dict[str, ConversionFieldInput] | None = None) -> InfrahubNode
 ```
 
-Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
-and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
-for more information.
+Convert a given node to another kind on a given branch.
+
+`fields_mapping` keys are target fields names and its values indicate how to fill in these fields.
+Any mandatory field not having an equivalent field in the source kind should be specified in this
+mapping. See https://docs.infrahub.app/guides/object-conversion for more information.
 
 ### `InfrahubClientSync`
 
@@ -502,7 +504,7 @@ Return the Infrahub version.
 get_user(self) -> dict
 ```
 
-Return user information
+Return user information.
 
 #### `get_user_permissions`
 
@@ -510,7 +512,7 @@ Return user information
 get_user_permissions(self) -> dict
 ```
 
-Return user permissions
+Return user permissions.
 
 #### `clone`
 
@@ -518,7 +520,7 @@ Return user permissions
 clone(self, branch: str | None = None) -> InfrahubClientSync
 ```
 
-Return a cloned version of the client using the same configuration
+Return a cloned version of the client using the same configuration.
 
 #### `execute_graphql`
 
@@ -527,6 +529,7 @@ execute_graphql(self, query: str, variables: dict | None = None, branch_name: st
 ```
 
 Execute a GraphQL query (or mutation).
+
 If retry_on_failure is True, the query will retry until the server becomes reachable.
 
 **Args:**
@@ -537,6 +540,10 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 - `at`: Time when the query should be executed. Defaults to None.
 - `timeout`: Timeout in second for the query. Defaults to None.
 
+**Returns:**
+
+- The GraphQL data payload (`response["data"]`).
+
 **Raises:**
 
 - `GraphQLError`: When the GraphQL response contains errors.
@@ -544,10 +551,6 @@ If retry_on_failure is True, the query will retry until the server becomes reach
 - `AuthenticationError`: If the server returns a 401 or 403 response.
 - `URLNotFoundError`: If the server returns a 404 response.
 - `Error`: If the response is unexpectedly missing.
-
-**Returns:**
-
-- The GraphQL data payload (`response["data"]`).
 
 #### `count`
 
@@ -578,7 +581,7 @@ all(self, kind: str, at: Timestamp | None = ..., branch: str | None = ..., timeo
 all(self, kind: str | type[SchemaTypeSync], at: Timestamp | None = None, branch: str | None = None, timeout: int | None = None, populate_store: bool = True, offset: int | None = None, limit: int | None = None, include: list[str] | None = None, exclude: list[str] | None = None, fragment: bool = False, prefetch_relationships: bool = False, property: bool = False, parallel: bool = False, order: Order | None = None, include_metadata: bool = False, query_name: str | None = None) -> list[InfrahubNodeSync] | list[SchemaTypeSync]
 ```
 
-Retrieve all nodes of a given kind
+Retrieve all nodes of a given kind.
 
 **Args:**
 
@@ -811,10 +814,11 @@ login(self, refresh: bool = False) -> None
 convert_object_type(self, node_id: str, target_kind: str, branch: str | None = None, fields_mapping: dict[str, ConversionFieldInput] | None = None) -> InfrahubNodeSync
 ```
 
-Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
-and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
-for more information.
+Convert a given node to another kind on a given branch.
+
+`fields_mapping` keys are target fields names and its values indicate how to fill in these fields.
+Any mandatory field not having an equivalent field in the source kind should be specified in this
+mapping. See https://docs.infrahub.app/guides/object-conversion for more information.
 
 ### `ProcessRelationsNode`
 
@@ -826,7 +830,7 @@ for more information.
 
 ### `BaseClient`
 
-Base class for InfrahubClient and InfrahubClientSync
+Base class for InfrahubClient and InfrahubClientSync.
 
 **Methods:**
 

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/node.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/node.mdx
@@ -626,7 +626,7 @@ caller re-fetches the node first.
 
 ### `InfrahubNodeBase`
 
-Base class for InfrahubNode and InfrahubNodeSync
+Base class for InfrahubNode and InfrahubNodeSync.
 
 **Methods:**
 

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/relationship.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/relationship.mdx
@@ -9,7 +9,7 @@ sidebarTitle: relationship
 
 ### `RelationshipManagerBase`
 
-Base class for RelationshipManager and RelationshipManagerSync
+Base class for RelationshipManager and RelationshipManagerSync.
 
 **Methods:**
 

--- a/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
+++ b/docs/docs_generation/content_gen_methods/mdx/mdx_collapsed_overload_section.py
@@ -8,10 +8,10 @@ from .mdx_section import ASection, MdxSection
 
 @dataclass
 class CollapsedOverloadSection(ASection):
-    """Collapses a group of overloaded method sections into one primary entry
-    followed by a collapsible ``<details>`` block with the remaining overloads.
+    """Collapse a group of overloaded method sections into a primary entry plus a details block.
 
-    The *primary* overload is the one with the most parameters (excluding
+    The remaining overloads are placed inside a collapsible ``<details>`` block following the
+    primary entry. The *primary* overload is the one with the most parameters (excluding
     ``self``).  On ties, the first in source order wins.
 
     Example::

--- a/infrahub_sdk/analyzer.py
+++ b/infrahub_sdk/analyzer.py
@@ -99,12 +99,12 @@ class GraphQLQueryAnalyzer:
         return response
 
     async def calculate_depth(self) -> int:
-        """Number of nested levels in the query"""
+        """Number of nested levels in the query."""
         fields = await self.get_fields()
         return calculate_dict_depth(data=fields)
 
     async def calculate_height(self) -> int:
-        """Total number of fields requested in the query"""
+        """Total number of fields requested in the query."""
         fields = await self.get_fields()
         return calculate_dict_height(data=fields)
 

--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -147,11 +147,12 @@ class InfrahubCheck:
         """Code to validate the status of this check."""
 
     async def collect_data(self) -> dict:
-        """Query the result of the GraphQL Query defined in self.query and return the result"""
+        """Query the result of the GraphQL Query defined in self.query and return the result."""
         return await self.client.query_gql_query(name=self.query, branch_name=self.branch_name, variables=self.params)
 
     async def run(self, data: dict | None = None) -> bool:
         """Execute the check after collecting the data from the GraphQL query.
+
         The result of the check is determined based on the presence or not of ERROR log messages.
         """
         if not data:

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -118,7 +118,7 @@ def get_kind_as_string(kind: str | type[SchemaType | SchemaTypeSync]) -> str:
 
 
 class BaseClient:
-    """Base class for InfrahubClient and InfrahubClientSync"""
+    """Base class for InfrahubClient and InfrahubClientSync."""
 
     def __init__(
         self,
@@ -159,7 +159,7 @@ class BaseClient:
         _ = self.config.tls_context  # Early load of the TLS context to catch errors
 
     def _initialize(self) -> None:
-        """Sets the properties for each version of the client"""
+        """Sets the properties for each version of the client."""
 
     def _record(self, response: httpx.Response) -> None:
         self.config.custom_recorder.record(response)
@@ -320,11 +320,11 @@ class InfrahubClient(BaseClient):
         return response.get("InfrahubInfo", {}).get("version", "")
 
     async def get_user(self) -> dict:
-        """Return user information"""
+        """Return user information."""
         return await self.execute_graphql(query=QUERY_USER)
 
     async def get_user_permissions(self) -> dict:
-        """Return user permissions"""
+        """Return user permissions."""
         user_info = await self.get_user()
         return get_user_permissions(user_info["AccountProfile"]["member_of_groups"]["edges"])
 
@@ -700,7 +700,7 @@ class InfrahubClient(BaseClient):
         include_metadata: bool = False,
         query_name: str | None = None,
     ) -> list[InfrahubNode] | list[SchemaType]:
-        """Retrieve all nodes of a given kind
+        """Retrieve all nodes of a given kind.
 
         Args:
             kind (str): kind of the nodes to query
@@ -932,7 +932,7 @@ class InfrahubClient(BaseClient):
         return nodes
 
     def clone(self, branch: str | None = None) -> InfrahubClient:
-        """Return a cloned version of the client using the same configuration"""
+        """Return a cloned version of the client using the same configuration."""
         return InfrahubClient(config=self.config.clone(branch=branch))
 
     async def execute_graphql(
@@ -945,6 +945,7 @@ class InfrahubClient(BaseClient):
         tracker: str | None = None,
     ) -> dict:
         """Execute a GraphQL query (or mutation).
+
         If retry_on_failure is True, the query will retry until the server becomes reachable.
 
         Args:
@@ -954,15 +955,15 @@ class InfrahubClient(BaseClient):
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
 
+        Returns:
+            dict: The GraphQL data payload (response["data"]).
+
         Raises:
             GraphQLError: When the GraphQL response contains errors.
             ServerNotReachableError: If the server is not reachable after exhausting retries.
             AuthenticationError: If the server returns a 401 or 403 response.
             URLNotFoundError: If the server returns a 404 response.
             Error: If the response is unexpectedly missing.
-
-        Returns:
-            dict: The GraphQL data payload (response["data"]).
 
         """
         branch_name = branch_name or self.default_branch
@@ -1042,11 +1043,11 @@ class InfrahubClient(BaseClient):
             timeout: Timeout in seconds for the query.
             tracker: Optional tracker for request tracing.
 
-        Raises:
-            GraphQLError: When the GraphQL response contains errors.
-
         Returns:
             dict: The GraphQL data payload (response["data"]).
+
+        Raises:
+            GraphQLError: When the GraphQL response contains errors.
 
         """
         branch_name = branch_name or self.default_branch
@@ -1769,10 +1770,11 @@ class InfrahubClient(BaseClient):
         branch: str | None = None,
         fields_mapping: dict[str, ConversionFieldInput] | None = None,
     ) -> InfrahubNode:
-        """Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
-        and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-        in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
-        for more information.
+        """Convert a given node to another kind on a given branch.
+
+        `fields_mapping` keys are target fields names and its values indicate how to fill in these fields.
+        Any mandatory field not having an equivalent field in the source kind should be specified in this
+        mapping. See https://docs.infrahub.app/guides/object-conversion for more information.
         """
         mapping_dict = (
             {}
@@ -1816,11 +1818,11 @@ class InfrahubClientSync(BaseClient):
         return response.get("InfrahubInfo", {}).get("version", "")
 
     def get_user(self) -> dict:
-        """Return user information"""
+        """Return user information."""
         return self.execute_graphql(query=QUERY_USER)
 
     def get_user_permissions(self) -> dict:
-        """Return user permissions"""
+        """Return user permissions."""
         user_info = self.get_user()
         return get_user_permissions(user_info["AccountProfile"]["member_of_groups"]["edges"])
 
@@ -1866,7 +1868,7 @@ class InfrahubClientSync(BaseClient):
         node.delete()
 
     def clone(self, branch: str | None = None) -> InfrahubClientSync:
-        """Return a cloned version of the client using the same configuration"""
+        """Return a cloned version of the client using the same configuration."""
         return InfrahubClientSync(config=self.config.clone(branch=branch))
 
     def execute_graphql(
@@ -1879,6 +1881,7 @@ class InfrahubClientSync(BaseClient):
         tracker: str | None = None,
     ) -> dict:
         """Execute a GraphQL query (or mutation).
+
         If retry_on_failure is True, the query will retry until the server becomes reachable.
 
         Args:
@@ -1888,15 +1891,15 @@ class InfrahubClientSync(BaseClient):
             at (str, optional): Time when the query should be executed. Defaults to None.
             timeout (int, optional): Timeout in second for the query. Defaults to None.
 
+        Returns:
+            dict: The GraphQL data payload (`response["data"]`).
+
         Raises:
             GraphQLError: When the GraphQL response contains errors.
             ServerNotReachableError: If the server is not reachable after exhausting retries.
             AuthenticationError: If the server returns a 401 or 403 response.
             URLNotFoundError: If the server returns a 404 response.
             Error: If the response is unexpectedly missing.
-
-        Returns:
-            dict: The GraphQL data payload (`response["data"]`).
 
         """
         branch_name = branch_name or self.default_branch
@@ -1976,11 +1979,11 @@ class InfrahubClientSync(BaseClient):
             timeout: Timeout in seconds for the query.
             tracker: Optional tracker for request tracing.
 
-        Raises:
-            GraphQLError: When the GraphQL response contains errors.
-
         Returns:
             dict: The GraphQL data payload (response["data"]).
+
+        Raises:
+            GraphQLError: When the GraphQL response contains errors.
 
         """
         branch_name = branch_name or self.default_branch
@@ -2176,7 +2179,7 @@ class InfrahubClientSync(BaseClient):
         include_metadata: bool = False,
         query_name: str | None = None,
     ) -> list[InfrahubNodeSync] | list[SchemaTypeSync]:
-        """Retrieve all nodes of a given kind
+        """Retrieve all nodes of a given kind.
 
         Args:
             kind (str): kind of the nodes to query
@@ -3232,10 +3235,11 @@ class InfrahubClientSync(BaseClient):
         branch: str | None = None,
         fields_mapping: dict[str, ConversionFieldInput] | None = None,
     ) -> InfrahubNodeSync:
-        """Convert a given node to another kind on a given branch. `fields_mapping` keys are target fields names
-        and its values indicate how to fill in these fields. Any mandatory field not having an equivalent field
-        in the source kind should be specified in this mapping. See https://docs.infrahub.app/guides/object-conversion
-        for more information.
+        """Convert a given node to another kind on a given branch.
+
+        `fields_mapping` keys are target fields names and its values indicate how to fill in these fields.
+        Any mandatory field not having an equivalent field in the source kind should be specified in this
+        mapping. See https://docs.infrahub.app/guides/object-conversion for more information.
         """
         mapping_dict = (
             {}

--- a/infrahub_sdk/config.py
+++ b/infrahub_sdk/config.py
@@ -91,6 +91,7 @@ class ConfigBase(BaseSettings):
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         """Customize settings sources to track which fields were explicitly provided.
+
         This allows us to properly handle authentication method precedence.
         """
 

--- a/infrahub_sdk/convert_object_type.py
+++ b/infrahub_sdk/convert_object_type.py
@@ -20,6 +20,7 @@ CONVERT_OBJECT_MUTATION = """
 
 class ConversionFieldValue(BaseModel):  # Only one of these fields can be not None
     """Holds the new value of the destination field during an object conversion.
+
     Use `attribute_value` to specify the new raw value of an attribute.
     Use `peer_id` to specify new peer of a cardinality one relationship.
     Use `peers_ids` to specify new peers of a cardinality many relationship.
@@ -41,6 +42,7 @@ class ConversionFieldValue(BaseModel):  # Only one of these fields can be not No
 
 class ConversionFieldInput(BaseModel):
     """Indicates how to fill in the value of the destination field during an object conversion.
+
     Use `source_field` to reuse the value of the corresponding field of the object being converted.
     Use `data` to specify the new value for the field.
     Use `use_default_value` to set the destination field to its schema default.

--- a/infrahub_sdk/ctl/graphql.py
+++ b/infrahub_sdk/ctl/graphql.py
@@ -121,7 +121,7 @@ async def generate_return_types(
     schema: Path = typer.Option("schema.graphql", help="Path to the GraphQL schema file."),
     _: str = CONFIG_PARAM,
 ) -> None:
-    """Create Pydantic Models for GraphQL query return types"""
+    """Create Pydantic Models for GraphQL query return types."""
     query = Path.cwd() if query is None else query
 
     # Load the GraphQL schema

--- a/infrahub_sdk/ctl/parameters.py
+++ b/infrahub_sdk/ctl/parameters.py
@@ -4,7 +4,7 @@ from ..ctl import config
 
 
 def load_configuration(value: str) -> str:
-    """Load the configuration file using default environment variables or from the specified configuration file"""
+    """Load the configuration file using default environment variables or from the specified configuration file."""
     config.SETTINGS.load_and_exit(config_file=value)
     return value
 

--- a/infrahub_sdk/ctl/validate.py
+++ b/infrahub_sdk/ctl/validate.py
@@ -30,7 +30,7 @@ def callback() -> None:
 @app.command(name="schema")
 @catch_exception(console=console)
 async def validate_schema(schema: Path, _: str = CONFIG_PARAM) -> None:
-    """Validate the format of a schema file either in JSON or YAML"""
+    """Validate the format of a schema file either in JSON or YAML."""
     schema_data = load_yamlfile_from_disk_and_exit(paths=[schema], file_type=SchemaFile, console=console)
     if not schema_data:
         console.print(f"[red]Unable to find {schema}")
@@ -62,7 +62,7 @@ def validate_graphql(
     _: str = CONFIG_PARAM,
     out: str = typer.Option(None, help="Path to a file to save the result."),
 ) -> None:
-    """Validate the format of a GraphQL Query stored locally by executing it on a remote GraphQL endpoint"""
+    """Validate the format of a GraphQL Query stored locally by executing it on a remote GraphQL endpoint."""
     try:
         query_str = find_graphql_query(query)
     except QueryNotFoundError:

--- a/infrahub_sdk/exceptions.py
+++ b/infrahub_sdk/exceptions.py
@@ -156,11 +156,11 @@ class FeatureNotSupportedError(Error):
 
 
 class UninitializedError(Error):
-    """Raised when an object requires an initialization step before use"""
+    """Raised when an object requires an initialization step before use."""
 
 
 class InvalidResponseError(Error):
-    """Raised when an object requires an initialization step before use"""
+    """Raised when an object requires an initialization step before use."""
 
 
 class RepositoryFileNotFoundError(Error):

--- a/infrahub_sdk/generator.py
+++ b/infrahub_sdk/generator.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class InfrahubGenerator(InfrahubOperation):
-    """Infrahub Generator class"""
+    """Infrahub Generator class."""
 
     def __init__(
         self,
@@ -66,7 +66,7 @@ class InfrahubGenerator(InfrahubOperation):
         self._client = value
 
     async def collect_data(self) -> dict:
-        """Query the result of the GraphQL Query defined in self.query and return the result"""
+        """Query the result of the GraphQL Query defined in self.query and return the result."""
         data = await self._init_client.query_gql_query(
             name=self.query,
             branch_name=self.branch_name,
@@ -92,7 +92,7 @@ class InfrahubGenerator(InfrahubOperation):
 
     @abstractmethod
     async def generate(self, data: dict) -> None:
-        """Code to run the generator
+        """Code to run the generator.
 
         Any child class of the InfrahubGenerator us expected to provide this method. The method is expected
         to use the provided InfrahubClient contained in self.client to create or update any nodes in an idempotent

--- a/infrahub_sdk/graphql/utils.py
+++ b/infrahub_sdk/graphql/utils.py
@@ -92,6 +92,7 @@ def strip_typename_from_fragment(fragment: FragmentDefinitionNode) -> FragmentDe
 
 def get_class_def_index(module: ast.Module) -> int:
     """Get the index of the first class definition in the module.
+
     It's useful to insert other classes before the first class definition.
     """
     for idx, item in enumerate(module.body):

--- a/infrahub_sdk/node/attribute.py
+++ b/infrahub_sdk/node/attribute.py
@@ -45,10 +45,12 @@ class Attribute:
     """Represents an attribute of a Node, including its schema, value, and properties."""
 
     def __init__(self, name: str, schema: AttributeSchemaAPI, data: Any | dict) -> None:
-        """Args:
-        name (str): The name of the attribute.
-        schema (AttributeSchema): The schema defining the attribute.
-        data (Union[Any, dict]): The data for the attribute, either in raw form or as a dictionary.
+        """Initialize the attribute.
+
+        Args:
+            name (str): The name of the attribute.
+            schema (AttributeSchema): The schema defining the attribute.
+            data (Union[Any, dict]): The data for the attribute, either in raw form or as a dictionary.
 
         """
         self.name = name

--- a/infrahub_sdk/node/metadata.py
+++ b/infrahub_sdk/node/metadata.py
@@ -7,8 +7,10 @@ class NodeMetadata:
     """Represents metadata about a node (created_at, created_by, updated_at, updated_by)."""
 
     def __init__(self, data: dict | None = None) -> None:
-        """Args:
-        data: Data containing the metadata fields from the GraphQL response.
+        """Initialize the node metadata.
+
+        Args:
+            data: Data containing the metadata fields from the GraphQL response.
 
         """
         self.created_at: str | None = None
@@ -45,8 +47,10 @@ class RelationshipMetadata:
     """Represents metadata about a relationship edge (updated_at, updated_by)."""
 
     def __init__(self, data: dict | None = None) -> None:
-        """Args:
-        data: Data containing the metadata fields from the GraphQL response.
+        """Initialize the relationship metadata.
+
+        Args:
+            data: Data containing the metadata fields from the GraphQL response.
 
         """
         self.updated_at: str | None = None

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -67,13 +67,15 @@ class UploadResult:
 
 
 class InfrahubNodeBase:
-    """Base class for InfrahubNode and InfrahubNodeSync"""
+    """Base class for InfrahubNode and InfrahubNodeSync."""
 
     def __init__(self, schema: MainSchemaTypesAPI, branch: str, data: dict | None = None) -> None:
-        """Args:
-        schema: The schema of the node.
-        branch: The branch where the node resides.
-        data: Optional data to initialize the node.
+        """Initialize the base node.
+
+        Args:
+            schema: The schema of the node.
+            branch: The branch where the node resides.
+            data: Optional data to initialize the node.
 
         """
         self._schema = schema
@@ -190,7 +192,7 @@ class InfrahubNodeBase:
             )
 
     def __setattr__(self, name: str, value: Any) -> None:
-        """Set values for attributes that exist or revert to normal behaviour"""
+        """Set values for attributes that exist or revert to normal behaviour."""
         if "_attribute_data" in self.__dict__ and name in self._attribute_data:
             self._attribute_data[name].value = value
             return
@@ -626,11 +628,13 @@ class InfrahubNode(InfrahubNodeBase):
         branch: str | None = None,
         data: dict | None = None,
     ) -> None:
-        """Args:
-        client: The client used to interact with the backend.
-        schema: The schema of the node.
-        branch: The branch where the node resides.
-        data: Optional data to initialize the node.
+        """Initialize the async node.
+
+        Args:
+            client: The client used to interact with the backend.
+            schema: The schema of the node.
+            branch: The branch where the node resides.
+            data: Optional data to initialize the node.
 
         """
         self._client = client
@@ -1599,11 +1603,13 @@ class InfrahubNodeSync(InfrahubNodeBase):
         branch: str | None = None,
         data: dict | None = None,
     ) -> None:
-        """Args:
-        client (InfrahubClientSync): The client used to interact with the backend synchronously.
-        schema (MainSchemaTypes): The schema of the node.
-        branch (Optional[str]): The branch where the node resides.
-        data (Optional[dict]): Optional data to initialize the node.
+        """Initialize the sync node.
+
+        Args:
+            client (InfrahubClientSync): The client used to interact with the backend synchronously.
+            schema (MainSchemaTypes): The schema of the node.
+            branch (Optional[str]): The branch where the node resides.
+            data (Optional[dict]): Optional data to initialize the node.
 
         """
         self._client = client

--- a/infrahub_sdk/node/property.py
+++ b/infrahub_sdk/node/property.py
@@ -5,8 +5,10 @@ class NodeProperty:
     """Represents a property of a node, typically used for metadata like display labels."""
 
     def __init__(self, data: dict | str) -> None:
-        """Args:
-        data (Union[dict, str]): Data representing the node property.
+        """Initialize the node property.
+
+        Args:
+            data (Union[dict, str]): Data representing the node property.
 
         """
         self.id = None

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -18,11 +18,13 @@ class RelatedNodeBase:
     """Base class for representing a related node in a relationship."""
 
     def __init__(self, branch: str, schema: RelationshipSchemaAPI, data: Any | dict, name: str | None = None) -> None:
-        """Args:
-        branch (str): The branch where the related node resides.
-        schema (RelationshipSchema): The schema of the relationship.
-        data (Union[Any, dict]): Data representing the related node.
-        name (Optional[str]): The name of the related node.
+        """Initialize the base related node.
+
+        Args:
+            branch (str): The branch where the related node resides.
+            schema (RelationshipSchema): The schema of the relationship.
+            data (Union[Any, dict]): Data representing the related node.
+            name (Optional[str]): The name of the related node.
 
         """
         self.schema = schema
@@ -222,12 +224,14 @@ class RelatedNode(RelatedNodeBase):
         data: Any | dict,
         name: str | None = None,
     ) -> None:
-        """Args:
-        client (InfrahubClient): The client used to interact with the backend asynchronously.
-        branch (str): The branch where the related node resides.
-        schema (RelationshipSchema): The schema of the relationship.
-        data (Union[Any, dict]): Data representing the related node.
-        name (Optional[str]): The name of the related node.
+        """Initialize the async related node.
+
+        Args:
+            client (InfrahubClient): The client used to interact with the backend asynchronously.
+            branch (str): The branch where the related node resides.
+            schema (RelationshipSchema): The schema of the relationship.
+            data (Union[Any, dict]): Data representing the related node.
+            name (Optional[str]): The name of the related node.
 
         """
         self._client = client
@@ -269,12 +273,14 @@ class RelatedNodeSync(RelatedNodeBase):
         data: Any | dict,
         name: str | None = None,
     ) -> None:
-        """Args:
-        client (InfrahubClientSync): The client used to interact with the backend synchronously.
-        branch (str): The branch where the related node resides.
-        schema (RelationshipSchema): The schema of the relationship.
-        data (Union[Any, dict]): Data representing the related node.
-        name (Optional[str]): The name of the related node.
+        """Initialize the sync related node.
+
+        Args:
+            client (InfrahubClientSync): The client used to interact with the backend synchronously.
+            branch (str): The branch where the related node resides.
+            schema (RelationshipSchema): The schema of the relationship.
+            data (Union[Any, dict]): Data representing the related node.
+            name (Optional[str]): The name of the related node.
 
         """
         self._client = client

--- a/infrahub_sdk/node/relationship.py
+++ b/infrahub_sdk/node/relationship.py
@@ -20,13 +20,15 @@ if TYPE_CHECKING:
 
 
 class RelationshipManagerBase:
-    """Base class for RelationshipManager and RelationshipManagerSync"""
+    """Base class for RelationshipManager and RelationshipManagerSync."""
 
     def __init__(self, name: str, branch: str, schema: RelationshipSchemaAPI) -> None:
-        """Args:
-        name (str): The name of the relationship.
-        branch (str): The branch where the relationship resides.
-        schema (RelationshipSchema): The schema of the relationship.
+        """Initialize the base relationship manager.
+
+        Args:
+            name (str): The name of the relationship.
+            branch (str): The branch where the relationship resides.
+            schema (RelationshipSchema): The schema of the relationship.
 
         """
         self.initialized: bool = False
@@ -125,13 +127,15 @@ class RelationshipManager(RelationshipManagerBase):
         schema: RelationshipSchemaAPI,
         data: Any | dict,
     ) -> None:
-        """Args:
-        name (str): The name of the relationship.
-        client (InfrahubClient): The client used to interact with the backend.
-        node (InfrahubNode): The node to which the relationship belongs.
-        branch (str): The branch where the relationship resides.
-        schema (RelationshipSchema): The schema of the relationship.
-        data (Union[Any, dict]): Initial data for the relationships.
+        """Initialize the async relationship manager.
+
+        Args:
+            name (str): The name of the relationship.
+            client (InfrahubClient): The client used to interact with the backend.
+            node (InfrahubNode): The node to which the relationship belongs.
+            branch (str): The branch where the relationship resides.
+            schema (RelationshipSchema): The schema of the relationship.
+            data (Union[Any, dict]): Initial data for the relationships.
 
         Raises:
             ValueError: If ``data`` is in an unexpected format.
@@ -256,13 +260,15 @@ class RelationshipManagerSync(RelationshipManagerBase):
         schema: RelationshipSchemaAPI,
         data: Any | dict,
     ) -> None:
-        """Args:
-        name (str): The name of the relationship.
-        client (InfrahubClientSync): The client used to interact with the backend synchronously.
-        node (InfrahubNodeSync): The node to which the relationship belongs.
-        branch (str): The branch where the relationship resides.
-        schema (RelationshipSchema): The schema of the relationship.
-        data (Union[Any, dict]): Initial data for the relationships.
+        """Initialize the sync relationship manager.
+
+        Args:
+            name (str): The name of the relationship.
+            client (InfrahubClientSync): The client used to interact with the backend synchronously.
+            node (InfrahubNodeSync): The node to which the relationship belongs.
+            branch (str): The branch where the relationship resides.
+            schema (RelationshipSchema): The schema of the relationship.
+            data (Union[Any, dict]): Initial data for the relationships.
 
         Raises:
             ValueError: If ``data`` is in an unexpected format.

--- a/infrahub_sdk/operation.py
+++ b/infrahub_sdk/operation.py
@@ -44,17 +44,17 @@ class InfrahubOperation:
 
     @property
     def store(self) -> NodeStore:
-        """The store will be populated with nodes based on the query during the collection of data if activated"""
+        """The store will be populated with nodes based on the query during the collection of data if activated."""
         return self._init_client.store
 
     @property
     def nodes(self) -> list[InfrahubNode]:
-        """Returns nodes collected and parsed during the data collection process if this feature is enabled"""
+        """Returns nodes collected and parsed during the data collection process if this feature is enabled."""
         return self._nodes
 
     @property
     def related_nodes(self) -> list[InfrahubNode]:
-        """Returns nodes collected and parsed during the data collection process if this feature is enabled"""
+        """Returns nodes collected and parsed during the data collection process if this feature is enabled."""
         return self._related_nodes
 
     async def process_nodes(self, data: dict) -> None:

--- a/infrahub_sdk/protocols_generator/generator.py
+++ b/infrahub_sdk/protocols_generator/generator.py
@@ -27,7 +27,7 @@ def load_template() -> str:
 
 
 def move_to_end_of_list(lst: list, item: str) -> list:
-    """Move an item to the end of a list if it exists in the list"""
+    """Move an item to the end of a list if it exists in the list."""
     if item in lst:
         lst.remove(item)
         lst.append(item)
@@ -93,7 +93,7 @@ class CodeGenerator:
 
     @staticmethod
     def _jinja2_filter_syncify(value: str | list, sync: bool = False) -> str | list:
-        """Filter to help with the convertion to sync
+        """Filter to help with the convertion to sync.
 
         If a string is provided, append Sync to the end of the string
         If a list is provided, search for CoreNode and replace it with CoreNodeSync

--- a/infrahub_sdk/pytest_plugin/items/base.py
+++ b/infrahub_sdk/pytest_plugin/items/base.py
@@ -78,7 +78,7 @@ class InfrahubItem(pytest.Item):
 
     @property
     def repository_base(self) -> str:
-        """Return the path to the root of the repository
+        """Return the path to the root of the repository.
 
         This will be an absolute path if --infrahub-config-path is an absolute path as happens when
         tests are started from within Infrahub server.

--- a/infrahub_sdk/query_groups.py
+++ b/infrahub_sdk/query_groups.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class InfrahubGroupContextBase:
-    """Base class for InfrahubGroupContext and InfrahubGroupContextSync"""
+    """Base class for InfrahubGroupContext and InfrahubGroupContextSync."""
 
     def __init__(self) -> None:
         self.related_node_ids: list[str] = []
@@ -52,7 +52,7 @@ class InfrahubGroupContextBase:
         self.branch = branch
 
     def _get_params_as_str(self) -> str:
-        """Convert the params in dict format, into a string"""
+        """Convert the params in dict format, into a string."""
         params_as_str: list[str] = []
         for key, value in self.params.items():
             params_as_str.append(f"{key}: {value!s}")
@@ -70,8 +70,9 @@ class InfrahubGroupContextBase:
         return group_name
 
     def _generate_group_description(self, schema: MainSchemaTypesAPI) -> str:
-        """Generate the description of the group from the params
-        and ensure it's not longer than the maximum length of the description field.
+        """Generate the description of the group from the params.
+
+        The result is truncated so it is not longer than the maximum length of the description field.
         """
         if not self.params:
             return ""

--- a/infrahub_sdk/recorder.py
+++ b/infrahub_sdk/recorder.py
@@ -19,13 +19,13 @@ class RecorderType(str, enum.Enum):
 @runtime_checkable
 class Recorder(Protocol):
     def record(self, response: httpx.Response) -> None:
-        """Record the response from Infrahub"""
+        """Record the response from Infrahub."""
 
 
 class NoRecorder:
     @staticmethod
     def record(response: httpx.Response) -> None:
-        """The NoRecorder just silently returns"""
+        """The NoRecorder just silently returns."""
 
     @classmethod
     def default(cls) -> NoRecorder:

--- a/infrahub_sdk/schema/__init__.py
+++ b/infrahub_sdk/schema/__init__.py
@@ -177,7 +177,7 @@ class InfrahubSchemaBase:
                 )
 
     def set_cache(self, schema: dict[str, Any] | SchemaRootAPI | BranchSchema, branch: str | None = None) -> None:
-        """Set the cache manually (primarily for unit testing)
+        """Set the cache manually (primarily for unit testing).
 
         Args:
             schema: The schema to set the cache as provided by the /api/schema endpoint either in dict or SchemaRootAPI format
@@ -369,7 +369,7 @@ class InfrahubSchema(InfrahubSchemaBase):
         return self._validate_load_schema_response(response=response)
 
     async def wait_until_converged(self, branch: str | None = None) -> None:
-        """Wait until the schema has converged on the selected branch or the timeout has been reached"""
+        """Wait until the schema has converged on the selected branch or the timeout has been reached."""
         waited = 0
         while True:
             if await self.in_sync(branch=branch):
@@ -384,7 +384,7 @@ class InfrahubSchema(InfrahubSchemaBase):
             await asyncio.sleep(delay=1)
 
     async def in_sync(self, branch: str | None = None) -> bool:
-        """Indicate if the schema is in sync across all workers for the provided branch"""
+        """Indicate if the schema is in sync across all workers for the provided branch."""
         response = await self.client.execute_graphql(query=SCHEMA_HASH_SYNC_STATUS, branch_name=branch)
         return response["InfrahubStatus"]["summary"]["schema_hash_synced"]
 
@@ -899,7 +899,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
         return self._validate_load_schema_response(response=response)
 
     def wait_until_converged(self, branch: str | None = None) -> None:
-        """Wait until the schema has converged on the selected branch or the timeout has been reached"""
+        """Wait until the schema has converged on the selected branch or the timeout has been reached."""
         waited = 0
         while True:
             if self.in_sync(branch=branch):
@@ -914,7 +914,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
             sleep(1)
 
     def in_sync(self, branch: str | None = None) -> bool:
-        """Indicate if the schema is in sync across all workers for the provided branch"""
+        """Indicate if the schema is in sync across all workers for the provided branch."""
         response = self.client.execute_graphql(query=SCHEMA_HASH_SYNC_STATUS, branch_name=branch)
         return response["InfrahubStatus"]["summary"]["schema_hash_synced"]
 

--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -294,7 +294,8 @@ class BaseSchema(BaseModel):
 
     @property
     def supports_artifacts(self) -> bool:
-        """Returns True if this schema supports artifact operations via CoreArtifactTarget inheritance.
+        """Return True if this schema supports artifact operations via CoreArtifactTarget inheritance.
+
         Only NodeSchemaAPI overrides this; all other schema types return False by design because
         artifact capability is tied to node inheritance, not profiles, templates, or generics.
         """
@@ -302,7 +303,8 @@ class BaseSchema(BaseModel):
 
     @property
     def supports_file_object(self) -> bool:
-        """Returns True if this schema supports file object operations via CoreFileObject inheritance.
+        """Return True if this schema supports file object operations via CoreFileObject inheritance.
+
         Only NodeSchemaAPI overrides this; all other schema types return False by design because
         file object capability is tied to node inheritance, not profiles, templates, or generics.
         """
@@ -315,7 +317,8 @@ class BaseSchema(BaseModel):
 
     @property
     def hierarchical_relationship_schemas(self) -> list[RelationshipSchemaAPI]:
-        """Returns pseudo-schemas for parent/children/ancestors/descendants if hierarchy is set.
+        """Return pseudo-schemas for parent/children/ancestors/descendants if hierarchy is set.
+
         Only NodeSchemaAPI overrides this; all other schema types return an empty list.
         """
         return []

--- a/infrahub_sdk/spec/object.py
+++ b/infrahub_sdk/spec/object.py
@@ -93,7 +93,7 @@ class RelationshipInfo(BaseModel):
 
     @property
     def is_bidirectional(self) -> bool:
-        """Indicate if a relationship with the same identifier exists on the other side"""
+        """Indicate if a relationship with the same identifier exists on the other side."""
         return bool(self.peer_rel)
 
     @property
@@ -119,7 +119,7 @@ class RelationshipInfo(BaseModel):
         return self.format in {RelationshipDataFormat.ONE_REF, RelationshipDataFormat.MANY_REF}
 
     def get_context(self, value: Any) -> dict:
-        """Return a dict to insert to the context if the relationship is mandatory"""
+        """Return a dict to insert to the context if the relationship is mandatory."""
         if self.peer_rel and self.is_mandatory and self.peer_rel.cardinality == RelationshipCardinality.ONE:
             return {self.peer_rel.name: value}
         if self.peer_rel and self.is_mandatory and self.peer_rel.cardinality == RelationshipCardinality.MANY:
@@ -129,7 +129,7 @@ class RelationshipInfo(BaseModel):
     def find_matching_relationship(
         self, peer_schema: MainSchemaTypesAPI, force: bool = False
     ) -> RelationshipSchema | None:
-        """Find the matching relationship on the other side of the relationship"""
+        """Find the matching relationship on the other side of the relationship."""
         if self.peer_rel and not force:
             return self.peer_rel
 
@@ -209,7 +209,7 @@ class InfrahubObjectFileData(BaseModel):
     data: list[dict[str, Any]] = Field(default_factory=list)
 
     async def _get_processed_data(self, data: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Get data processed according to the strategy"""
+        """Get data processed according to the strategy."""
         return await DataProcessorFactory.process_data(kind=self.kind, parameters=self.parameters, data=data)
 
     async def validate_format(self, client: InfrahubClient, branch: str | None = None) -> list[ObjectValidationError]:

--- a/infrahub_sdk/spec/processors/data_processor.py
+++ b/infrahub_sdk/spec/processors/data_processor.py
@@ -3,8 +3,8 @@ from typing import Any
 
 
 class DataProcessor(ABC):
-    """Abstract base class for data processing strategies"""
+    """Abstract base class for data processing strategies."""
 
     @abstractmethod
     async def process_data(self, data: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Process the data according to the strategy"""
+        """Process the data according to the strategy."""

--- a/infrahub_sdk/spec/processors/factory.py
+++ b/infrahub_sdk/spec/processors/factory.py
@@ -9,7 +9,7 @@ PROCESSOR_PER_KIND: dict[str, DataProcessor] = {}
 
 
 class DataProcessorFactory:
-    """Factory to create appropriate data processor based on strategy"""
+    """Factory to create appropriate data processor based on strategy."""
 
     @classmethod
     def get_processors(cls, kind: str, parameters: InfrahubObjectParameters) -> Sequence[DataProcessor]:

--- a/infrahub_sdk/spec/processors/range_expand_processor.py
+++ b/infrahub_sdk/spec/processors/range_expand_processor.py
@@ -13,7 +13,7 @@ log = logging.getLogger("infrahub_sdk")
 
 
 class RangeExpandDataProcessor(DataProcessor):
-    """Process data with range expansion"""
+    """Process data with range expansion."""
 
     @classmethod
     async def process_data(

--- a/infrahub_sdk/spec/range_expansion.py
+++ b/infrahub_sdk/spec/range_expansion.py
@@ -90,9 +90,9 @@ def _expand_interfaces(pattern: str, interface_constant: list[int], cartesian_li
 
 
 def range_expansion(interface_pattern: str) -> list[str]:
-    """Expand string pattern into a list of strings, supporting both
-    number and single-character alphabet ranges. Heavily inspired by
-    Netutils interface_range_expansion but adapted to support letters.
+    """Expand a string pattern into a list of strings, supporting number and single-character alphabet ranges.
+
+    Heavily inspired by Netutils interface_range_expansion but adapted to support letters.
 
     Args:
         interface_pattern: The string pattern that will be parsed to create the list of interfaces.

--- a/infrahub_sdk/task/manager.py
+++ b/infrahub_sdk/task/manager.py
@@ -211,11 +211,11 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
             interval: The interval to check the task state. Defaults to 1.
             timeout: The timeout to wait for the task to complete. Defaults to 60.
 
-        Raises:
-            TaskNotCompletedError: The task did not complete in the given timeout.
-
         Returns:
             The task object.
+
+        Raises:
+            TaskNotCompletedError: The task did not complete in the given timeout.
 
         """
         for _ in range(timeout // interval):
@@ -451,11 +451,11 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
             interval: The interval to check the task state. Defaults to 1.
             timeout: The timeout to wait for the task to complete. Defaults to 60.
 
-        Raises:
-            TaskNotCompletedError: The task did not complete in the given timeout.
-
         Returns:
             The task object.
+
+        Raises:
+            TaskNotCompletedError: The task did not complete in the given timeout.
 
         """
         for _ in range(timeout // interval):

--- a/infrahub_sdk/transforms.py
+++ b/infrahub_sdk/transforms.py
@@ -54,7 +54,7 @@ class InfrahubTransform(InfrahubOperation):
         pass
 
     async def collect_data(self) -> dict:
-        """Query the result of the GraphQL Query defined in self.query and return the result"""
+        """Query the result of the GraphQL Query defined in self.query and return the result."""
         return await self.client.query_gql_query(name=self.query, branch_name=self.branch_name)
 
     async def run(self, data: dict | None = None) -> Any:

--- a/infrahub_sdk/types.py
+++ b/infrahub_sdk/types.py
@@ -49,13 +49,13 @@ class AsyncRequester(Protocol):
 @runtime_checkable
 class InfrahubLogger(Protocol):
     def debug(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
-        """Send a debug event"""
+        """Send a debug event."""
 
     def info(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
-        """Send an info event"""
+        """Send an info event."""
 
     def warning(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
-        """Send a warning event"""
+        """Send a warning event."""
 
     def error(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         """Send an error event."""

--- a/infrahub_sdk/utils.py
+++ b/infrahub_sdk/utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 def generate_short_id() -> str:
-    """Generate a short unique ID"""
+    """Generate a short unique ID."""
     return base64.urlsafe_b64encode(uuid.uuid4().bytes).rstrip(b"=").decode("ascii").lower()
 
 
@@ -121,10 +121,13 @@ def intersection(list1: list[Any], list2: list[Any]) -> list:
 
 
 def compare_lists(list1: list[Any], list2: list[Any]) -> tuple[list[Any], list[Any], list[Any]]:
-    """Compare 2 lists and return :
-    - the intersection of both
-    - the item present only in list1
-    - the item present only in list2
+    """Compare 2 lists and return the intersection plus items present only in each list.
+
+    Returns:
+        - the intersection of both
+        - the item present only in list1
+        - the item present only in list2
+
     """
     in_both = intersection(list1=list1, list2=list2)
     in_list_1 = list(set(list1) - set(in_both))
@@ -202,7 +205,7 @@ def str_to_bool(value: str | bool | int) -> bool:
 
 
 def generate_request_filename(request: httpx.Request) -> str:
-    """Return a filename for a request sent to the Infrahub API
+    """Return a filename for a request sent to the Infrahub API.
 
     This function is used when recording and playing back requests, as Infrahub is using a GraphQL
     API it's not possible to rely on the URL endpoint alone to separate one request from another,
@@ -270,7 +273,7 @@ def calculate_dict_height(data: dict, cnt: int = 0) -> int:
 
 
 async def extract_fields(selection_set: SelectionSetNode | None) -> dict[str, dict] | None:
-    """This function extract all the requested fields in a tree of Dict from a SelectionSetNode
+    """This function extract all the requested fields in a tree of Dict from a SelectionSetNode.
 
     The goal of this function is to limit the fields that we need to query from the backend.
 

--- a/infrahub_sdk/uuidt.py
+++ b/infrahub_sdk/uuidt.py
@@ -23,8 +23,9 @@ def generate_uuid() -> str:
 
 def encode_number(number: int, min_length: int) -> str:
     """Encode a number into a base16 string and ensure the result has a minimum size.
-    If the initial response produced doesn't match the min requirement,
-    random number will be used to fill the gap
+
+    If the initial response produced doesn't match the min requirement, a random number is
+    used to fill the gap.
     """
     response = base16encode(number=number).lower()
     if len(response) >= min_length:
@@ -56,7 +57,7 @@ class UUIDT:
         return f"{timestamp_str[:8]}-{timestamp_str[8:12]}-{timestamp_str[-4:]}-{hostname_str[:4]}-{namespace_str[:4]}{self.random_chars[:8]}"
 
     def short(self) -> str:
-        """Return the last 8 digit of the UUID (the most random part)"""
+        """Return the last 8 digit of the UUID (the most random part)."""
         return str(self)[-8:]
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,14 +349,10 @@ ignore = [
     "D104",    # Missing docstring in public package
     "D105",    # Missing docstring in magic method
     "D107",    # Missing docstring in `__init__`
-    "D205",    # Missing blank line after summary
     "D301",    # Use `r"""` if any backslashes in a docstring
-    "D400",    # First line should end with a period
     "D401",    # First line of docstring should be in imperative mood
     "D404",    # First word of the docstring should not be "This"
-    "D415",    # First line should end with a period, question mark, or exclamation point
     "D417",    # Missing argument description in the docstring
-    "D420",    # Section name should end with a newline
     "DOC102",  # Docstring contains extraneous parameter(s)
     "DOC201",  # `return` is not documented in docstring
     "DOC402",  # `yield` is not documented in docstring

--- a/tasks.py
+++ b/tasks.py
@@ -411,7 +411,7 @@ def generate_python_sdk(context: Context) -> None:
 
 @task
 def generate_repository_jsonschema(context: Context) -> None:
-    """Generate JSON schema file for repository configuration. https://github.com/opsmill/infrahub-jsonschema"""
+    """Generate JSON schema file for repository configuration. https://github.com/opsmill/infrahub-jsonschema."""
     from infrahub_sdk.schema.repository import InfrahubRepositoryConfig
 
     repository_jsonschema = MAIN_DIRECTORY_PATH / "generated" / "repository-config" / "develop.json"

--- a/tests/unit/ctl/test_render_app.py
+++ b/tests/unit/ctl/test_render_app.py
@@ -56,7 +56,7 @@ RENDER_APP_FAIL_TEST_CASES = [
     [pytest.param(tc, id=tc.name) for tc in RENDER_APP_FAIL_TEST_CASES],
 )
 def test_validate_template_not_found(test_case: RenderAppFailure, httpx_mock: HTTPXMock) -> None:
-    """Ensure that the correct errors are caught"""
+    """Ensure that the correct errors are caught."""
     httpx_mock.add_response(
         method="POST",
         url="http://mock/graphql/main",

--- a/tests/unit/ctl/test_schema_app.py
+++ b/tests/unit/ctl/test_schema_app.py
@@ -131,7 +131,7 @@ def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock) -> None:
 
 
 def test_load_valid_generic_schema(httpx_mock: HTTPXMock) -> None:
-    """A test which ensures that a generic schema is correctly loaded when loaded from infrahubctl command"""
+    """A test which ensures that a generic schema is correctly loaded when loaded from infrahubctl command."""
     # Arrange
     fixture_file = get_fixtures_dir() / "models" / "valid_generic_schema.json"
 

--- a/tests/unit/ctl/test_transform_app.py
+++ b/tests/unit/ctl/test_transform_app.py
@@ -89,7 +89,7 @@ class TestInfrahubctlTransform:
 
     @staticmethod
     def test_gql_query_not_defined(tags_transform_dir: str) -> None:
-        """Case GraphQL Query is not defined"""
+        """Case GraphQL Query is not defined."""
         # Remove GraphQL Query file
         gql_file = Path(Path(tags_transform_dir) / "tags_query.gql")
         Path.unlink(gql_file)
@@ -102,7 +102,7 @@ class TestInfrahubctlTransform:
 
     @staticmethod
     def test_infrahubctl_transform_cmd_success(httpx_mock: HTTPXMock, tags_transform_dir: str) -> None:
-        """Case infrahubctl transform command executes successfully"""
+        """Case infrahubctl transform command executes successfully."""
         httpx_mock.add_response(
             method="POST",
             url="http://mock/graphql/main",

--- a/tests/unit/doc_generation/content_gen_methods/test_command_output_method.py
+++ b/tests/unit/doc_generation/content_gen_methods/test_command_output_method.py
@@ -18,8 +18,9 @@ class StubCommand(ACommand):
 
 class TestCommandOutputDocContentGenMethod:
     def test_apply_runs_command_and_reads_output(self, tmp_path: Path) -> None:
-        """The method executes the command via context.run, then reads
-        the content from the temp file whose path was appended via --output.
+        """The method executes the command via context.run, then reads the output file.
+
+        The content is read from the temp file whose path was appended via --output.
         """
         output_content = "# Generated docs"
 

--- a/tests/unit/doc_generation/content_gen_methods/test_jinja2_method.py
+++ b/tests/unit/doc_generation/content_gen_methods/test_jinja2_method.py
@@ -55,8 +55,9 @@ class TestJinja2DocContentGenMethod:
         assert result == "Hi there!"
 
     def test_auto_escaping_is_disabled(self, tmp_path: Path) -> None:
-        """HTML content in template variables must not be auto-escaped,
-        since the SDK Jinja2 environment does not enable autoescape.
+        """HTML content in template variables must not be auto-escaped.
+
+        The SDK Jinja2 environment does not enable autoescape.
         """
         # Arrange
         template_file = tmp_path / "test.j2"

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -2079,7 +2079,7 @@ async def mock_query_infrahub_user(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 def query_01() -> str:
-    """Simple query with one document"""
+    """Simple query with one document."""
     return """
     query {
         TestPerson {
@@ -2151,7 +2151,7 @@ def query_02() -> str:
 
 @pytest.fixture
 def query_03() -> str:
-    """Advanced Query with 2 documents"""
+    """Advanced Query with 2 documents."""
     return """
     query FirstQuery {
         TestPerson {
@@ -2190,7 +2190,7 @@ def query_03() -> str:
 
 @pytest.fixture
 def query_04() -> str:
-    """Simple query with variables"""
+    """Simple query with variables."""
     return """
     query ($person: String!){
         TestPerson(name__value: $person) {
@@ -2240,7 +2240,7 @@ def query_05() -> str:
 
 @pytest.fixture
 def query_06() -> str:
-    """Simple query with variables"""
+    """Simple query with variables."""
     return """
     query (
         $str1: String,

--- a/tests/unit/sdk/pool/test_attribute_from_pool.py
+++ b/tests/unit/sdk/pool/test_attribute_from_pool.py
@@ -1,4 +1,7 @@
-"""When using from_pool on a number attribute (e.g. vlan_id), the SDK should generate:
+"""Tests that ``from_pool`` on a number attribute generates the expected GraphQL payload.
+
+When using from_pool on a number attribute (e.g. vlan_id), the SDK should generate::
+
     vlan_id: { from_pool: { id: "...", identifier: "..." } }
 
 There are two ways to request a pool allocation:

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -691,7 +691,7 @@ async def test_query_echo(httpx_mock: HTTPXMock, echo_clients: BothClients, clie
 
 @pytest.mark.parametrize("client_type", client_types)
 async def test_clone(clients: BothClients, client_type: str) -> None:
-    """Validate that the configuration of a cloned client is a replica of the original client"""
+    """Validate that the configuration of a cloned client is a replica of the original client."""
     if client_type == "standard":
         clone = clients.standard.clone()
         assert clone.config == clients.standard.config
@@ -706,7 +706,7 @@ async def test_clone(clients: BothClients, client_type: str) -> None:
 
 @pytest.mark.parametrize("client_type", client_types)
 async def test_clone_define_branch(clients: BothClients, client_type: str) -> None:
-    """Validate that the clone branch parameter sets the correct branch of the cloned client"""
+    """Validate that the clone branch parameter sets the correct branch of the cloned client."""
     clone_branch = "my_other_branch"
     if client_type == "standard":
         original_branch = clients.standard.default_branch

--- a/tests/unit/sdk/test_config.py
+++ b/tests/unit/sdk/test_config.py
@@ -43,7 +43,7 @@ def test_config_address() -> None:
 
 
 def test_password_auth_overrides_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that explicit username/password overrides INFRAHUB_API_TOKEN from environment"""
+    """Test that explicit username/password overrides INFRAHUB_API_TOKEN from environment."""
     # Set environment variable for api_token
     monkeypatch.setenv("INFRAHUB_API_TOKEN", "token-from-env")
 
@@ -58,7 +58,7 @@ def test_password_auth_overrides_env_token(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_token_auth_overrides_env_password(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that explicit api_token overrides INFRAHUB_USERNAME and INFRAHUB_PASSWORD from environment"""
+    """Test that explicit api_token overrides INFRAHUB_USERNAME and INFRAHUB_PASSWORD from environment."""
     # Set environment variables for username/password
     monkeypatch.setenv("INFRAHUB_USERNAME", "user-from-env")
     monkeypatch.setenv("INFRAHUB_PASSWORD", "pass-from-env")
@@ -76,8 +76,10 @@ def test_token_auth_overrides_env_password(monkeypatch: pytest.MonkeyPatch) -> N
 def test_password_auth_overrides_env_token_when_password_env_var_and_username_explicit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that explicit username/password overrides INFRAHUB_API_TOKEN from environment when only username is provided
-    through Config object and password is provided through environment variable
+    """Test that explicit username/password overrides INFRAHUB_API_TOKEN from environment.
+
+    The username is provided through the Config object and the password is provided through an
+    environment variable.
     """
     # Set environment variable for api_token and password
     monkeypatch.setenv("INFRAHUB_API_TOKEN", "token-from-env")

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -91,13 +91,13 @@ async def test_method_sanity() -> None:
 
 @pytest.mark.parametrize("value", SAFE_GRAPHQL_VALUES)
 def test_validate_graphql_value(value: str) -> None:
-    """All these values are safe and should not be converted"""
+    """All these values are safe and should not be converted."""
     assert SAFE_VALUE.match(value)
 
 
 @pytest.mark.parametrize("value", UNSAFE_GRAPHQL_VALUES)
 def test_identify_unsafe_graphql_value(value: str) -> None:
-    """All these values are safe and should not be converted"""
+    """All these values are safe and should not be converted."""
     assert not SAFE_VALUE.match(value)
 
 
@@ -1391,7 +1391,7 @@ async def test_create_input_data(client: InfrahubClient, location_schema: NodeSc
 async def test_create_input_data_with_dropdown(
     client: InfrahubClient, location_schema_with_dropdown: NodeSchemaAPI, client_type: str
 ) -> None:
-    """Validate input data including dropdown field"""
+    """Validate input data including dropdown field."""
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK Airport"},
@@ -1453,7 +1453,7 @@ async def test_update_input_data_existing_node_with_optional_relationship(
 async def test_create_input_data__with_relationships_02(
     client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
 ) -> None:
-    """Validate input data with variables that needs replacements"""
+    """Validate input data with variables that needs replacements."""
     data = {
         "name": {"value": "JFK1"},
         "description": {"value": "JFK\n Airport"},

--- a/tests/unit/sdk/test_schema.py
+++ b/tests/unit/sdk/test_schema.py
@@ -64,7 +64,7 @@ async def test_fetch_schema(mock_schema_query_01: HTTPXMock, client_type: str) -
 
 @pytest.mark.parametrize("client_type", client_types)
 async def test_fetch_schema_conditional_refresh(mock_schema_query_01: HTTPXMock, client_type: str) -> None:
-    """Verify that only one schema request is sent if we request to update the schema but already have the correct hash"""
+    """Verify that only one schema request is sent if we request to update the schema but already have the correct hash."""
     if client_type == "standard":
         client = InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
         nodes = await client.schema.all(branch="main")

--- a/tests/unit/sdk/test_topological_sort.py
+++ b/tests/unit/sdk/test_topological_sort.py
@@ -74,11 +74,15 @@ def test_topological_sort_disjoint_2() -> None:
 
 
 def test_topological_sort_binary_tree() -> None:
-    """A
-        b               c
-      d   e         f       g
-    hi            j   k
-                  lm
+    """Sort a binary dependency tree with uneven depth on each side.
+
+    The `dependencies` mapping below describes this tree::
+
+            a
+          b               c
+        d   e         f       g
+      h i            j   k
+                    l m
     """
     dependencies = {
         "a": ["b", "c"],


### PR DESCRIPTION
# Why

* Cleaner reading of docstrings
* Tighten ruff rules before requiring docstrings in additional places

## What changed

* Mainly whitespaces and punctuation
* At times insert linebreaks
* Rules in ruff
* Most notable change is a sorting function in the tests that only had an ascii drawing as a docstring, here a sensible header was added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized docstrings and SDK/CLI reference text across the codebase for clearer, consistent API references. Tightened `ruff` docstring rules (now enforcing summary punctuation and section formatting) without changing runtime behavior.

- **Refactors**
  - Normalized first-line summaries (imperative, end with a period) and added missing blank lines; added clear “Initialize …” summaries for `__init__` methods and “Base class …” summaries across nodes, relationships, and clients.
  - Clarified Args/Returns/Raises and ordered them consistently; explicitly documented returns for `execute_graphql` (async/sync), `_execute_graphql_with_file` (async/sync), and `convert_object_type`.
  - Polished SDK and CLI docs (`infrahubctl graphql/validate`, client and node refs) with concise phrasing and terminal punctuation; improved generator and doc-build helper docstrings (e.g., collapsed overload sections).
  - Tightened tests’ docstrings for clarity and style without altering assertions or behavior.
  - Removed `ruff` ignores `D205`, `D400`, `D415`, `D420` in `pyproject.toml` to enforce stricter docstring rules.

<sup>Written for commit 3f1f7370fb58a77174f557b6c26f865ed4a82b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

