### PR TITLE
fix: Print clear error when fetching/editing a relationship on an id-less node

### DIFF
--- a/changelog/1153.fixed.md
+++ b/changelog/1153.fixed.md
@@ -1,0 +1,1 @@
+Fetching or editing a relationship on a node that has no ID (e.g. a node created locally but not yet saved) now raises a clear error explaining the node needs to be saved first, instead of the generic `At least one filter must be provided to get()` message (for `fetch()`) or sending the caller in a circle between `add()` and `fetch()`.

--- a/infrahub_sdk/node/relationship.py
+++ b/infrahub_sdk/node/relationship.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Generic, cast
+from typing import TYPE_CHECKING, Any, Generic, NoReturn, cast
 
 from ..exceptions import (
     Error,
@@ -17,6 +17,25 @@ if TYPE_CHECKING:
     from ..client import InfrahubClient, InfrahubClientSync
     from ..schema import RelationshipSchemaAPI
     from .node import InfrahubNode, InfrahubNodeSync
+
+
+def _raise_missing_identifier(node: InfrahubNode | InfrahubNodeSync, name: str) -> NoReturn:
+    """Raise a clear error for fetching/editing a relationship on a node with no ID.
+
+    A relationship can only be fetched or edited once the parent node has an ID to look it up
+    by. When it does not, the underlying ``client.get()`` call would otherwise fail with a
+    generic "At least one filter must be provided to get()" message that gives the caller no
+    hint about the real cause.
+
+    Raises:
+        UninitializedError: Always; the parent node has no ID to look the relationship up by.
+
+    """
+    raise UninitializedError(
+        f"Cannot access the '{name}' relationship because the {node._schema.kind} node has no ID to "
+        f"look it up by. This usually means the node was created locally but not saved yet — call "
+        f".save() on it first (or fetch it from Infrahub) before fetching or editing its relationships."
+    )
 
 
 class RelationshipManagerBase(Generic[PeerT]):
@@ -243,6 +262,8 @@ class RelationshipManager(RelationshipManagerBase[PeerT]):
 
         """
         if not self.initialized:
+            if not self.node.id:
+                _raise_missing_identifier(self.node, self.name)
             exclude = self.node._schema.relationship_names + self.node._schema.attribute_names
             exclude.remove(self.schema.name)
             node = await self.client.get(
@@ -293,6 +314,8 @@ class RelationshipManager(RelationshipManagerBase[PeerT]):
 
         """
         if not self.initialized:
+            if not self.node.id:
+                _raise_missing_identifier(self.node, self.name)
             raise UninitializedError("Must call fetch() on RelationshipManager before editing members")
         new_node = cast(
             "RelatedNode[PeerT]", RelatedNode(schema=self.schema, client=self.client, branch=self.branch, data=data)
@@ -337,6 +360,8 @@ class RelationshipManager(RelationshipManagerBase[PeerT]):
 
         """
         if not self.initialized:
+            if not self.node.id:
+                _raise_missing_identifier(self.node, self.name)
             raise UninitializedError("Must call fetch() on RelationshipManager before editing members")
         node_to_remove = RelatedNode(schema=self.schema, client=self.client, branch=self.branch, data=data)
 
@@ -440,6 +465,8 @@ class RelationshipManagerSync(RelationshipManagerBase[PeerTSync]):
 
         """
         if not self.initialized:
+            if not self.node.id:
+                _raise_missing_identifier(self.node, self.name)
             exclude = self.node._schema.relationship_names + self.node._schema.attribute_names
             exclude.remove(self.schema.name)
             node = self.client.get(
@@ -490,6 +517,8 @@ class RelationshipManagerSync(RelationshipManagerBase[PeerTSync]):
 
         """
         if not self.initialized:
+            if not self.node.id:
+                _raise_missing_identifier(self.node, self.name)
             raise UninitializedError("Must call fetch() on RelationshipManager before editing members")
         new_node = cast(
             "RelatedNodeSync[PeerTSync]",
@@ -535,6 +564,8 @@ class RelationshipManagerSync(RelationshipManagerBase[PeerTSync]):
 
         """
         if not self.initialized:
+            if not self.node.id:
+                _raise_missing_identifier(self.node, self.name)
             raise UninitializedError("Must call fetch() on RelationshipManager before editing members")
         node_to_remove = RelatedNodeSync(schema=self.schema, client=self.client, branch=self.branch, data=data)
 

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub_sdk.exceptions import FeatureNotSupportedError, NodeNotFoundError
+from infrahub_sdk.exceptions import FeatureNotSupportedError, NodeNotFoundError, UninitializedError
 from infrahub_sdk.node import (
     InfrahubNode,
     InfrahubNodeBase,
@@ -340,6 +340,48 @@ async def test_cardinality_many_accepts_list(
     else:
         node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
     assert len(node.tags.peers) == 2
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_fetch_relationship_without_node_id_raises_clear_error(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """fetch() on a node with no ID explains it isn't saved instead of raising the generic get() filter error."""
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+        with pytest.raises(UninitializedError, match=r"has no ID"):
+            await node.tags.fetch()
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+        with pytest.raises(UninitializedError, match=r"has no ID"):
+            node.tags.fetch()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_edit_relationship_without_node_id_raises_clear_error(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """add() on a node with no ID points the user at .save() instead of at fetch(), avoiding the circular guidance."""
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data={"name": {"value": "JFK1"}})
+    with pytest.raises(UninitializedError, match=r"has no ID"):
+        node.tags.add("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_edit_relationship_with_node_id_still_requires_fetch(
+    client: InfrahubClient, location_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    """When the node has an ID but the relationship isn't loaded, the original "call fetch()" guidance is preserved."""
+    data = {"id": "22222222-2222-2222-2222-222222222222", "name": {"value": "JFK1"}}
+    if client_type == "standard":
+        node = InfrahubNode(client=client, schema=location_schema, data=data)
+    else:
+        node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
+    with pytest.raises(UninitializedError, match=r"Must call fetch"):
+        node.tags.add("11111111-1111-1111-1111-111111111111")
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
## What

Fixes #1153.

Fetching or editing a cardinality-many relationship on a node with no ID (e.g. one built with `client.create()` but never `save()`d) produced confusing errors:

- `node.rel.fetch()` → `ValueError: At least one filter must be provided to get()` — because `fetch()` re-queries the parent via `client.get(id=self.node.id)` with `id=None`.
- `node.rel.add(...)` / `remove(...)` → `Must call fetch() on RelationshipManager before editing members` — but `fetch()` can't succeed either, so the two guards send the caller in a circle.

## Change

`fetch()`, `add()`, and `remove()` (both `RelationshipManager` and `RelationshipManagerSync`) now detect the missing node ID up front and raise a clear `UninitializedError` that nudges the user to `.save()` first, via a shared `_raise_missing_identifier()` helper. When the node **does** have an ID, the existing `"Must call fetch()"` guidance is preserved.

The message is deliberately phrased around "no ID to look it up by / likely not saved yet" rather than asserting the node doesn't exist in Infrahub — at that point only a local attribute has been inspected, no server call has been made.

## Tests

Added to `tests/unit/sdk/test_node.py` (async + sync):

- `test_fetch_relationship_without_node_id_raises_clear_error`
- `test_edit_relationship_without_node_id_raises_clear_error`
- `test_edit_relationship_with_node_id_still_requires_fetch` (regression: id-bearing node still gets "call fetch()")

`uv run invoke format lint-code` clean; `uv run pytest tests/unit/sdk/test_node.py` → 228 passed.

## Related

Sibling PR for #1152 (assigning to a cardinality-many relationship).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear error when fetching or editing a relationship on a node without an ID, guiding users to save the node first. Prevents the generic `get()` error and the circular “call fetch()” guidance.

- **Bug Fixes**
  - In `RelationshipManager` and `RelationshipManagerSync`, `fetch()`, `add()`, and `remove()` now detect a missing node ID and raise `UninitializedError` with a hint to call `.save()` first.
  - Preserves the original “Must call fetch()” error when the node has an ID but the relationship isn’t loaded; added unit tests covering both cases.

<sup>Written for commit df30f2747b0974539d83c2d0ff40253d753ac7db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

