### PR TITLE
Add missing protocols for Infrahub 1.11

### DIFF
--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -151,6 +151,10 @@ class CoreGroup(CoreNode):
     children: RelationshipManager
 
 
+class CoreIPPool(CoreNode):
+    pass
+
+
 class CoreKeyValue(CoreNode):
     name: String
     key: String
@@ -212,6 +216,9 @@ class CoreTransformation(CoreNode):
     label: StringOptional
     description: StringOptional
     timeout: Integer
+    fingerprint: StringOptional
+    dependencies: ListAttributeOptional
+    dependencies_complete: BooleanOptional
     query: RelatedNode
     repository: RelatedNode
     tags: RelationshipManager
@@ -269,6 +276,7 @@ class CoreAccount(LineageOwner, LineageSource, CoreGenericAccount):
 
 
 class CoreAccountGroup(LineageOwner, LineageSource, CoreGroup):
+    origin: StringOptional
     roles: RelationshipManager
 
 
@@ -303,6 +311,7 @@ class CoreArtifactDefinition(CoreTaskTarget):
     description: StringOptional
     parameters: JSONAttribute
     content_type: Enum
+    fingerprint: StringOptional
     targets: RelatedNode
     transformation: RelatedNode
 
@@ -390,6 +399,9 @@ class CoreGeneratorDefinition(CoreTaskTarget):
     convert_query_response: BooleanOptional
     execute_in_proposed_change: BooleanOptional
     execute_after_merge: BooleanOptional
+    fingerprint: StringOptional
+    dependencies: ListAttributeOptional
+    dependencies_complete: BooleanOptional
     query: RelatedNode
     repository: RelatedNode
     targets: RelatedNode
@@ -419,6 +431,7 @@ class CoreGraphQLQuery(CoreNode):
     name: String
     description: StringOptional
     query: String
+    fingerprint: StringOptional
     variables: JSONAttributeOptional
     operations: ListAttributeOptional
     models: ListAttributeOptional
@@ -443,14 +456,14 @@ class CoreGroupTriggerRule(CoreTriggerRule):
     group: RelatedNode
 
 
-class CoreIPAddressPool(CoreResourcePool, LineageSource):
+class CoreIPAddressPool(CoreResourcePool, LineageSource, CoreIPPool):
     default_address_type: String
     default_prefix_length: IntegerOptional
     resources: RelationshipManager
     ip_namespace: RelatedNode
 
 
-class CoreIPPrefixPool(CoreResourcePool, LineageSource):
+class CoreIPPrefixPool(CoreResourcePool, LineageSource, CoreIPPool):
     default_prefix_length: IntegerOptional
     default_member_type: Enum
     default_prefix_type: StringOptional
@@ -736,6 +749,10 @@ class CoreGroupSync(CoreNodeSync):
     children: RelationshipManagerSync
 
 
+class CoreIPPoolSync(CoreNodeSync):
+    pass
+
+
 class CoreKeyValueSync(CoreNodeSync):
     name: String
     key: String
@@ -797,6 +814,9 @@ class CoreTransformationSync(CoreNodeSync):
     label: StringOptional
     description: StringOptional
     timeout: Integer
+    fingerprint: StringOptional
+    dependencies: ListAttributeOptional
+    dependencies_complete: BooleanOptional
     query: RelatedNodeSync
     repository: RelatedNodeSync
     tags: RelationshipManagerSync
@@ -854,6 +874,7 @@ class CoreAccountSync(LineageOwnerSync, LineageSourceSync, CoreGenericAccountSyn
 
 
 class CoreAccountGroupSync(LineageOwnerSync, LineageSourceSync, CoreGroupSync):
+    origin: StringOptional
     roles: RelationshipManagerSync
 
 
@@ -888,6 +909,7 @@ class CoreArtifactDefinitionSync(CoreTaskTargetSync):
     description: StringOptional
     parameters: JSONAttribute
     content_type: Enum
+    fingerprint: StringOptional
     targets: RelatedNodeSync
     transformation: RelatedNodeSync
 
@@ -975,6 +997,9 @@ class CoreGeneratorDefinitionSync(CoreTaskTargetSync):
     convert_query_response: BooleanOptional
     execute_in_proposed_change: BooleanOptional
     execute_after_merge: BooleanOptional
+    fingerprint: StringOptional
+    dependencies: ListAttributeOptional
+    dependencies_complete: BooleanOptional
     query: RelatedNodeSync
     repository: RelatedNodeSync
     targets: RelatedNodeSync
@@ -1004,6 +1029,7 @@ class CoreGraphQLQuerySync(CoreNodeSync):
     name: String
     description: StringOptional
     query: String
+    fingerprint: StringOptional
     variables: JSONAttributeOptional
     operations: ListAttributeOptional
     models: ListAttributeOptional
@@ -1028,14 +1054,14 @@ class CoreGroupTriggerRuleSync(CoreTriggerRuleSync):
     group: RelatedNodeSync
 
 
-class CoreIPAddressPoolSync(CoreResourcePoolSync, LineageSourceSync):
+class CoreIPAddressPoolSync(CoreResourcePoolSync, LineageSourceSync, CoreIPPoolSync):
     default_address_type: String
     default_prefix_length: IntegerOptional
     resources: RelationshipManagerSync
     ip_namespace: RelatedNodeSync
 
 
-class CoreIPPrefixPoolSync(CoreResourcePoolSync, LineageSourceSync):
+class CoreIPPrefixPoolSync(CoreResourcePoolSync, LineageSourceSync, CoreIPPoolSync):
     default_prefix_length: IntegerOptional
     default_member_type: Enum
     default_prefix_type: StringOptional


### PR DESCRIPTION
# Why

Update missing protocol definitions

## What changed

Regenerated protocols from the backend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SDK protocol definitions for Infrahub 1.11. Adds missing node types and fields so clients can use new 1.11 features.

- **New Features**
  - Introduced `CoreIPPool` and `CoreIPPoolSync`; `CoreIPAddressPool`/`CoreIPPrefixPool` (and sync variants) now inherit from it.
  - Added `fingerprint` to `CoreTransformation`, `CoreArtifactDefinition`, `CoreGeneratorDefinition`, `CoreGraphQLQuery` and their sync variants.
  - Added `dependencies` and `dependencies_complete` to `CoreTransformation` and `CoreGeneratorDefinition` (and sync variants).
  - Added `origin` to `CoreAccountGroup` and `CoreAccountGroupSync`.

<sup>Written for commit a05347a1139f37f8b37fe613aaa260eb518e380c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

