### PR TITLE
**WIP** fix: Support attribute assignment of cardinality-many relationships

### DIFF
--- a/changelog/1152.fixed.md
+++ b/changelog/1152.fixed.md
@@ -1,0 +1,1 @@
+Assigning to a cardinality-many relationship (e.g. `node.members = [peer]`) now populates the relationship manager, and assigning a non-list value raises a clear error at assignment time instead of being silently accepted and failing later in `save()` with a confusing `'InfrahubNode' object has no attribute 'initialized'` message.

--- a/infrahub_sdk/node/node.py
+++ b/infrahub_sdk/node/node.py
@@ -978,6 +978,29 @@ class InfrahubNode(InfrahubNodeBase):
             self._relationship_cardinality_one_data[name] = new_rel
             return
 
+        if "_relationship_cardinality_many_data" in self.__dict__ and name in self._relationship_cardinality_many_data:
+            rel_schemas = [rel_schema for rel_schema in self._schema.relationships if rel_schema.name == name]
+            if not rel_schemas:
+                raise SchemaNotFoundError(
+                    identifier=self._schema.kind,
+                    message=f"Unable to find relationship schema for '{name}' on {self._schema.kind}",
+                )
+            rel_schema = rel_schemas[0]
+            # RelationshipManager validates that a cardinality-many value is a list and raises a
+            # helpful error otherwise, so assigning a single node fails here instead of silently
+            # corrupting the node and blowing up later in save().
+            new_many_rel = RelationshipManager(
+                name=rel_schema.name,
+                client=self._client,
+                node=self,
+                branch=self._branch,
+                schema=rel_schema,
+                data=value,
+            )
+            new_many_rel._has_update = True
+            self._relationship_cardinality_many_data[name] = new_many_rel
+            return
+
         super().__setattr__(name, value)
 
     async def generate(self, nodes: list[str] | None = None) -> None:
@@ -2167,6 +2190,29 @@ class InfrahubNodeSync(InfrahubNodeBase):
             )
             new_rel._peer_has_been_mutated = True
             self._relationship_cardinality_one_data[name] = new_rel
