### PR TITLE
fix(repository): detect existing repo when .git is a worktree gitlink

### DIFF
--- a/infrahub_sdk/repository.py
+++ b/infrahub_sdk/repository.py
@@ -17,7 +17,8 @@ class GitRepoManager:
 
         root_path = Path(self.root_directory)
 
-        if root_path.exists() and (root_path / ".git").is_dir():
+        if root_path.exists() and (root_path / ".git").exists():
+            # `.git` is a directory in a regular clone and a gitlink file in a worktree.
             repo = Repo(self.root_directory)  # Open existing repo
         else:
             repo = Repo.init(self.root_directory, default_branch=self.branch.encode("utf-8"))

--- a/tests/unit/sdk/test_repository.py
+++ b/tests/unit/sdk/test_repository.py
@@ -41,6 +41,26 @@ def test_initialize_repo_uses_existing_repo(temp_dir: str) -> None:
     assert (Path(temp_dir) / ".git").is_dir()
 
 
+def test_initialize_repo_uses_existing_repo_in_worktree(temp_dir: str) -> None:
+    """A git worktree has a `.git` file (gitlink), not a directory.
+
+    GitRepoManager must open the existing repo via the gitlink instead of trying
+    to re-initialize one, which would crash on `mkdir` because the file already exists.
+    """
+    main_path = Path(temp_dir) / "main"
+    worktree_path = Path(temp_dir) / "worktree"
+    main_path.mkdir()
+    worktree_path.mkdir()
+    Repo.init(str(main_path), default_branch=b"main")
+    (worktree_path / ".git").write_text(f"gitdir: {main_path}/.git\n")
+
+    manager = GitRepoManager(str(worktree_path))
+
+    assert manager.git is not None
+    assert isinstance(manager.git, Repo)
+    assert (worktree_path / ".git").is_file()
+
+
 def test_active_branch_returns_correct_branch(temp_dir: str) -> None:
     """Test that the active branch is correctly returned."""
     manager = GitRepoManager(temp_dir, branch="develop")


### PR DESCRIPTION
## Summary

- `GitRepoManager.initialize_repo()` checked `(root / ".git").is_dir()`, which is False in a git worktree where `.git` is a gitlink file (`gitdir: /path/to/main/.git/worktrees/<name>`).
- The existing-repo branch was skipped and `Repo.init` then crashed with `FileExistsError: ./.git` when dulwich tried to `mkdir` over the gitlink file. This made `infrahubctl transform` (and anything else relying on branch auto-detection) unusable from a worktree.
- Fix: switch the check to `.exists()` — dulwich's `Repo(path)` already resolves the gitlink to the real controldir, and `porcelain.active_branch` returns the worktree's branch correctly.

## Test plan

- [x] New unit test `test_initialize_repo_uses_existing_repo_in_worktree` constructs a real gitlink `.git` file pointing to a fresh dulwich repo and asserts `GitRepoManager` opens it instead of re-initializing.
- [x] `uv run pytest tests/unit/sdk/test_repository.py` — all 6 tests pass.
- [x] `uv run invoke format lint-code` — clean (ruff, ty, mypy).
- [x] Manual repro in a worktree: `GitRepoManager('.').active_branch` now returns the worktree branch instead of crashing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix repository detection in Git worktrees by treating `.git` as existing even when it is a gitlink file. This prevents init crashes and restores branch auto-detection for commands like `infrahubctl transform`.

- **Bug Fixes**
  - Switched `.git` check from `.is_dir()` to `.exists()` so worktrees open via `dulwich` `Repo(path)` and return the correct branch.
  - Added unit test `test_initialize_repo_uses_existing_repo_in_worktree` to ensure we open the existing repo instead of re-initializing.

<sup>Written for commit 05d636b43215eebe1dbf49bedd4d5a36e7b8140a. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1029?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

