### PR TITLE
support new ordering format

### DIFF
--- a/changelog/+order-by-fields.added.md
+++ b/changelog/+order-by-fields.added.md
@@ -1,0 +1,1 @@
+Added `OrderByEntry` and an `Order.by` field so query results can be ordered by attributes, related-node attributes, or node metadata, e.g. `Order(by=[OrderByEntry(field="name__value", direction=OrderDirection.DESC)])`. The `Order.node_metadata` field is deprecated; use `by` with the `node_metadata__created_at` / `node_metadata__updated_at` fields instead.

--- a/docs/docs/python-sdk/guides/query_data.mdx
+++ b/docs/docs/python-sdk/guides/query_data.mdx
@@ -668,11 +668,79 @@ Relationship metadata tracks changes to the relationship edge itself (for exampl
 
 ## Ordering query results
 
-You can control the order in which query results are returned using the `order` argument. This is particularly useful when you need results sorted by metadata fields like creation or update timestamps.
+You can control the order in which query results are returned using the `order` argument. Results can be ordered by attributes, related-node attributes, or object metadata such as creation and update timestamps.
 
-### Ordering by node metadata
+### Ordering by fields
 
-Use the `Order` and `NodeMetaOrder` classes along with `OrderDirection` to specify how results should be ordered.
+Use the `Order` and `OrderByEntry` classes along with `OrderDirection` to order results by one or more fields. Each `OrderByEntry` takes a `field` and an optional `direction` (defaulting to `OrderDirection.ASC`). The entries are applied in order, so the first entry is the primary sort key.
+
+A `field` can reference:
+
+- an attribute, e.g. `name__value`
+- a related-node attribute, e.g. `owner__name__value`
+- node metadata, e.g. `node_metadata__created_at` or `node_metadata__updated_at`
+
+<Tabs groupId="async-sync">
+  <TabItem value="Async" default>
+
+  ```python
+  from infrahub_sdk.enums import OrderDirection
+  from infrahub_sdk.types import Order, OrderByEntry
+
+  # Get devices ordered by name (ascending is the default)
+  devices = await client.all(
+      kind="TestDevice",
+      order=Order(by=[OrderByEntry(field="name__value")])
+  )
+
+  # Order by name ascending, then by creation time descending
+  devices = await client.all(
+      kind="TestDevice",
+      order=Order(by=[
+          OrderByEntry(field="name__value", direction=OrderDirection.ASC),
+          OrderByEntry(field="node_metadata__created_at", direction=OrderDirection.DESC),
+      ])
+  )
+  ```
+
+  </TabItem>
+  <TabItem value="Sync" default>
+
+  ```python
+  from infrahub_sdk.enums import OrderDirection
+  from infrahub_sdk.types import Order, OrderByEntry
+
+  # Get devices ordered by name (ascending is the default)
+  devices = client.all(
+      kind="TestDevice",
+      order=Order(by=[OrderByEntry(field="name__value")])
+  )
+
+  # Order by name ascending, then by creation time descending
+  devices = client.all(
+      kind="TestDevice",
+      order=Order(by=[
+          OrderByEntry(field="name__value", direction=OrderDirection.ASC),
+          OrderByEntry(field="node_metadata__created_at", direction=OrderDirection.DESC),
+      ])
+  )
+  ```
+
+  </TabItem>
+</Tabs>
+
+The available order directions are:
+
+- `OrderDirection.ASC`: Ascending order (oldest/smallest first)
+- `OrderDirection.DESC`: Descending order (newest/largest first)
+
+### Ordering by node metadata (deprecated)
+
+:::warning
+The `node_metadata` argument is deprecated. Order by metadata through `by` using the `node_metadata__created_at` / `node_metadata__updated_at` fields instead. `node_metadata` cannot be combined with `by` in the same `Order`.
+:::
+
+The `Order` and `NodeMetaOrder` classes order results by a single metadata field.
 
 <Tabs groupId="async-sync">
   <TabItem value="Async" default>
@@ -685,12 +753,6 @@ Use the `Order` and `NodeMetaOrder` classes along with `OrderDirection` to speci
   devices = await client.all(
       kind="TestDevice",
       order=Order(node_metadata=NodeMetaOrder(created_at=OrderDirection.ASC))
-  )
-
-  # Get devices ordered by last update time (most recent first)
-  devices = await client.all(
-      kind="TestDevice",
-      order=Order(node_metadata=NodeMetaOrder(updated_at=OrderDirection.DESC))
   )
   ```
 
@@ -706,21 +768,10 @@ Use the `Order` and `NodeMetaOrder` classes along with `OrderDirection` to speci
       kind="TestDevice",
       order=Order(node_metadata=NodeMetaOrder(created_at=OrderDirection.ASC))
   )
-
-  # Get devices ordered by last update time (most recent first)
-  devices = client.all(
-      kind="TestDevice",
-      order=Order(node_metadata=NodeMetaOrder(updated_at=OrderDirection.DESC))
-  )
   ```
 
   </TabItem>
 </Tabs>
-
-The available order directions are:
-
-- `OrderDirection.ASC`: Ascending order (oldest/smallest first)
-- `OrderDirection.DESC`: Descending order (newest/largest first)
 
 :::note
 You can only order by one metadata field at a time. Specifying both `created_at` and `updated_at` in the same `NodeMetaOrder` will raise a validation error, as they are mutually exclusive.

--- a/docs/docs/python-sdk/guides/query_data.mdx
+++ b/docs/docs/python-sdk/guides/query_data.mdx
@@ -693,6 +693,18 @@ A `field` can reference:
       order=Order(by=[OrderByEntry(field="name__value")])
   )
 