+            return
+
+        if "_relationship_cardinality_many_data" in self.__dict__ and name in self._relationship_cardinality_many_data:
+            rel_schemas = [rel_schema for rel_schema in self._schema.relationships if rel_schema.name == name]
+            if not rel_schemas:
+                raise SchemaNotFoundError(
+                    identifier=self._schema.kind,
+                    message=f"Unable to find relationship schema for '{name}' on {self._schema.kind}",
+                )
+            rel_schema = rel_schemas[0]
+            # RelationshipManagerSync validates that a cardinality-many value is a list and raises a
+            # helpful error otherwise, so assigning a single node fails here instead of silently
+            # corrupting the node and blowing up later in save().
+            new_many_rel = RelationshipManagerSync(
+                name=rel_schema.name,
+                client=self._client,
+                node=self,
+                branch=self._branch,
+                schema=rel_schema,
+                data=value,
+            )
+            new_many_rel._has_update = True
+            self._relationship_cardinality_many_data[name] = new_many_rel
             return
 
         super().__setattr__(name, value)

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -343,6 +343,42 @@ async def test_cardinality_many_accepts_list(
 
 
 @pytest.mark.parametrize("client_type", client_types)
+async def test_cardinality_many_assignment_requires_list(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Assigning a single node to a cardinality-many relationship must fail at assignment time.
+
+    Previously this was silently accepted and only blew up later in save() with a confusing
+    "'InfrahubNode' object has no attribute 'initialized'" error.
+    """
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+
+    with pytest.raises(ValueError, match=r"expects a list of nodes"):
+        node.tags = {"id": "pppppppp"}
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_cardinality_many_assignment_accepts_list(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Assigning a list to a cardinality-many relationship populates the manager and marks it updated."""
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+
+    node.tags = [{"id": "aaaaaa"}, {"id": "bbbb"}]
+
+    assert isinstance(node.tags, RelationshipManagerBase)
+    assert node.tags.peer_ids == ["aaaaaa", "bbbb"]
+    # has_update must be set so save() actually persists the assignment instead of stripping it.
+    assert node.tags.has_update is True
+
+
+@pytest.mark.parametrize("client_type", client_types)
 async def test_query_data_no_filters_property(
     clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
 ) -> None:

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -379,6 +379,53 @@ async def test_cardinality_many_assignment_accepts_list(
 
 
 @pytest.mark.parametrize("client_type", client_types)
+async def test_cardinality_many_assignment_included_in_input_data(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """A list assigned after construction is carried into the mutation payload built by save().
+
+    This is the exact path that used to raise 'InfrahubNode' object has no attribute 'initialized',
+    and it also guards that _strip_unmodified keeps the assignment (thanks to has_update).
+    """
+    data = {"name": {"value": "JFK1"}, "type": {"value": "SITE"}}
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data=data)
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
+
+    node.tags = [{"id": "aaaaaa"}, {"id": "bbbb"}]
+
+    input_data = node._generate_input_data()["data"]["data"]
+    assert input_data["tags"] == [{"id": "aaaaaa"}, {"id": "bbbb"}]
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_cardinality_many_assignment_saved(
+    httpx_mock: HTTPXMock, clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """Assigning a list then calling save() succeeds and sends the peers in the create mutation."""
+    httpx_mock.add_response(
+        method="POST",
+        json={"data": {"BuiltinLocationCreate": {"ok": True, "object": {"id": "location-123"}}}},
+    )
+    data = {"name": {"value": "JFK1"}, "type": {"value": "SITE"}}
+    client = getattr(clients, client_type)
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data=data)
+        node.tags = [{"id": "aaaaaa"}, {"id": "bbbb"}]
+        await node.save()
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
+        node.tags = [{"id": "aaaaaa"}, {"id": "bbbb"}]
+        node.save()
+
+    assert node.id == "location-123"
+    body = httpx_mock.get_requests()[-1].content.decode()
+    assert "aaaaaa" in body
+    assert "bbbb" in body
+
+
+@pytest.mark.parametrize("client_type", client_types)
 async def test_query_data_no_filters_property(
     clients: BothClients, location_schema: NodeSchemaAPI, client_type: str
 ) -> None:


### PR DESCRIPTION
## What

Fixes #1152.

Assigning to a cardinality-many relationship attribute (e.g. `node.members = [peer]`) previously fell through `InfrahubNode.__setattr__` to `super().__setattr__`, storing the raw value as a normal attribute and not correctly wrapping the object in a `RelationshipManager`. The node then failed in `save()` with the confusing `'list' object has no attribute 'initialized'` error. This behavior is different than instantiating an object via .create() with a list passed into `data=`, which correctly used .__setattr__ to construct a RelationshipManager and doesn't fall through to `super().__setattr__`.

## Change

`__setattr__` now handles cardinality-many relationships (both `InfrahubNode` and `InfrahubNodeSync`):

- a **list** rebuilds the `RelationshipManager` from the value and marks it `_has_update` so `save()` actually persists it;
- a **non-list** value raises the existing `"expects a list of nodes"` error from the `RelationshipManager` constructor, at assignment time rather than deferred to `save()`.

## Tests

Added to `tests/unit/sdk/test_node.py` (async + sync):

- `test_cardinality_many_assignment_requires_list` — single node/dict assignment raises `"expects a list of nodes"`.
- `test_cardinality_many_assignment_accepts_list` — list assignment populates peers and sets `has_update`.

`uv run invoke format lint-code` clean; `uv run pytest tests/unit/sdk/test_node.py` → 226 passed.

## Related

Same relationship-editing ergonomics area as #1031 and the sibling PR for #1153.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assignment to cardinality-many relationships so list assignments populate the manager and non-list values fail fast, eliminating the confusing `'InfrahubNode' object has no attribute 'initialized'` save-time error. Applies to both async and sync nodes.

- **Bug Fixes**
  - Handle cardinality-many attrs in `__setattr__` for `InfrahubNode` and `InfrahubNodeSync`.
  - List assignment rebuilds the relationship manager, marks `_has_update`, and is included in mutation payloads.
  - Non-list assignment raises a clear “expects a list of nodes” error at assignment time.
  - Added tests for list vs non-list assignment, input payload generation, and the `save()` path for both clients.

<sup>Written for commit 9beed45ca43d7adeff03f4c5e363c3c5bf3be83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



