### PR TITLE
Add watch for generators

### DIFF
--- a/infrahub_sdk/schema/repository.py
+++ b/infrahub_sdk/schema/repository.py
@@ -131,6 +131,10 @@ class InfrahubGeneratorDefinitionConfig(InfrahubRepositoryConfigElement):
         default=True,
         description="When true (default), the Generator runs after a branch merge. Set to false for Generators that only run via event triggers.",
     )
+    watch: InfrahubWatchConfig | None = Field(
+        default=None,
+        description="Extra files and directories this generator depends on, in addition to the ones Infrahub detects automatically.",
+    )
 
     def load_class(self, import_root: str | None = None, relative_path: str | None = None) -> type[InfrahubGenerator]:
         module = import_module(module_path=self.file_path, import_root=import_root, relative_path=relative_path)

--- a/tests/unit/sdk/test_schema_repository.py
+++ b/tests/unit/sdk/test_schema_repository.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from infrahub_sdk.exceptions import FragmentFileNotFoundError, RepositoryFileNotFoundError, ResourceNotDefinedError
 from infrahub_sdk.schema.repository import (
+    InfrahubGeneratorDefinitionConfig,
     InfrahubJinja2TransformConfig,
     InfrahubPythonTransformConfig,
     InfrahubRepositoryConfig,
@@ -392,3 +393,47 @@ def test_jinja2_transform_payload_includes_declared_watch() -> None:
         }
     )
     assert config.payload["watch"] == {"files": ["templates/partials/"]}
+
+
+def test_generator_watch_omitted_defaults_to_none() -> None:
+    """A generator definition without a watch block parses, with watch defaulting to None.
+
+    The generator config sets extra="forbid", so this also proves watch is a recognised optional
+    field rather than a rejected extra key.
+    """
+    config = InfrahubGeneratorDefinitionConfig.model_validate(
+        {"name": "my_generator", "file_path": "generators/g.py", "query": "q", "targets": "grp"}
+    )
+    assert config.watch is None
+
+
+def test_generator_watch_parses_object_form() -> None:
+    """The object form `watch: {files: [...]}` parses into an InfrahubWatchConfig with the files preserved."""
+    config = InfrahubGeneratorDefinitionConfig.model_validate(
+        {
+            "name": "my_generator",
+            "file_path": "generators/g.py",
+            "query": "q",
+            "targets": "grp",
+            "watch": {"files": ["a", "dir/"]},
+        }
+    )
+    assert config.watch is not None
+    assert config.watch.files == ["a", "dir/"]
+
+
+def test_generator_watch_list_form_rejected() -> None:
+    """A bare list `watch: [a, b]` is rejected: the realistic YAML mistake of a list instead of an object.
+
+    Matching the message confirms the rejection is the watch model-type error, not some unrelated failure.
+    """
+    with pytest.raises(ValidationError, match="valid dictionary or instance of InfrahubWatchConfig"):
+        InfrahubGeneratorDefinitionConfig.model_validate(
+            {
+                "name": "my_generator",
+                "file_path": "generators/g.py",
+                "query": "q",
+                "targets": "grp",
+                "watch": ["a", "b"],
+            }
+        )


### PR DESCRIPTION
# Why

Adds the watch statement for generators, for IFC-2738.

## What changed

* New watch option on generators
* Sanity tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a watch field to generator definitions so generators can declare extra files and directories they depend on. This enables accurate rebuilds when those paths change and aligns with IHS-245.

- **New Features**
  - Added optional `watch: InfrahubWatchConfig | None` to `InfrahubGeneratorDefinitionConfig` for extra file/dir dependencies.
  - Validation rules: omitted => `None`; accepts object form `watch: { files: [...] }`; rejects bare list form.
  - Added unit tests for defaulting, object parsing, and invalid list rejection.

<sup>Written for commit 9b9172981f8f5d2231e67584a5926d458657efaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

