### PR TITLE
IHS-75: Fix cardinality many error message

### DIFF
--- a/changelog/174.fixed.md
+++ b/changelog/174.fixed.md
@@ -1,0 +1,1 @@
+Improve error message when a single node is passed to a cardinality-many relationship.

--- a/infrahub_sdk/node/relationship.py
+++ b/infrahub_sdk/node/relationship.py
@@ -163,7 +163,11 @@ class RelationshipManager(RelationshipManagerBase):
                     RelatedNode(name=name, client=self.client, branch=self.branch, schema=schema, data=item)
                 )
         else:
-            raise ValueError(f"Unexpected format for {name} found a {type(data)}, {data}")
+            raise ValueError(
+                f"Relationship '{name}' expects a list of nodes (cardinality many), "
+                f"but received a single {type(data).__name__}. "
+                f"Wrap the value in a list, e.g. {name}=[value]."
+            )
 
     def __getitem__(self, item: int) -> RelatedNode:
         return self.peers[item]  # type: ignore[return-value]
@@ -296,7 +300,11 @@ class RelationshipManagerSync(RelationshipManagerBase):
                     RelatedNodeSync(name=name, client=self.client, branch=self.branch, schema=schema, data=item)
                 )
         else:
-            raise ValueError(f"Unexpected format for {name} found a {type(data)}, {data}")
+            raise ValueError(
+                f"Relationship '{name}' expects a list of nodes (cardinality many), "
+                f"but received a single {type(data).__name__}. "
+                f"Wrap the value in a list, e.g. {name}=[value]."
+            )
 
     def __getitem__(self, item: int) -> RelatedNodeSync:
         return self.peers[item]  # type: ignore[return-value]

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -313,6 +313,36 @@ async def test_init_node_data_graphql(
 
 
 @pytest.mark.parametrize("client_type", client_types)
+async def test_cardinality_many_requires_list(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    data = {
+        "name": {"value": "JFK1"},
+        "tags": {"id": "pppppppp"},
+    }
+    with pytest.raises(ValueError, match=r"expects a list of nodes"):
+        if client_type == "standard":
+            InfrahubNode(client=client, schema=location_schema, data=data)
+        else:
+            InfrahubNodeSync(client=client, schema=location_schema, data=data)
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_cardinality_many_accepts_list(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    data = {
+        "name": {"value": "JFK1"},
+        "tags": [{"id": "aaaaaa"}, {"id": "bbbb"}],
+    }
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data=data)
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
+    assert len(node.tags.peers) == 2
+
+
+@pytest.mark.parametrize("client_type", client_types)
 async def test_query_data_no_filters_property(
     clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
 ) -> None:


### PR DESCRIPTION
# Why

Improve error message now names the relationship, states that a list is required, and shows the correction.

Closes https://github.com/opsmill/infrahub-sdk-python/issues/174

## Checklist

- [X] Tests added/updated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the error shown when a single value is passed to a cardinality-many relationship. The message now names the relationship, says a list is required, shows the received type, and gives an example fix (e.g., tags=[value]).

- **Bug Fixes**
  - Update `relationship.py` to raise a clear ValueError in both async and sync constructors when non-list data is provided to a many relationship.
  - Add unit tests to confirm single values are rejected and lists are accepted.

<sup>Written for commit 329c647eea8a17b5bcb505070d86cb5c4b7c2033. Summary will update on new commits. <a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1044?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

