### PR TITLE
ci: remove customer3 from SDK update repository dispatch

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -38,7 +38,6 @@ jobs:
           - "opsmill/emma"
           - "opsmill/infrahub-demo-dc"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
-          - "INFRAHUB_CUSTOMER3_REPOSITORY"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Why

The customer3 repository has been archived, so dispatching the Infrahub SDK update event to it on every release is no longer needed and would fail.

## What changed

- Removed the `INFRAHUB_CUSTOMER3_REPOSITORY` entry from the dispatch matrix in `.github/workflows/repository-dispatch.yml`. The remaining dispatch targets (`opsmill/emma`, `opsmill/infrahub-demo-dc`, customer1) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `INFRAHUB_CUSTOMER3_REPOSITORY` from the repository-dispatch matrix because the repo is archived; prevents failed SDK update dispatches on release. Remaining targets are `opsmill/emma`, `opsmill/infrahub-demo-dc`, and `INFRAHUB_CUSTOMER1_REPOSITORY`.

<sup>Written for commit dbdc43a6ca57dac8005006b86f273544e6044ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

