### PR TITLE
IHS-136: Update click version

### DIFF
--- a/docs/docs/infrahubctl/infrahubctl-branch.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-branch.mdx
@@ -18,13 +18,28 @@ $ infrahubctl branch [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
+* `list`: List all existing branches.
 * `create`: Create a new branch.
 * `delete`: Delete a branch.
-* `list`: List all existing branches.
-* `merge`: Merge a Branch with main.
 * `rebase`: Rebase a Branch with main.
-* `report`: Generate branch cleanup status report.
+* `merge`: Merge a Branch with main.
 * `validate`: Validate if a branch has some conflict and...
+* `report`: Generate branch cleanup status report.
+
+## `infrahubctl branch list`
+
+List all existing branches.
+
+**Usage**:
+
+```console
+$ infrahubctl branch list [OPTIONS]
+```
+
+**Options**:
+
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
 
 ## `infrahubctl branch create`
 
@@ -66,15 +81,19 @@ $ infrahubctl branch delete [OPTIONS] BRANCH_NAME
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
 
-## `infrahubctl branch list`
+## `infrahubctl branch rebase`
 
-List all existing branches.
+Rebase a Branch with main.
 
 **Usage**:
 
 ```console
-$ infrahubctl branch list [OPTIONS]
+$ infrahubctl branch rebase [OPTIONS] BRANCH_NAME
 ```
+
+**Arguments**:
+
+* `BRANCH_NAME`: [required]
 
 **Options**:
 
@@ -100,14 +119,14 @@ $ infrahubctl branch merge [OPTIONS] BRANCH_NAME
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
 
-## `infrahubctl branch rebase`
+## `infrahubctl branch validate`
 
-Rebase a Branch with main.
+Validate if a branch has some conflict and is passing all the tests (NOT IMPLEMENTED YET).
 
 **Usage**:
 
 ```console
-$ infrahubctl branch rebase [OPTIONS] BRANCH_NAME
+$ infrahubctl branch validate [OPTIONS] BRANCH_NAME
 ```
 
 **Arguments**:
@@ -136,24 +155,5 @@ $ infrahubctl branch report [OPTIONS] BRANCH_NAME
 **Options**:
 
 * `--update-diff`: Update diff before generating report
-* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--help`: Show this message and exit.
-
-## `infrahubctl branch validate`
-
-Validate if a branch has some conflict and is passing all the tests (NOT IMPLEMENTED YET).
-
-**Usage**:
-
-```console
-$ infrahubctl branch validate [OPTIONS] BRANCH_NAME
-```
-
-**Arguments**:
-
-* `BRANCH_NAME`: [required]
-
-**Options**:
-
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.

--- a/docs/docs/infrahubctl/infrahubctl-object.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-object.mdx
@@ -16,12 +16,52 @@ $ infrahubctl object [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `create`: Create a new object in Infrahub.
-* `delete`: Delete an Infrahub object.
 * `get`: Query and display Infrahub objects.
-* `load`: Load one or multiple objects files into...
+* `create`: Create a new object in Infrahub.
 * `update`: Update an existing object in Infrahub.
+* `delete`: Delete an Infrahub object.
+* `load`: Load one or multiple objects files into...
 * `validate`: Validate one or multiple objects files.
+
+## `infrahubctl object get`
+
+Query and display Infrahub objects.
+
+When IDENTIFIER is omitted the command lists all objects of the given
+KIND. When IDENTIFIER is provided it displays a single object in
+detail view. Empty columns are hidden by default (use --all-columns).
+
+Examples:
+  infrahubctl object get InfraDevice
+  infrahubctl object get InfraDevice spine01
+  infrahubctl object get InfraDevice --filter name__value=spine01
+  infrahubctl object get InfraDevice --output json
+  infrahubctl object get InfraDevice --output yaml &gt; backup.yml
+
+Exit codes: 0 = results found, 1 = error (including not found in detail
+mode), 80 = list query succeeded but returned zero objects.
+
+**Usage**:
+
+```console
+$ infrahubctl object get [OPTIONS] KIND [IDENTIFIER]
+```
+
+**Arguments**:
+
+* `KIND`: Infrahub schema kind to query  [required]
+* `[IDENTIFIER]`: UUID, name, or HFID (use / for multi-part, for example: Cisco/NX-OS)
+
+**Options**:
+
+* `--filter TEXT`: Filter in attr__value=x format
+* `-o, --output [table|json|csv|yaml]`: Output format
+* `-b, --branch TEXT`: Target branch
+* `--limit INTEGER`: Maximum results
+* `--offset INTEGER`: Skip first N results
+* `--all-columns`: Show all columns including empty ones
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
 
 ## `infrahubctl object create`
 
@@ -49,6 +89,37 @@ $ infrahubctl object create [OPTIONS] KIND
 
 * `--set TEXT`: Field value in key=value format
 * `-f, --file PATH`: JSON or YAML file with object data
+* `-b, --branch TEXT`: Target branch
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
+
+## `infrahubctl object update`
+
+Update an existing object in Infrahub.
+
+Fetches the object by KIND and IDENTIFIER, applies the requested
+changes, and saves back to the server. Use --set or --file.
+
+Examples:
+  infrahubctl object update InfraDevice spine01 --set status=active
+  infrahubctl object update InfraDevice spine01 --set location=DC1
+  infrahubctl object update InfraDevice spine01 --file updates.yml
+
+**Usage**:
+
+```console
+$ infrahubctl object update [OPTIONS] KIND IDENTIFIER
+```
+
+**Arguments**:
+
+* `KIND`: Infrahub schema kind  [required]
+* `IDENTIFIER`: UUID, name, or HFID (use / for multi-part, for example: Cisco/NX-OS)  [required]
+
+**Options**:
+
+* `--set TEXT`: Field value in key=value format
+* `-f, --file PATH`: JSON or YAML file with update data
 * `-b, --branch TEXT`: Target branch
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
@@ -82,46 +153,6 @@ $ infrahubctl object delete [OPTIONS] KIND IDENTIFIER
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
 
-## `infrahubctl object get`
-
-Query and display Infrahub objects.
-
-When IDENTIFIER is omitted the command lists all objects of the given
-KIND. When IDENTIFIER is provided it displays a single object in
-detail view. Empty columns are hidden by default (use --all-columns).
-
-Examples:
-  infrahubctl object get InfraDevice
-  infrahubctl object get InfraDevice spine01
-  infrahubctl object get InfraDevice --filter name__value=spine01
-  infrahubctl object get InfraDevice --output json
-  infrahubctl object get InfraDevice --output yaml > backup.yml
-
-Exit codes: 0 = results found, 1 = error (including not found in detail
-mode), 80 = list query succeeded but returned zero objects.
-
-**Usage**:
-
-```console
-$ infrahubctl object get [OPTIONS] KIND [IDENTIFIER]
-```
-
-**Arguments**:
-
-* `KIND`: Infrahub schema kind to query  [required]
-* `[IDENTIFIER]`: UUID, name, or HFID (use / for multi-part, for example: Cisco/NX-OS)
-
-**Options**:
-
-* `--filter TEXT`: Filter in attr__value=x format
-* `-o, --output [table|json|csv|yaml]`: Output format
-* `-b, --branch TEXT`: Target branch
-* `--limit INTEGER`: Maximum results
-* `--offset INTEGER`: Skip first N results
-* `--all-columns`: Show all columns including empty ones
-* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--help`: Show this message and exit.
-
 ## `infrahubctl object load`
 
 Load one or multiple objects files into Infrahub.
@@ -140,37 +171,6 @@ $ infrahubctl object load [OPTIONS] PATHS...
 
 * `--debug / --no-debug`: [default: no-debug]
 * `--branch TEXT`: Branch on which to load the objects.
-* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--help`: Show this message and exit.
-
-## `infrahubctl object update`
-
-Update an existing object in Infrahub.
-
-Fetches the object by KIND and IDENTIFIER, applies the requested
-changes, and saves back to the server. Use --set or --file.
-
-Examples:
-  infrahubctl object update InfraDevice spine01 --set status=active
-  infrahubctl object update InfraDevice spine01 --set location=DC1
-  infrahubctl object update InfraDevice spine01 --file updates.yml
-
-**Usage**:
-
-```console
-$ infrahubctl object update [OPTIONS] KIND IDENTIFIER
-```
-
-**Arguments**:
-
-* `KIND`: Infrahub schema kind  [required]
-* `IDENTIFIER`: UUID, name, or HFID (use / for multi-part, for example: Cisco/NX-OS)  [required]
-
-**Options**:
-
-* `--set TEXT`: Field value in key=value format
-* `-f, --file PATH`: JSON or YAML file with update data
-* `-b, --branch TEXT`: Target branch
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
 

--- a/docs/docs/infrahubctl/infrahubctl-repository.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-repository.mdx
@@ -19,8 +19,8 @@ $ infrahubctl repository [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `add`: Add a new repository.
-* `init`: Initialize a new Infrahub repository.
 * `list`
+* `init`: Initialize a new Infrahub repository.
 
 ## `infrahubctl repository add`
 
@@ -48,20 +48,6 @@ $ infrahubctl repository add [OPTIONS] NAME LOCATION
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
 
-## `infrahubctl repository init`
-
-Initialize a new Infrahub repository.
-
-**Usage**:
-
-```console
-$ infrahubctl repository init [OPTIONS]
-```
-
-**Options**:
-
-* `--help`: Show this message and exit.
-
 ## `infrahubctl repository list`
 
 **Usage**:
@@ -75,4 +61,18 @@ $ infrahubctl repository list [OPTIONS]
 * `--branch TEXT`: Branch on which to list repositories.
 * `--debug / --no-debug`: [default: no-debug]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
+
+## `infrahubctl repository init`
+
+Initialize a new Infrahub repository.
+
+**Usage**:
+
+```console
+$ infrahubctl repository init [OPTIONS]
+```
+
+**Options**:
+
 * `--help`: Show this message and exit.

--- a/docs/docs/infrahubctl/infrahubctl-schema.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-schema.mdx
@@ -16,11 +16,33 @@ $ infrahubctl schema [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
+* `load`: Load one or multiple schema files into...
 * `check`: Check if schema files are valid and what...
 * `export`: Export the schema from Infrahub as YAML...
 * `list`: List all available schema kinds.
-* `load`: Load one or multiple schema files into...
 * `show`: Show details for a specific schema kind.
+
+## `infrahubctl schema load`
+
+Load one or multiple schema files into Infrahub.
+
+**Usage**:
+
+```console
+$ infrahubctl schema load [OPTIONS] SCHEMAS...
+```
+
+**Arguments**:
+
+* `SCHEMAS...`: [required]
+
+**Options**:
+
+* `--debug / --no-debug`: [default: no-debug]
+* `--branch TEXT`: Branch on which to load the schema.
+* `--wait INTEGER`: Time in seconds to wait until the schema has converged across all workers  [default: 0]
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
 
 ## `infrahubctl schema check`
 
@@ -83,28 +105,6 @@ $ infrahubctl schema list [OPTIONS]
 
 * `--filter TEXT`: Filter kinds by name
 * `-b, --branch TEXT`: Target branch
-* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--help`: Show this message and exit.
-
-## `infrahubctl schema load`
-
-Load one or multiple schema files into Infrahub.
-
-**Usage**:
-
-```console
-$ infrahubctl schema load [OPTIONS] SCHEMAS...
-```
-
-**Arguments**:
-
-* `SCHEMAS...`: [required]
-
-**Options**:
-
-* `--debug / --no-debug`: [default: no-debug]
-* `--branch TEXT`: Branch on which to load the schema.
-* `--wait INTEGER`: Time in seconds to wait until the schema has converged across all workers  [default: 0]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.
 

--- a/docs/docs/infrahubctl/infrahubctl-telemetry.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-telemetry.mdx
@@ -14,8 +14,26 @@ $ infrahubctl telemetry [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `export`: Export telemetry snapshots to a JSON file.
 * `list`: List telemetry snapshots with summary...
+* `export`: Export telemetry snapshots to a JSON file.
+
+## `infrahubctl telemetry list`
+
+List telemetry snapshots with summary information.
+
+**Usage**:
+
+```console
+$ infrahubctl telemetry list [OPTIONS]
+```
+
+**Options**:
+
+* `--start-date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%dT%H:%M:%S%z]`: Start date filter (ISO 8601)
+* `--end-date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%dT%H:%M:%S%z]`: End date filter (ISO 8601)
+* `--limit INTEGER`: Maximum number of results  [default: 50]
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
 
 ## `infrahubctl telemetry export`
 
@@ -35,23 +53,5 @@ $ infrahubctl telemetry export [OPTIONS]
 * `--output TEXT`: Output file path  [default: telemetry-export.json]
 * `--start-date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%dT%H:%M:%S%z]`: Start date filter (ISO 8601)
 * `--end-date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%dT%H:%M:%S%z]`: End date filter (ISO 8601)
-* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--help`: Show this message and exit.
-
-## `infrahubctl telemetry list`
-
-List telemetry snapshots with summary information.
-
-**Usage**:
-
-```console
-$ infrahubctl telemetry list [OPTIONS]
-```
-
-**Options**:
-
-* `--start-date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%dT%H:%M:%S%z]`: Start date filter (ISO 8601)
-* `--end-date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%dT%H:%M:%S%z]`: End date filter (ISO 8601)
-* `--limit INTEGER`: Maximum number of results  [default: 50]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.

--- a/docs/docs/infrahubctl/infrahubctl-validate.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-validate.mdx
@@ -16,8 +16,27 @@ $ infrahubctl validate [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `graphql-query`: Validate the format of a GraphQL Query...
 * `schema`: Validate the format of a schema file...
+* `graphql-query`: Validate the format of a GraphQL Query...
+
+## `infrahubctl validate schema`
+
+Validate the format of a schema file either in JSON or YAML
+
+**Usage**:
+
+```console
+$ infrahubctl validate schema [OPTIONS] SCHEMA
+```
+
+**Arguments**:
+
+* `SCHEMA`: [required]
+
+**Options**:
+
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--help`: Show this message and exit.
 
 ## `infrahubctl validate graphql-query`
 
