### PR TITLE
ci: dispatch infrahub-sdk updates to infrahub-sync

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -37,6 +37,7 @@ jobs:
         repo:
           - "opsmill/emma"
           - "opsmill/infrahub-demo-dc"
+          - "opsmill/infrahub-sync"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
           - "INFRAHUB_CUSTOMER3_REPOSITORY"
 


### PR DESCRIPTION
infrahub-sync now ships `.github/workflows/update-infrahub-sdk.yml`, which listens for the `repository_dispatch: trigger-infrahub-sdk-python-update` event, bumps `infrahub-sdk[all]` via uv, and opens a PR. The SDK release fan-out did not target it, so those bumps never fired.

This adds `opsmill/infrahub-sync` as a literal entry to the `repository-dispatch` job matrix (grouped with the other first-party `opsmill/` repos). Literal `owner/repo` values are used directly; secret-named entries are looked up as secrets.

```diff
           - "opsmill/infrahub-demo-dc"
+          - "opsmill/infrahub-sync"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opsmill/infrahub-sync to the repository-dispatch fan-out so SDK release events trigger its update workflow. This ensures it auto-bumps `infrahub-sdk[all]` via uv and opens a PR like other first-party repos.

<sup>Written for commit bf8ecc9b28bd366bc0072ab0ee6c6f2653641e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