+  # Get devices ordered by creation time (oldest first)
+  devices = await client.all(
+      kind="TestDevice",
+      order=Order(by=[OrderByEntry(field="node_metadata__created_at", direction=OrderDirection.ASC)])
+  )
+
+  # Get devices ordered by last update time (most recent first)
+  devices = await client.all(
+      kind="TestDevice",
+      order=Order(by=[OrderByEntry(field="node_metadata__updated_at", direction=OrderDirection.DESC)])
+  )
+
   # Order by name ascending, then by creation time descending
   devices = await client.all(
       kind="TestDevice",
@@ -716,6 +728,18 @@ A `field` can reference:
       order=Order(by=[OrderByEntry(field="name__value")])
   )
 
+  # Get devices ordered by creation time (oldest first)
+  devices = client.all(
+      kind="TestDevice",
+      order=Order(by=[OrderByEntry(field="node_metadata__created_at", direction=OrderDirection.ASC)])
+  )
+
+  # Get devices ordered by last update time (most recent first)
+  devices = client.all(
+      kind="TestDevice",
+      order=Order(by=[OrderByEntry(field="node_metadata__updated_at", direction=OrderDirection.DESC)])
+  )
+
   # Order by name ascending, then by creation time descending
   devices = client.all(
       kind="TestDevice",
@@ -734,47 +758,8 @@ The available order directions are:
 - `OrderDirection.ASC`: Ascending order (oldest/smallest first)
 - `OrderDirection.DESC`: Descending order (newest/largest first)
 
-### Ordering by node metadata (deprecated)
-
-:::warning
-The `node_metadata` argument is deprecated. Order by metadata through `by` using the `node_metadata__created_at` / `node_metadata__updated_at` fields instead. `node_metadata` cannot be combined with `by` in the same `Order`.
-:::
-
-The `Order` and `NodeMetaOrder` classes order results by a single metadata field.
-
-<Tabs groupId="async-sync">
-  <TabItem value="Async" default>
-
-  ```python
-  from infrahub_sdk.enums import OrderDirection
-  from infrahub_sdk.types import NodeMetaOrder, Order
-
-  # Get devices ordered by creation time (oldest first)
-  devices = await client.all(
-      kind="TestDevice",
-      order=Order(node_metadata=NodeMetaOrder(created_at=OrderDirection.ASC))
-  )
-  ```
-
-  </TabItem>
-  <TabItem value="Sync" default>
-
-  ```python
-  from infrahub_sdk.enums import OrderDirection
-  from infrahub_sdk.types import NodeMetaOrder, Order
-
-  # Get devices ordered by creation time (oldest first)
-  devices = client.all(
-      kind="TestDevice",
-      order=Order(node_metadata=NodeMetaOrder(created_at=OrderDirection.ASC))
-  )
-  ```
-
-  </TabItem>
-</Tabs>
-
 :::note
-You can only order by one metadata field at a time. Specifying both `created_at` and `updated_at` in the same `NodeMetaOrder` will raise a validation error, as they are mutually exclusive.
+The `node_metadata` argument on `Order` is deprecated in favor of the `by` form shown above. It cannot be combined with `by` in the same `Order`.
 :::
 
 ### Disabling default ordering

--- a/infrahub_sdk/types.py
+++ b/infrahub_sdk/types.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field, model_validator
 
-from infrahub_sdk.enums import OrderDirection  # noqa: TC001
+from infrahub_sdk.enums import OrderDirection
 
 if TYPE_CHECKING:
     import httpx
@@ -81,8 +81,31 @@ class NodeMetaOrder(BaseModel):
         return self
 
 
+class OrderByEntry(BaseModel):
+    field: str = Field(
+        description=(
+            "Field to order by: an attribute (`name__value`), a relationship attribute "
+            "(`owner__name__value`), or node metadata (`node_metadata__created_at`)"
+        )
+    )
+    direction: OrderDirection = Field(default=OrderDirection.ASC, description="Sort direction (default ASC)")
+
+
 class Order(BaseModel):
     disable: bool | None = Field(
         default=None, description="Disable default ordering, can be used to improve performance"
     )
-    node_metadata: NodeMetaOrder | None = Field(default=None, description="Order by node meta fields")
+    by: list[OrderByEntry] | None = Field(default=None, description="Ordered list of fields to order results by")
+    node_metadata: NodeMetaOrder | None = Field(
+        default=None,
+        description="Deprecated: order by node meta fields. Use `by` with `node_metadata__created_at` instead",
+        deprecated=True,
+    )
+
+    @model_validator(mode="after")
+    def validate_selection(self) -> Order:
+        # Read node_metadata via __dict__ to avoid triggering its deprecation warning here;
+        # the warning should fire when a caller actually accesses the deprecated field.
+        if self.by and self.__dict__.get("node_metadata"):
+            raise ValueError("'by' and 'node_metadata' are mutually exclusive; use 'by' instead of 'node_metadata'")
+        return self

--- a/tests/unit/sdk/graphql/test_order.py
+++ b/tests/unit/sdk/graphql/test_order.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub_sdk.enums import OrderDirection
+from infrahub_sdk.graphql.renderers import convert_to_graphql_as_string
+from infrahub_sdk.types import NodeMetaOrder, Order, OrderByEntry
+
+
+@dataclass
+class OrderRenderCase:
+    name: str
+    order: Order
+    expected: str
+
+
+ORDER_RENDER_CASES = [
+    OrderRenderCase(
+        name="disable",
+        order=Order(disable=True),
+        expected="{ disable: true }",
+    ),
+    OrderRenderCase(
+        name="by-single-default-direction",
+        order=Order(by=[OrderByEntry(field="name__value")]),
+        expected='{ by: [{ field: "name__value", direction: ASC }] }',
+    ),
+    OrderRenderCase(
+        name="by-single-desc",
+        order=Order(by=[OrderByEntry(field="name__value", direction=OrderDirection.DESC)]),
+        expected='{ by: [{ field: "name__value", direction: DESC }] }',
+    ),
+    OrderRenderCase(
+        name="by-relationship-and-metadata",
+        order=Order(
+            by=[
+                OrderByEntry(field="owner__name__value", direction=OrderDirection.ASC),
+                OrderByEntry(field="node_metadata__created_at", direction=OrderDirection.DESC),
+            ]
+        ),
+        expected=(
+            '{ by: [{ field: "owner__name__value", direction: ASC }, '
+            '{ field: "node_metadata__created_at", direction: DESC }] }'
+        ),
+    ),
+    OrderRenderCase(
+        name="deprecated-node-metadata-still-works",
+        order=Order(node_metadata=NodeMetaOrder(created_at=OrderDirection.DESC)),
+        expected="{ node_metadata: { created_at: DESC } }",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", [pytest.param(tc, id=tc.name) for tc in ORDER_RENDER_CASES])
+def test_order_renders_to_graphql(case: OrderRenderCase) -> None:
+    assert convert_to_graphql_as_string(value=case.order) == case.expected
+
+
+def test_order_by_and_node_metadata_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="'by' and 'node_metadata' are mutually exclusive"):
+        Order(
+            by=[OrderByEntry(field="name__value")],
+            node_metadata=NodeMetaOrder(created_at=OrderDirection.ASC),
+        )


### PR DESCRIPTION
Add OrderByEntry and an Order.by field so query results can be ordered by attributes, related-node attributes, or node metadata via the structured {field, direction} interface. Order.node_metadata is deprecated in favor of by with node_metadata__created_at / node_metadata__updated_at. by and node_metadata are mutually exclusive.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured ordering to query results via `Order.by` with `OrderByEntry`, allowing multi-key sorting by attributes, related-node attributes, or node metadata. Deprecates `Order.node_metadata` and makes it mutually exclusive with `by`.

- **New Features**
  - Introduces `Order.by` as a list of `OrderByEntry { field, direction }` (default `ASC`) with support for multiple sort keys.
  - Supported fields include `name__value`, `owner__name__value`, and `node_metadata__created_at` / `node_metadata__updated_at`.

- **Migration**
  - Replace `Order.node_metadata` with `Order(by=[OrderByEntry(field="node_metadata__created_at|updated_at", direction=...)])`.
  - Do not use `by` and `node_metadata` together; validation will raise an error.

<sup>Written for commit 14cdb63d3fc613c07233b1158d2722aba0af2e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

