### PR TITLE
fix(ctl): let typer.Exit propagate so CLI commands exit without a traceback

### DIFF
--- a/changelog/1047.fixed.md
+++ b/changelog/1047.fixed.md
@@ -1,0 +1,1 @@
+Fix `infrahubctl` printing a spurious `Error: 1` and Python traceback after the human-readable error message when a command exits with `typer.Exit`. The CLI now exits cleanly with only the intended error output.

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 import typer
-from click.exceptions import Exit
 from httpx import HTTPError
 from rich.console import Console
 from rich.logging import RichHandler
@@ -54,8 +53,6 @@ def init_logging(debug: bool = False) -> None:
 
 def handle_exception(exc: Exception, console: Console, exit_code: int) -> NoReturn:
     """Handle exception in a different fashion based on its type."""
-    if isinstance(exc, Exit):
-        raise typer.Exit(code=exc.exit_code)
     if isinstance(exc, AuthenticationError):
         console.print(f"[red]Authentication failure: {exc!s}")
         raise typer.Exit(code=exit_code)
@@ -91,6 +88,8 @@ def catch_exception(
             async def async_wrapper(*args: Any, **kwargs: Any) -> T:
                 try:
                     return await func(*args, **kwargs)
+                except typer.Exit:
+                    raise
                 except (Error, Exception) as exc:
                     return handle_exception(exc=exc, console=console, exit_code=exit_code)
 
@@ -100,6 +99,8 @@ def catch_exception(
         def wrapper(*args: Any, **kwargs: Any) -> T:
             try:
                 return func(*args, **kwargs)
+            except typer.Exit:
+                raise
             except (Error, Exception) as exc:
                 return handle_exception(exc=exc, console=console, exit_code=exit_code)
 

--- a/infrahub_sdk/ctl/utils.py
+++ b/infrahub_sdk/ctl/utils.py
@@ -53,6 +53,8 @@ def init_logging(debug: bool = False) -> None:
 
 def handle_exception(exc: Exception, console: Console, exit_code: int) -> NoReturn:
     """Handle exception in a different fashion based on its type."""
+    if isinstance(exc, typer.Exit):
+        raise exc
     if isinstance(exc, AuthenticationError):
         console.print(f"[red]Authentication failure: {exc!s}")
         raise typer.Exit(code=exit_code)
@@ -88,8 +90,6 @@ def catch_exception(
             async def async_wrapper(*args: Any, **kwargs: Any) -> T:
                 try:
                     return await func(*args, **kwargs)
-                except typer.Exit:
-                    raise
                 except (Error, Exception) as exc:
                     return handle_exception(exc=exc, console=console, exit_code=exit_code)
 
@@ -99,8 +99,6 @@ def catch_exception(
         def wrapper(*args: Any, **kwargs: Any) -> T:
             try:
                 return func(*args, **kwargs)
-            except typer.Exit:
-                raise
             except (Error, Exception) as exc:
                 return handle_exception(exc=exc, console=console, exit_code=exit_code)
 

--- a/tests/unit/ctl/test_utils.py
+++ b/tests/unit/ctl/test_utils.py
@@ -1,0 +1,47 @@
+import typer
+from rich.console import Console
+from typer.testing import CliRunner
+
+from infrahub_sdk.async_typer import AsyncTyper
+from infrahub_sdk.ctl.utils import catch_exception
+from tests.helpers.cli import remove_ansi_color
+
+runner = CliRunner()
+
+
+def test_catch_exception_async_passes_through_typer_exit() -> None:
+    console = Console()
+    app = AsyncTyper()
+
+    @app.command()
+    @catch_exception(console=console)
+    async def fail() -> None:
+        console.print("human-readable failure message")
+        raise typer.Exit(1)
+
+    result = runner.invoke(app, [])
+    stdout = remove_ansi_color(result.stdout)
+
+    assert result.exit_code == 1
+    assert "human-readable failure message" in stdout
+    assert "Traceback" not in stdout
+    assert "Error: 1" not in stdout
+
+
+def test_catch_exception_sync_passes_through_typer_exit() -> None:
+    console = Console()
+    app = typer.Typer()
+
+    @app.command()
+    @catch_exception(console=console)
+    def fail() -> None:
+        console.print("human-readable failure message")
+        raise typer.Exit(1)
+
+    result = runner.invoke(app, [])
+    stdout = remove_ansi_color(result.stdout)
+
+    assert result.exit_code == 1
+    assert "human-readable failure message" in stdout
+    assert "Traceback" not in stdout
+    assert "Error: 1" not in stdout


### PR DESCRIPTION
# Why

Newer versions of typer behave differently and produce an error that's not as friendly as we'd want and we don't want to show that error.

Closes #1047

## What changed

* Catch error from typer early and avoid showing it to the end user
* Tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `infrahubctl` so commands that raise `typer.Exit` exit cleanly without the "Error: 1" line or a traceback. Addresses IHS-237 by ensuring `infrahubctl schema load` prints only the human-readable error and exits with code 1.

- **Bug Fixes**
  - Let `typer.Exit` pass through in `catch_exception` (sync/async) and `handle_exception`, removing `click.exceptions.Exit` interception so Typer exits cleanly without a traceback.
  - Add tests for `typer.Typer` and `AsyncTyper` to verify clean output, correct exit code, and no "Error: 1" line.

<sup>Written for commit b39470721e82ccea8360f5c84e6f47f01036e1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

