### PR TITLE
Prepare for version 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
-## [1.20.0](https://github.com/opsmill/infrahub-sdk-python/tree/v1.20.0) - 2026-05-20
+## [1.20.1](https://github.com/opsmill/infrahub-sdk-python/tree/v1.20.1) - 2026-05-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [1.20.0](https://github.com/opsmill/infrahub-sdk-python/tree/v1.20.0) - 2026-05-20
+
+### Added
+
+- Added SHA-1 idempotency primitives for `CoreFileObject` nodes:
+
+  - `InfrahubNode.matches_local_checksum(source)` / sync variant — compare a local `bytes | Path | BinaryIO` source against the node's server-stored checksum without invoking a transfer.
+  - `InfrahubNode.upload_if_changed(source, name=None)` / sync variant — stage + save only when the local source differs from the server, returning an `UploadResult(was_uploaded, checksum)` dataclass.
+  - `download_file(..., skip_if_unchanged=True)` — short-circuit the download when `dest` already exists on disk with a matching SHA-1. Returns `0` bytes written when skipped.
+
+  A shared `sha1_of_source` helper (streaming, 64 KiB chunks) centralises the hashing convention in `infrahub_sdk.file_handler`.
+
+### Fixed
+
+- Skip mandatory field validation during object loading when `object_profile` is specified. ([#908](https://github.com/opsmill/infrahub-sdk-python/issues/908))
+- Render schema rejections originating in an `extensions:` block as a readable one-line message in `infrahubctl schema load`, instead of crashing with `ValueError: invalid literal for int()`. ([#1007](https://github.com/opsmill/infrahub-sdk-python/issues/1007))
+- Add `MERGING` branch status so that a merging branch can still be correctly retrieved. ([#1037](https://github.com/opsmill/infrahub-sdk-python/issues/1037))
+
 ## [1.20.0](https://github.com/opsmill/infrahub-sdk-python/tree/v1.20.0) - 2026-04-24
 
 ### Removed

--- a/changelog/+idempotent-file-ops.added.md
+++ b/changelog/+idempotent-file-ops.added.md
@@ -1,7 +1,0 @@
-Added SHA-1 idempotency primitives for `CoreFileObject` nodes:
-
-- `InfrahubNode.matches_local_checksum(source)` / sync variant — compare a local `bytes | Path | BinaryIO` source against the node's server-stored checksum without invoking a transfer.
-- `InfrahubNode.upload_if_changed(source, name=None)` / sync variant — stage + save only when the local source differs from the server, returning an `UploadResult(was_uploaded, checksum)` dataclass.
-- `download_file(..., skip_if_unchanged=True)` — short-circuit the download when `dest` already exists on disk with a matching SHA-1. Returns `0` bytes written when skipped.
-
-A shared `sha1_of_source` helper (streaming, 64 KiB chunks) centralises the hashing convention in `infrahub_sdk.file_handler`.

--- a/changelog/1007.fixed.md
+++ b/changelog/1007.fixed.md
@@ -1,1 +1,0 @@
-Render schema rejections originating in an `extensions:` block as a readable one-line message in `infrahubctl schema load`, instead of crashing with `ValueError: invalid literal for int()`.

--- a/changelog/1037.fixed.md
+++ b/changelog/1037.fixed.md
@@ -1,1 +1,0 @@
-Add `MERGING` branch status so that a merging branch can still be correctly retrieved.

--- a/changelog/908.fixed.md
+++ b/changelog/908.fixed.md
@@ -1,1 +1,0 @@
-Skip mandatory field validation during object loading when `object_profile` is specified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-sdk"
-version = "1.20.0"
+version = "1.20.1"
 description = "Python Client to interact with Infrahub"
 authors = [
     {name = "OpsMill", email = "info@opsmill.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.20.0"
+version = "1.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },


### PR DESCRIPTION
# Why

Prepare for version 1.20.1

## What changed

* Version bump & compile release notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the `infrahub-sdk` 1.20.1 release. Bumps version and compiles towncrier fragments into the CHANGELOG.

- **New Features**
  - Idempotent file ops for `CoreFileObject`: checksum match, conditional upload, and skip unchanged downloads.

- **Bug Fixes**
  - Skip mandatory field validation when `object_profile` is set (#908).
  - Show one-line error for `extensions:` schema rejections in `infrahubctl schema load` instead of crashing (#1007).
  - Add `MERGING` branch status so merging branches can be retrieved (#1037).

<sup>Written for commit 8efeda2fe884a592e7fa616959886dc35f1be004. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1040?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

