### PR TITLE
Merge 'stable' into 'develop' with resolved conflicts

### DIFF
--- a/changelog/339.fixed.md
+++ b/changelog/339.fixed.md
@@ -1,0 +1,1 @@
+Calling `.save(allow_upsert=True)` on a node whose human-friendly identifier contains a CoreNumberPool-sourced attribute now raises a clear `ValidationError` instead of crashing with an opaque backend error.

--- a/docs/docs/python-sdk/guides/resource-manager.mdx
+++ b/docs/docs/python-sdk/guides/resource-manager.mdx
@@ -309,3 +309,58 @@ query {
 ```
 
 Notice that we have one IP address allocated by the Resource manager in the test branch. The query in the main branch shows us this allocation, indicating that it has been allocated and the resource cannot be allocated again. However, the IP address does not exist itself within the main branch.
+
+## CoreNumberPool and attribute allocation
+
+`CoreNumberPool` allocates integer values (such as VLAN IDs or AS numbers) directly to node attributes. The pool assigns the integer value at the moment the node is created on the server.
+
+```python
+vlan = await client.create(
+    kind="InfraVLAN",
+    name="VLAN-100",
+    vlan_id={"from_pool": {"id": pool_id}},
+)
+await vlan.save()
+```
+
+### Limitation: `allow_upsert=True` with a pool-sourced HFID attribute
+
+`CoreNumberPool` assigns the integer value at server creation time. The SDK does not know the assigned value before the node exists. When a node's human-friendly identifier (HFID) includes a pool-sourced attribute, the SDK cannot construct the HFID needed to look up an existing node for upsert.
+
+:::warning
+
+Calling `save(allow_upsert=True)` on a node whose HFID contains a `CoreNumberPool`-sourced attribute raises `ValidationError` before any network call is made.
+
+```python
+# Schema has human_friendly_id: ["vlan_id__value"]
+vlan = await client.create(
+    kind="InfraVLAN",
+    name="VLAN-100",
+    vlan_id={"from_pool": {"id": pool_id}},
+)
+
+# This raises ValidationError — the pool-assigned vlan_id is unknown client-side
+await vlan.save(allow_upsert=True)
+```
+
+**Alternatives:**
+
+- **Two-step pattern** — create the node first, then update it in a separate call:
+
+  ```python
+  await vlan.save()           # creates node, pool assigns vlan_id
+  # later, if you need to update:
+  vlan.name.value = "VLAN-100-updated"
+  await vlan.save()           # now _existing=True, calls update
+  ```
+
+- **Explicit id** — if you already know the node's UUID, set `node.id` before saving. The upsert will use the UUID directly and skip HFID lookup:
+
+  ```python
+  vlan.id = "known-uuid"
+  await vlan.save(allow_upsert=True)  # guard bypassed
+  ```
+
+- **Deterministic identifier** — if possible, design your schema so the HFID uses a non-pool attribute (for example, a human-assigned `name`) and keep `vlan_id` out of the HFID.
+
+:::

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/node/attribute.mdx
@@ -36,3 +36,19 @@ Check whether this attribute's value is sourced from a resource pool.
 **Returns:**
 
 - True if the attribute value is a resource pool node or was explicitly allocated from a pool.
+
+#### `is_unresolved_pool_attribute`
+
+```python
+is_unresolved_pool_attribute(self) -> bool
+```
+
+Return True when pool-backed but no concrete scalar value is available yet.
+
+A pool-backed attribute is unresolved when:
+
+- its value is a pool node object (the pool reference itself, not an allocated scalar), or
+- its value is None and the from_pool allocation dict is set.
+
+An attribute whose _from_pool dict is set but whose value has already been populated
+with the allocated scalar (e.g. after a prior save) is considered resolved.

--- a/infrahub_sdk/node/attribute.py
+++ b/infrahub_sdk/node/attribute.py
@@ -191,3 +191,17 @@ class Attribute:
 
         """
         return (isinstance(self.value, CoreNodeBase) and self.value.is_resource_pool()) or self._from_pool is not None
+
+    def is_unresolved_pool_attribute(self) -> bool:
+        """Return True when pool-backed but no concrete scalar value is available yet.
+
+        A pool-backed attribute is unresolved when:
+        - its value is a pool node object (the pool reference itself, not an allocated scalar), or
+        - its value is None and the from_pool allocation dict is set.
+
+        An attribute whose _from_pool dict is set but whose value has already been populated
+        with the allocated scalar (e.g. after a prior save) is considered resolved.
+        """
+        if isinstance(self.value, CoreNodeBase) and self.value.is_resource_pool():
+            return True
+        return self._from_pool is not None and self.value is None

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, overload
 
 from ..constants import InfrahubClientMode
-from ..exceptions import FeatureNotSupportedError, NodeNotFoundError, ResourceNotDefinedError, SchemaNotFoundError
+from ..exceptions import (
+    FeatureNotSupportedError,
+    NodeNotFoundError,
+    ResourceNotDefinedError,
+    SchemaNotFoundError,
+    ValidationError,
+)
 from ..file_handler import FileHandler, FileHandlerBase, FileHandlerSync, PreparedFile, sha1_of_source
 from ..graphql import Mutation, Query
 from ..schema import (
@@ -590,6 +596,36 @@ class InfrahubNodeBase:
             return self._attribute_data[name]
 
         raise ResourceNotDefinedError(message=f"The node doesn't have an attribute for {name}")
+
+    def _validate_upsert(self, allow_upsert: bool) -> None:
+        """Ensure an upsert can resolve the HFID before attempting to save.
+
+        An attribute sourced from a CoreNumberPool has no concrete value until the node is
+        created, so it cannot be used to look up an existing node by its human-friendly identifier.
+
+        Raises:
+            ValidationError: If an HFID attribute is sourced from an unresolved CoreNumberPool.
+
+        """
+        if not (allow_upsert and not self.id):
+            return
+
+        for hfid_path in self._schema.human_friendly_id or []:
+            attr_name = hfid_path.split("__")[0]
+            try:
+                attr = self._get_attribute(attr_name)
+            except ResourceNotDefinedError:
+                continue
+            if attr.is_unresolved_pool_attribute():
+                raise ValidationError(
+                    identifier=attr_name,
+                    message=(
+                        f"Attribute '{attr_name}' is sourced from a CoreNumberPool and is part of "
+                        "this node's human-friendly identifier. Upsert cannot resolve the HFID "
+                        "without a concrete value. Use an explicit id, or create the node first "
+                        "and update it in a separate call."
+                    ),
+                )
 
     @staticmethod
     def _build_rel_query_data(
@@ -1265,6 +1301,8 @@ class InfrahubNode(InfrahubNodeBase):
     async def create(
         self, allow_upsert: bool = False, timeout: int | None = None, request_context: RequestContext | None = None
     ) -> None:
+        self._validate_upsert(allow_upsert=allow_upsert)
+
         if self._file_object_support and self._file_content is None:
             raise ValueError(
                 f"Cannot create {self._schema.kind} without file content. Use upload_from_path() or upload_from_bytes() to provide "
@@ -2237,6 +2275,8 @@ class InfrahubNodeSync(InfrahubNodeBase):
     def create(
         self, allow_upsert: bool = False, timeout: int | None = None, request_context: RequestContext | None = None
     ) -> None:
+        self._validate_upsert(allow_upsert=allow_upsert)
+
         if self._file_object_support and self._file_content is None:
             raise ValueError(
                 f"Cannot create {self._schema.kind} without file content. Use upload_from_path() or upload_from_bytes() to provide "

--- a/infrahub_sdk/repository.py
+++ b/infrahub_sdk/repository.py
@@ -17,7 +17,8 @@ class GitRepoManager:
 
         root_path = Path(self.root_directory)
 
-        if root_path.exists() and (root_path / ".git").is_dir():
+        if root_path.exists() and (root_path / ".git").exists():
+            # `.git` is a directory in a regular clone and a gitlink file in a worktree.
             repo = Repo(self.root_directory)  # Open existing repo
         else:
             repo = Repo.init(self.root_directory, default_branch=self.branch.encode("utf-8"))

--- a/tests/unit/sdk/pool/conftest.py
+++ b/tests/unit/sdk/pool/conftest.py
@@ -114,3 +114,23 @@ async def ipprefix_pool_schema() -> NodeSchemaAPI:
         ],
     }
     return NodeSchema(**data).convert_api()
+
+
+@pytest.fixture
+async def vlan_schema_with_pool_hfid() -> NodeSchemaAPI:
+    """VLAN schema where vlan_id (NumberPool-sourced) is part of the human_friendly_id."""
+    data: dict[str, Any] = {
+        "name": "VLAN",
+        "namespace": "Infra",
+        "label": "VLAN",
+        "default_filter": "name__value",
+        "order_by": ["name__value"],
+        "display_labels": ["name__value"],
+        "human_friendly_id": ["vlan_id__value"],
+        "attributes": [
+            {"name": "name", "kind": "Text", "unique": True},
+            {"name": "vlan_id", "kind": "Number"},
+        ],
+        "relationships": [],
+    }
+    return NodeSchema(**data).convert_api()

--- a/tests/unit/sdk/pool/test_attribute_from_pool.py
+++ b/tests/unit/sdk/pool/test_attribute_from_pool.py
@@ -11,11 +11,17 @@ There are two ways to request a pool allocation:
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
+from infrahub_sdk.exceptions import ValidationError
 from infrahub_sdk.node import InfrahubNode, InfrahubNodeSync
 
 if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
     from infrahub_sdk import InfrahubClient, InfrahubClientSync
     from infrahub_sdk.schema import NodeSchemaAPI
 
@@ -204,3 +210,126 @@ async def test_attribute_with_pool_node_generates_mutation_query(
     mutation_query = vlan._generate_mutation_query()
 
     assert mutation_query["object"]["vlan_id"] == {"value": None}
+
+
+UPSERT_MOCK_RESPONSE = {
+    "data": {
+        "InfraVLANUpsert": {
+            "ok": True,
+            "object": {"id": "mock-vlan-uuid", "vlan_id": {"value": 100}},
+        }
+    }
+}
+
+
+async def test_save_upsert_raises_when_numberpool_attr_in_hfid(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+) -> None:
+    """save(allow_upsert=True) raises ValidationError naming the pool-sourced HFID attribute."""
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
+        await node.save(allow_upsert=True)
+
+
+async def test_save_upsert_proceeds_when_explicit_id_set(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Upsert proceeds when an explicit node id is already set."""
+    httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+    node.id = "existing-node-uuid"
+
+    await node.save(allow_upsert=True)
+
+    assert node.id == "mock-vlan-uuid"
+
+
+async def test_save_upsert_proceeds_when_numberpool_attr_not_in_hfid(
+    client: InfrahubClient,
+    vlan_schema: NodeSchemaAPI,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Upsert proceeds when the pool-sourced attribute is not part of the HFID."""
+    httpx_mock.add_response(method="POST", json=UPSERT_MOCK_RESPONSE)
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    await node.save(allow_upsert=True)
+
+    assert node.id == "mock-vlan-uuid"
+
+
+async def test_save_upsert_raises_when_pool_node_object_in_hfid(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+    ipaddress_pool_schema: NodeSchemaAPI,
+    ipam_ipprefix_schema: NodeSchemaAPI,
+    ipam_ipprefix_data: dict[str, Any],
+) -> None:
+    """save(allow_upsert=True) raises ValidationError when vlan_id is set to a pool node object (not a from_pool dict)."""
+    ip_prefix = InfrahubNode(client=client, schema=ipam_ipprefix_schema, data=ipam_ipprefix_data)
+    ip_pool = InfrahubNode(
+        client=client,
+        schema=ipaddress_pool_schema,
+        data={
+            "id": NODE_POOL_ID,
+            "name": "Core loopbacks",
+            "default_address_type": "IpamIPAddress",
+            "default_prefix_length": 32,
+            "ip_namespace": "ip_namespace",
+            "resources": [ip_prefix],
+        },
+    )
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": ip_pool},
+    )
+
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
+        await node.save(allow_upsert=True)
+
+
+async def test_create_upsert_raises_when_numberpool_attr_in_hfid(
+    client: InfrahubClient,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+) -> None:
+    """create(allow_upsert=True) raises ValidationError directly, not only through save()."""
+    node = InfrahubNode(
+        client=client,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
+        await node.create(allow_upsert=True)
+
+
+def test_create_upsert_raises_when_numberpool_attr_in_hfid_sync(
+    client_sync: InfrahubClientSync,
+    vlan_schema_with_pool_hfid: NodeSchemaAPI,
+) -> None:
+    """Sync create(allow_upsert=True) raises ValidationError directly, not only through save()."""
+    node = InfrahubNodeSync(
+        client=client_sync,
+        schema=vlan_schema_with_pool_hfid,
+        data={"name": "Test VLAN", "vlan_id": {"from_pool": {"id": POOL_ID}}},
+    )
+
+    with pytest.raises(ValidationError, match=re.escape("Attribute 'vlan_id' is sourced from a CoreNumberPool")):
+        node.create(allow_upsert=True)

--- a/tests/unit/sdk/test_repository.py
+++ b/tests/unit/sdk/test_repository.py
@@ -41,6 +41,26 @@ def test_initialize_repo_uses_existing_repo(temp_dir: str) -> None:
     assert (Path(temp_dir) / ".git").is_dir()
 
 
+def test_initialize_repo_uses_existing_repo_in_worktree(temp_dir: str) -> None:
+    """A git worktree has a `.git` file (gitlink), not a directory.
+
+    GitRepoManager must open the existing repo via the gitlink instead of trying
+    to re-initialize one, which would crash on `mkdir` because the file already exists.
+    """
+    main_path = Path(temp_dir) / "main"
+    worktree_path = Path(temp_dir) / "worktree"
+    main_path.mkdir()
+    worktree_path.mkdir()
+    Repo.init(str(main_path), default_branch=b"main")
+    (worktree_path / ".git").write_text(f"gitdir: {main_path}/.git\n")
+
+    manager = GitRepoManager(str(worktree_path))
+
+    assert manager.git is not None
+    assert isinstance(manager.git, Repo)
+    assert (worktree_path / ".git").is_file()
+
+
 def test_active_branch_returns_correct_branch(temp_dir: str) -> None:
     """Test that the active branch is correctly returned."""
     manager = GitRepoManager(temp_dir, branch="develop")


### PR DESCRIPTION


# Why

Resolve merge conflict between stable and develop

## What changed

* Everything from stable
* Resolved merge conflict in `infrahub_sdk/node/attribute.py`

Conflict:
```python
<<<<<<< HEAD
        return (
            hasattr(self.value, "is_resource_pool") and self.value.is_resource_pool()
        ) or self._from_pool is not None
=======
        return (isinstance(self.value, CoreNodeBase) and self.value.is_resource_pool()) or self._from_pool is not None

    def is_unresolved_pool_attribute(self) -> bool:
        """Return True when pool-backed but no concrete scalar value is available yet.

        A pool-backed attribute is unresolved when:
        - its value is a pool node object (the pool reference itself, not an allocated scalar), or
        - its value is None and the from_pool allocation dict is set.

        An attribute whose _from_pool dict is set but whose value has already been populated
        with the allocated scalar (e.g. after a prior save) is considered resolved.
        """
        if isinstance(self.value, CoreNodeBase) and self.value.is_resource_pool():
            return True
        return self._from_pool is not None and self.value is None
>>>>>>> stable
```

Resolution:
```python

    def is_from_pool_attribute(self) -> bool:
        """Check whether this attribute's value is sourced from a resource pool.

        Returns:
            True if the attribute value is a resource pool node or was explicitly allocated from a pool.

        """
        return (
            hasattr(self.value, "is_resource_pool") and self.value.is_resource_pool()
        ) or self._from_pool is not None

    def is_unresolved_pool_attribute(self) -> bool:
        """Return True when pool-backed but no concrete scalar value is available yet.

        A pool-backed attribute is unresolved when:
        - its value is a pool node object (the pool reference itself, not an allocated scalar), or
        - its value is None and the from_pool allocation dict is set.

        An attribute whose _from_pool dict is set but whose value has already been populated
        with the allocated scalar (e.g. after a prior save) is considered resolved.
        """
        if hasattr(self.value, "is_resource_pool") and self.value.is_resource_pool():
            return True
        return self._from_pool is not None and self.value is None

```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes upsert when a node’s HFID includes a `CoreNumberPool`-sourced attribute and makes repository detection work in Git worktrees. Users now get a clear `ValidationError` instead of an opaque backend error, and CLI flows work from worktrees.

- Bug Fixes
  - Upsert guard: when `allow_upsert=True` and the HFID uses a pool-backed attribute, raise `ValidationError` before sending a request. Adds `Attribute.is_unresolved_pool_attribute()` and `_validate_upsert()` in `InfrahubNode`, used by `save()`/`create()`. Docs updated and tests added. Addresses Linear IHS-119.
  - Repository: handle `.git` as a file (gitlink) or directory so an existing repo is opened instead of re-initialized in worktrees. Includes a new test for worktree setups.

<sup>Written for commit f219cd8650fb3bb10890e174b612e9b5b8ed84cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

