### PR TITLE
Merge 'develop' into 'infrahub-develop' with resolved conflicts

### DIFF
--- a/changelog/1064.fixed.md
+++ b/changelog/1064.fixed.md
@@ -1,0 +1,5 @@
+Cardinality-one relationships in generated protocols are now typed with a `RelationshipAttribute[...]` descriptor. It still reads back as a typed `RelatedNode[Peer]` (so `.peer` keeps the peer type), but it accepts assignment of an id string, an HFID, a peer node, or `None` — mirroring the runtime `InfrahubNode.__setattr__`, which wraps the assigned value in a `RelatedNode`.
+
+Previously relationships were typed read-only as `RelatedNode`, so the documented way of setting a relationship (`node.rel = "<id>"` or `node.rel = peer_node`) failed under mypy/ty with an `assignment` error. The descriptor only appears in generated protocols and is never instantiated at runtime.
+
+Because the new typing lives in the generated protocols, existing projects must regenerate them with `infrahubctl protocols` to pick up the change — it does not take effect for already-generated protocol files. ([#1064](https://github.com/opsmill/infrahub-sdk-python/issues/1064))

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/related_node.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/related_node.mdx
@@ -156,3 +156,18 @@ when this RelatedNode's .id is None — that is the case in which
 
 - `ValueError`: when neither a peer, (_id,_typename), nor hfid_str
 is available.
+
+### `RelationshipAttribute`
+
+Typing descriptor for a cardinality-one relationship on a generated protocol.
+
+It reads back as ``RelatedNode[PeerT]`` (so ``.peer`` keeps the peer type) but accepts
+assignment of an id string, an HFID, a peer node, or ``None`` — mirroring the runtime
+``InfrahubNode.__setattr__`` behaviour, which wraps the assigned value in a ``RelatedNode``.
+
+This type only appears in generated protocols (it is never instantiated at runtime), so it
+exists purely to give ``node.rel`` separate read and assignment types under a type checker.
+
+### `RelationshipAttributeSync`
+
+Synchronous counterpart of :class:`RelationshipAttribute`.

--- a/infrahub_sdk/node/__init__.py
+++ b/infrahub_sdk/node/__init__.py
@@ -16,7 +16,13 @@ from .constants import (
 from .node import InfrahubNode, InfrahubNodeBase, InfrahubNodeSync, UploadResult
 from .parsers import parse_human_friendly_id
 from .property import NodeProperty
-from .related_node import RelatedNode, RelatedNodeBase, RelatedNodeSync
+from .related_node import (
+    RelatedNode,
+    RelatedNodeBase,
+    RelatedNodeSync,
+    RelationshipAttribute,
+    RelationshipAttributeSync,
+)
 from .relationship import RelationshipManager, RelationshipManagerBase, RelationshipManagerSync
 
 __all__ = [
@@ -38,6 +44,8 @@ __all__ = [
     "RelatedNode",
     "RelatedNodeBase",
     "RelatedNodeSync",
+    "RelationshipAttribute",
+    "RelationshipAttributeSync",
     "RelationshipManager",
     "RelationshipManagerBase",
     "RelationshipManagerSync",

--- a/infrahub_sdk/node/related_node.py
+++ b/infrahub_sdk/node/related_node.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Generic, cast
+from typing import TYPE_CHECKING, Any, Generic, cast, overload
 
 from typing_extensions import TypeVar
 
@@ -350,3 +350,45 @@ class RelatedNodeSync(RelatedNodeBase, Generic[PeerTSync]):
             return cast("PeerTSync", self._client.store.get(key=self.hfid_str, branch=self._branch))
 
         raise ValueError("Node must have at least one identifier (ID or HFID) to query it.")
+
+
+class RelationshipAttribute(Generic[PeerT]):
+    """Typing descriptor for a cardinality-one relationship on a generated protocol.
+
+    It reads back as ``RelatedNode[PeerT]`` (so ``.peer`` keeps the peer type) but accepts
+    assignment of an id string, an HFID, a peer node, or ``None`` — mirroring the runtime
+    ``InfrahubNode.__setattr__`` behaviour, which wraps the assigned value in a ``RelatedNode``.
+
+    This type only appears in generated protocols (it is never instantiated at runtime), so it
+    exists purely to give ``node.rel`` separate read and assignment types under a type checker.
+    """
+
+    @overload
+    def __get__(self, instance: None, owner: Any = None) -> RelationshipAttribute[PeerT]: ...
+
+    @overload
+    def __get__(self, instance: object, owner: Any = None) -> RelatedNode[PeerT]: ...
+
+    def __get__(self, instance: object | None, owner: Any = None) -> RelationshipAttribute[PeerT] | RelatedNode[PeerT]:
+        raise NotImplementedError  # typing-only descriptor; never invoked at runtime
+
+    def __set__(self, instance: object, value: str | list[str] | PeerT | None) -> None:
+        raise NotImplementedError  # typing-only descriptor; never invoked at runtime
+
+
+class RelationshipAttributeSync(Generic[PeerTSync]):
+    """Synchronous counterpart of :class:`RelationshipAttribute`."""
+
+    @overload
+    def __get__(self, instance: None, owner: Any = None) -> RelationshipAttributeSync[PeerTSync]: ...
+
+    @overload
+    def __get__(self, instance: object, owner: Any = None) -> RelatedNodeSync[PeerTSync]: ...
+
+    def __get__(
+        self, instance: object | None, owner: Any = None
+    ) -> RelationshipAttributeSync[PeerTSync] | RelatedNodeSync[PeerTSync]:
+        raise NotImplementedError  # typing-only descriptor; never invoked at runtime
+
+    def __set__(self, instance: object, value: str | list[str] | PeerTSync | None) -> None:
+        raise NotImplementedError  # typing-only descriptor; never invoked at runtime

--- a/infrahub_sdk/protocols_generator/generator.py
+++ b/infrahub_sdk/protocols_generator/generator.py
@@ -128,7 +128,9 @@ class CodeGenerator:
         cardinality = value.cardinality
         peer = value.peer
 
-        type_ = "RelatedNode"
+        # Cardinality-one relationships use a descriptor so they can be assigned an id string,
+        # an HFID, a peer node or ``None`` while still reading back as a typed ``RelatedNode``.
+        type_ = "RelationshipAttribute"
         if cardinality == RelationshipCardinality.MANY:
             type_ = "RelationshipManager"
 

--- a/infrahub_sdk/protocols_generator/template.j2
+++ b/infrahub_sdk/protocols_generator/template.j2
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional
 from infrahub_sdk.protocols import {{ "CoreNode" | syncify(sync) }}, {{ base_protocols | join(', ') }}
 
 if TYPE_CHECKING:
-    from infrahub_sdk.node import {{ "RelatedNode" | syncify(sync) }}, {{ "RelationshipManager" | syncify(sync) }}
+    from infrahub_sdk.node import {{ "RelatedNode" | syncify(sync) }}, {{ "RelationshipAttribute" | syncify(sync) }}, {{ "RelationshipManager" | syncify(sync) }}
     from infrahub_sdk.protocols_base import (
         AnyAttribute,
         AnyAttributeOptional,
@@ -52,7 +52,7 @@ class {{ generic.namespace + generic.name }}({{core_node_name}}):
     {{ relationship | render_relationship(sync) }}
     {% endfor %}
     {% if generic.hierarchical | default(false) %}
-    parent: {{ "RelatedNode" | syncify(sync) }}[{{ generic.namespace + generic.name }}]
+    parent: {{ "RelationshipAttribute" | syncify(sync) }}[{{ generic.namespace + generic.name }}]
     children: {{ "RelationshipManager" | syncify(sync) }}[{{ generic.namespace + generic.name }}]
     {% endif %}
 {% endfor %}
@@ -71,7 +71,7 @@ class {{ node.namespace + node.name }}({{ node.inherit_from | syncify(sync) | jo
     {{ relationship | render_relationship(sync) }}
     {% endfor %}
     {% if node.hierarchical | default(false) %}
-    parent: {{ "RelatedNode" | syncify(sync) }}[{{ node.namespace + node.name }}]
+    parent: {{ "RelationshipAttribute" | syncify(sync) }}[{{ node.namespace + node.name }}]
     children: {{ "RelationshipManager" | syncify(sync) }}[{{ node.namespace + node.name }}]
     {% endif %}
 
@@ -91,7 +91,7 @@ class {{ node.namespace + node.name }}({{ node.inherit_from | syncify(sync) | jo
     {{ relationship | render_relationship(sync) }}
     {% endfor %}
     {% if node.hierarchical | default(false) %}
-    parent: {{ "RelatedNode" | syncify(sync) }}[{{ node.namespace + node.name }}]
+    parent: {{ "RelationshipAttribute" | syncify(sync) }}[{{ node.namespace + node.name }}]
     children: {{ "RelationshipManager" | syncify(sync) }}[{{ node.namespace + node.name }}]
     {% endif %}
 

--- a/tests/unit/sdk/test_protocols_generator.py
+++ b/tests/unit/sdk/test_protocols_generator.py
@@ -115,7 +115,7 @@ class LocationSite(LocationGeneric):
     shortname: String
     children: RelationshipManagerSync[LocationRack]
     member_of_groups: RelationshipManagerSync[CoreGroupSync]
-    parent: RelatedNodeSync[LocationCountry]
+    parent: RelationshipAttributeSync[LocationCountry]
     profiles: RelationshipManagerSync[CoreProfileSync]
     servers: RelationshipManagerSync[NetworkManagementServer]
     subscriber_of_groups: RelationshipManagerSync[CoreGroupSync]

--- a/uv.lock
+++ b/uv.lock
@@ -894,7 +894,7 @@ types = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.6"
+version = "1.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -904,9 +904,9 @@ dependencies = [
     { name = "pytest" },
     { name = "testcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/25/0e56af611410a79ab242dea99a1892af8840524c58870b3050e59a4f99b1/infrahub_testcontainers-1.9.6.tar.gz", hash = "sha256:c75015a166d05aaa00804bf5be42f041e10745a7fa4c6ac13713febc60ae617f", size = 17365, upload-time = "2026-05-20T19:42:41.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/02/467481cbc12e0c841b155426e52567b443ab02928566dc0975c27f69f145/infrahub_testcontainers-1.9.7.tar.gz", hash = "sha256:87fbbaf64682ff07937543b2ef2335f8e250a8ecbd5420b525a629462a583b37", size = 17365, upload-time = "2026-06-03T16:07:03.507Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/25/284135f880d60d1c912a269c88a048a420a691b5b337d05027d269803d48/infrahub_testcontainers-1.9.6-py3-none-any.whl", hash = "sha256:6a2d185513b56071e0235ec71d8ac33be1e29dc2c6815b1ec5ce1d9994cc4e74", size = 23197, upload-time = "2026-05-20T19:42:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8b/3d60e3ad79ca9ec492c865f9464d0416ec7a008550df28fe0ced1108ef0c/infrahub_testcontainers-1.9.7-py3-none-any.whl", hash = "sha256:af29200fc4aedcbd432f53692573e3d8bac381642d89c9a56986bc6d6586e45b", size = 23199, upload-time = "2026-06-03T16:07:04.268Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Why

Resolve merge conflicts between the two branches

## What changed

* Everything from develop
* Resolved merge conflict in uv.lock (version mismatch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `RelationshipAttribute`/`RelationshipAttributeSync` in generated protocols so cardinality‑one relationships are assignable (id, HFID, peer, or None) while reading as a typed `RelatedNode`, fixing mypy/ty errors. Also updates codegen templates, docs, tests, and bumps `infrahub-testcontainers` to 1.9.7.

- **Bug Fixes**
  - Generated one-to-one relationships use a typing-only descriptor that preserves `RelatedNode[Peer]` on read and allows safe assignment.

- **Migration**
  - Regenerate protocols to pick up the new typing: run `infrahubctl protocols`.

<sup>Written for commit d37bbc7af94ec3a4f342c40720bcbe53ef94d72c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

