### PR TITLE
Add watch statement to artifact definitions

### DIFF
--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -69,7 +69,7 @@ class InfrahubJinja2TransformConfig(InfrahubRepositoryConfigElement):
         return str(self.template_path)
 
     @property
-    def payload(self) -> dict[str, str]:
+    def payload(self) -> dict[str, Any]:
         data = self.model_dump(exclude_none=True)
         data["template_path"] = self.template_path_value
         return data

--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -37,12 +37,32 @@ class InfrahubRepositoryArtifactDefinitionConfig(InfrahubRepositoryConfigElement
     transformation: str = Field(..., description="The transformation to use.")
 
 
+class InfrahubWatchConfig(BaseModel):
+    """Extra files and directories a transform depends on.
+
+    Infrahub already detects the files a transform reads directly. Use this when a transform also
+    depends on files that cannot be detected automatically, such as templates pulled in dynamically
+    or helper modules imported at runtime. When any watched file changes, the transform's artifacts
+    are regenerated.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    files: list[str] = Field(
+        default_factory=list,
+        description="Files or directories the transform depends on, relative to the repository root. A directory watches every file beneath it.",
+    )
+
+
 class InfrahubJinja2TransformConfig(InfrahubRepositoryConfigElement):
     model_config = ConfigDict(extra="forbid")
     name: str = Field(..., description="The name of the transform")
     query: str = Field(..., description="The name of the GraphQL Query")
     template_path: Path = Field(..., description="The path within the repository of the template file")
     description: str | None = Field(default=None, description="Description for this transform")
+    watch: InfrahubWatchConfig | None = Field(
+        default=None,
+        description="Extra files and directories this transform depends on, in addition to the ones Infrahub detects automatically.",
+    )
 
     @property
     def template_path_value(self) -> str:
@@ -137,6 +157,10 @@ class InfrahubPythonTransformConfig(InfrahubRepositoryConfigElement):
         description="Decide if the transform should convert the result of the GraphQL query to SDK InfrahubNode objects.",
     )
     description: str | None = Field(default=None, description="Description for this transform")
+    watch: InfrahubWatchConfig | None = Field(
+        default=None,
+        description="Extra files and directories this transform depends on, in addition to the ones Infrahub detects automatically.",
+    )
 
     def load_class(self, import_root: str | None = None, relative_path: str | None = None) -> type[InfrahubTransform]:
         module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)

--- a/tests/unit/sdk/test_schema_repository.py
+++ b/tests/unit/sdk/test_schema_repository.py
@@ -2,12 +2,16 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from infrahub_sdk.exceptions import FragmentFileNotFoundError, RepositoryFileNotFoundError, ResourceNotDefinedError
 from infrahub_sdk.schema.repository import (
+    InfrahubJinja2TransformConfig,
+    InfrahubPythonTransformConfig,
     InfrahubRepositoryConfig,
     InfrahubRepositoryFragmentConfig,
     InfrahubRepositoryGraphQLConfig,
+    InfrahubWatchConfig,
 )
 
 
@@ -336,3 +340,55 @@ def test_load_query_missing_file_raises() -> None:
     with tempfile.TemporaryDirectory() as tmp, pytest.raises(RepositoryFileNotFoundError) as exc_info:
         cfg.load_query(relative_path=tmp)
     assert "does_not_exist.gql" in exc_info.value.file_path
+
+
+# --- InfrahubWatchConfig ---
+
+
+def test_watch_config_unknown_key_rejected() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        InfrahubWatchConfig.model_validate({"fles": ["utils/"]})
+
+
+def test_jinja2_transform_watch_parses_object_form() -> None:
+    config = InfrahubJinja2TransformConfig.model_validate(
+        {
+            "name": "DeviceConfig",
+            "query": "q",
+            "template_path": "templates/device.j2",
+            "watch": {"files": ["templates/partials/"]},
+        }
+    )
+    assert config.watch is not None
+    assert config.watch.files == ["templates/partials/"]
+
+
+def test_python_transform_watch_parses_object_form() -> None:
+    config = InfrahubPythonTransformConfig.model_validate(
+        {
+            "name": "DeviceName",
+            "file_path": "transforms/name.py",
+            "watch": {"files": ["utils/", "shared/helpers.py"]},
+        }
+    )
+    assert config.watch is not None
+    assert config.watch.files == ["utils/", "shared/helpers.py"]
+
+
+def test_jinja2_transform_payload_excludes_absent_watch() -> None:
+    config = InfrahubJinja2TransformConfig.model_validate(
+        {"name": "DeviceConfig", "query": "q", "template_path": "templates/device.j2"}
+    )
+    assert "watch" not in config.payload
+
+
+def test_jinja2_transform_payload_includes_declared_watch() -> None:
+    config = InfrahubJinja2TransformConfig.model_validate(
+        {
+            "name": "DeviceConfig",
+            "query": "q",
+            "template_path": "templates/device.j2",
+            "watch": {"files": ["templates/partials/"]},
+        }
+    )
+    assert config.payload["watch"] == {"files": ["templates/partials/"]}


### PR DESCRIPTION

# Why

Add watch section under artifact definitions, part of the larger effort in https://github.com/opsmill/infrahub/pull/9414 

Closes IHS-238

## What changed

* New "watch" section in artifact definition config
* Tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `watch` section to artifact transforms in `infrahub_sdk` to list extra files and directories that trigger regeneration. Supports IHS-238 by rebuilding artifacts on Git changes that aren’t auto-detected.

- **New Features**
  - Added `InfrahubWatchConfig` with `files: list[str]`; directories are recursive; unknown keys are rejected.
  - `watch` supported on `InfrahubJinja2TransformConfig` and `InfrahubPythonTransformConfig`; included in `payload` only when set.
  - Tests for validation, parsing, and payload inclusion/exclusion.

<sup>Written for commit 79596357397948365fa2fd2a2459f2854df279dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

