### PR TITLE
chore: ignore .specify/feature.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ sandbox/
 
 # SpecKit internal cache
 .specify/**/.cache/
+.specify/feature.json


### PR DESCRIPTION
## Summary
Keeps the local SpecKit feature-tracking file out of version control so it no longer shows up as noise in `git status` or risks being committed accidentally.

## Key Changes
- `.specify/feature.json` is now git-ignored, alongside the existing `.specify/**/.cache/` entry in the SpecKit section of `.gitignore`.

## Test Plan
- `git check-ignore .specify/feature.json` returns the path (confirming it is ignored).
- No functional or CI impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `.specify/feature.json` in Git to keep the local SpecKit feature-tracking file out of version control. Reduces git status noise and prevents accidental commits.

<sup>Written for commit 942716d9e3ad375d876ac8023df082bc49bf3f4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