@@ -40,23 +59,4 @@ $ infrahubctl validate graphql-query [OPTIONS] QUERY [VARIABLES]...
 * `--branch TEXT`: Branch on which to validate the GraphQL Query.
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--out TEXT`: Path to a file to save the result.
-* `--help`: Show this message and exit.
-
-## `infrahubctl validate schema`
-
-Validate the format of a schema file either in JSON or YAML
-
-**Usage**:
-
-```console
-$ infrahubctl validate schema [OPTIONS] SCHEMA
-```
-
-**Arguments**:
-
-* `SCHEMA`: [required]
-
-**Options**:
-
-* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--help`: Show this message and exit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ ctl = [
     "pyarrow>=14",
     "pyyaml>=6",
     "rich>=12,<14",
-    "typer>=0.12.5",
-    "click==8.1.*",
+    "typer>=0.15.0",
+    "click>=8.2,<9",
     "ariadne-codegen==0.15.3",
     "mdxify>=0.2.23; python_version>='3.10'",
 ]
@@ -62,8 +62,8 @@ all = [
     "pytest",
     "pyyaml>=6",
     "rich>=12,<14",
-    "typer>=0.12.5",
-    "click==8.1.*",
+    "typer>=0.15.0",
+    "click>=8.2,<9",
     "ariadne-codegen==0.15.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -277,14 +277,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -800,8 +800,8 @@ types = [
 requires-dist = [
     { name = "ariadne-codegen", marker = "extra == 'all'", specifier = "==0.15.3" },
     { name = "ariadne-codegen", marker = "extra == 'ctl'", specifier = "==0.15.3" },
-    { name = "click", marker = "extra == 'all'", specifier = "==8.1.*" },
-    { name = "click", marker = "extra == 'ctl'", specifier = "==8.1.*" },
+    { name = "click", marker = "extra == 'all'", specifier = ">=8.2,<9" },
+    { name = "click", marker = "extra == 'ctl'", specifier = ">=8.2,<9" },
     { name = "dulwich", specifier = ">=0.24.7" },
     { name = "graphql-core", specifier = ">=3.1,<3.3" },
     { name = "httpx", specifier = ">=0.20" },
@@ -823,8 +823,8 @@ requires-dist = [
     { name = "rich", marker = "extra == 'all'", specifier = ">=12,<14" },
     { name = "rich", marker = "extra == 'ctl'", specifier = ">=12,<14" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
-    { name = "typer", marker = "extra == 'all'", specifier = ">=0.12.5" },
-    { name = "typer", marker = "extra == 'ctl'", specifier = ">=0.12.5" },
+    { name = "typer", marker = "extra == 'all'", specifier = ">=0.15.0" },
+    { name = "typer", marker = "extra == 'ctl'", specifier = ">=0.15.0" },
     { name = "ujson", specifier = ">=5" },
     { name = "whenever", specifier = ">=0.9.3,<0.10.0" },
 ]
@@ -2784,17 +2784,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.12.5"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/58/a79003b91ac2c6890fc5d90145c662fd5771c6f11447f116b63300436bc9/typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722", size = 98953, upload-time = "2024-08-24T21:17:57.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/2b/886d13e742e514f704c33c4caa7df0f3b89e5a25ef8db02aa9ca3d9535d5/typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b", size = 47288, upload-time = "2024-08-24T21:17:55.451Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Why

`infrahubctl --help` (and all other `infrahubctl` commands) crash with a `TypeError` when click 8.2+ is installed. Click 8.2 changed the `make_metavar()` signature to require a `ctx` argument; click 8.3 added stricter boolean flag validation. Typer 0.12.x calls both APIs in the old way, so it breaks on any click release beyond 8.1.

The existing `click==8.1.*` pin kept things working as a workaround, but it blocks users from installing packages that require a newer click and prevents us from upgrading `ariadne-codegen` (which requires click 8.2+).

Closes https://github.com/opsmill/infrahub-sdk-python/issues/406


## How to test

```bash
uv run infrahubctl --help        # should print the command listing, no TypeError
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `click` and `typer` so `infrahubctl --help` no longer crashes with Click 8.2+, and refreshes CLI docs to match current help output. Aligns with IHS-136 and unblocks packages that require newer `click` (e.g., `ariadne-codegen`).

- **Dependencies**
  - Set `click` to `>=8.2,<9` and `typer` to `>=0.15.0` for `ctl` and `all` extras; regenerated `uv.lock` (now resolves to `click` 8.2.1 and `typer` 0.25.1).

- **Docs**
  - Synced `infrahubctl` pages (branch, object, repository, schema, telemetry, validate) with current CLI help: reordered subcommands (e.g., list/get first), added missing sections, and fixed arguments/options/examples.

<sup>Written for commit b52edaa156eaf83c2bc96cc23bec0b7a2314fee2. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1024?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

