### PR TITLE
add the "ordered" schema attribute property

### DIFF
--- a/infrahub_sdk/schema/export.py
+++ b/infrahub_sdk/schema/export.py
@@ -49,6 +49,7 @@ _FIELD_EXPORT_EXCLUDE: set[str] = {"inherited", "allow_override", "hierarchical"
 _ATTR_EXPORT_DEFAULTS: dict[str, Any] = {
     "read_only": False,
     "optional": False,
+    "ordered": True,
 }
 
 # Relationship field values that match schema loading defaults — omitted for cleaner output

--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -111,6 +111,7 @@ class AttributeSchema(BaseModel):
     min_length: int | None = None
     regex: str | None = None
     order_weight: int | None = None
+    ordered: bool = True
 
 
 class AttributeSchemaAPI(AttributeSchema):

--- a/tests/unit/sdk/test_schema_export.py
+++ b/tests/unit/sdk/test_schema_export.py
@@ -13,6 +13,7 @@ from infrahub_sdk.schema import (
     SchemaExport,
     TemplateSchemaAPI,
 )
+from infrahub_sdk.schema.export import schema_to_export_dict
 
 if TYPE_CHECKING:
     from pytest_httpx import HTTPXMock
@@ -189,6 +190,25 @@ class TestBuildExportSchemas:
         assert isinstance(as_dict["Infra"], dict)
         assert len(as_dict["Infra"]["nodes"]) == 1
         assert len(as_dict["Infra"]["generics"]) == 1
+
+
+def test_export_preserves_non_default_ordered_flag() -> None:
+    """`ordered: false` survives the fetch -> export round-trip; the default `true` is omitted."""
+    node = NodeSchemaAPI(
+        **{
+            **_BASE_NODE,
+            "namespace": "Infra",
+            "name": "Device",
+            "attributes": [
+                {"name": "tags_unordered", "kind": "List", "ordered": False},
+                {"name": "tags_ordered", "kind": "List"},
+            ],
+        }
+    )
+    exported = schema_to_export_dict(node)
+    attrs = {attr["name"]: attr for attr in exported["attributes"]}
+    assert attrs["tags_unordered"]["ordered"] is False
+    assert "ordered" not in attrs["tags_ordered"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
goes with https://github.com/opsmill/infrahub/pull/9782

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ordered` attribute property to schema models and export logic. Defaults to true; exports only include `ordered` when set to false to keep output clean.

- **New Features**
  - Added `ordered: bool = True` to `infrahub_sdk.schema.main.AttributeSchema`.
  - Updated `_ATTR_EXPORT_DEFAULTS` to omit `"ordered"` when true and include it when false; added a unit test to validate the round-trip.

<sup>Written for commit 15eafefc24bcb9312614dc673dc24c0fe0484394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

