### PR TITLE
Raise timeout for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
     runs-on:
       group: "huge-runners"
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v6"


### PR DESCRIPTION
# Why

Pipelines are failing due to timeout issues

## What changed

Increase timeout value..

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase CI integration test job timeout from 40 to 60 minutes to prevent pipeline failures on longer runs.

<sup>Written for commit 13433b6ef861f4510aad27b1d2356773e90f4cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1049?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

