### PR TITLE
feat(release): derive package version from git tags via hatch-vcs

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,6 +50,9 @@ jobs:
         uses: "actions/checkout@v7"
         with:
           submodules: true
+          # Full history + tags so hatch-vcs stamps the real tag version at build time, not the fallback
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Cache UV dependencies
         uses: "actions/cache@v5"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         uses: "actions/checkout@v7"
         with:
           submodules: true
+          # Full history + tags so hatch-vcs resolves the exact tag version from installed metadata
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: "Set up Python"
         uses: "actions/setup-python@v6"
@@ -41,10 +44,13 @@ jobs:
       - name: Check prerelease type
         id: release
         run: |
-          VERSION=$(uv version --short)
+          VERSION=$(uv run python -c "import importlib.metadata; print(importlib.metadata.version('infrahub-sdk'))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo is_prerelease=$(uv run python -c "from packaging.version import Version; print(int(Version('$VERSION').is_prerelease))") >> "$GITHUB_OUTPUT"
           echo is_devrelease=$(uv run python -c "from packaging.version import Version; print(int(Version('$VERSION').is_devrelease))") >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo is_local=$(uv run python -c "from packaging.version import Version; print(int(Version('$VERSION').local is not None))") >> "$GITHUB_OUTPUT"
+          echo base_version=$(uv run python -c "from packaging.version import Version; print(Version('$VERSION').base_version)") >> "$GITHUB_OUTPUT"
+          echo fallback_base=$(uv run python -c "import tomllib; from packaging.version import Version; print(Version(tomllib.load(open('pyproject.toml', 'rb'))['tool']['hatch']['version']['fallback-version']).base_version)") >> "$GITHUB_OUTPUT"
           echo major_minor_version=$(uv run python -c "from packaging.version import Version; v = Version('$VERSION'); print(f'{v.major}.{v.minor}')") >> "$GITHUB_OUTPUT"
           echo latest_tag=$(curl -L \
               -H "Accept: application/vnd.github+json" \
@@ -53,15 +59,22 @@ jobs:
               https://api.github.com/repos/${{ github.repository }}/releases/latest \
               | jq -r '.tag_name') >> "$GITHUB_OUTPUT"
 
-      - name: Check tag version
+      - name: "Publish guard: resolved version must match the release tag"
         run: |
           EXPECTED_TAG="v${{ steps.release.outputs.version }}"
           if [ "${{ github.event.release.tag_name }}" != "$EXPECTED_TAG" ]; then
-            echo "Tag version does not match python project version"
+            echo "Resolved version (${{ steps.release.outputs.version }}) does not match release tag ${{ github.event.release.tag_name }}"
             echo "Expected: $EXPECTED_TAG"
             echo "Got: ${{ github.event.release.tag_name }}"
             exit 1
           fi
+
+      - name: "Publish guard: reject unreleased fallback version"
+        # fallback_base is read from pyproject.toml at run time; the fallback is a static sentinel (0.0.0.dev0)
+        if: steps.release.outputs.base_version == steps.release.outputs.fallback_base && (steps.release.outputs.is_devrelease == 1 || steps.release.outputs.is_local == 1)
+        run: |
+          echo "Resolved version (${{ steps.release.outputs.version }}) is an unreleased fallback (base ${{ steps.release.outputs.fallback_base }}, dev/local build): no v* tag is reachable. Refusing to publish."
+          exit 1
 
       - name: Check prerelease and project version
         if: github.event.release.prerelease == true && steps.release.outputs.is_prerelease == 0 && steps.release.outputs.is_devrelease == 0

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ dist/*
 generated/
 sandbox/
 
+# hatch-vcs version file (written at build time; must not be tracked)
+infrahub_sdk/_version.py
+
 # SpecKit internal cache
 .specify/**/.cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-sdk"
-version = "1.22.1"
+dynamic = ["version"]
 description = "Python Client to interact with Infrahub"
 authors = [
     {name = "OpsMill", email = "info@opsmill.com"}
@@ -519,8 +519,25 @@ name = "Housekeeping"
 showcontent = true
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+# Static sentinel for tag-less checkouts (e.g. a shallow clone without tags). It is identical on
+# every branch so releases never touch it — a moving value would conflict on every stable/develop
+# merge, which is exactly what dynamic versioning removes. Tag-less builds resolve 0.0.0.devN+g<hash>,
+# unmistakably a non-release, and are publish-guarded in release.yml.
+fallback-version = "0.0.0.dev0"
+
+[tool.hatch.version.raw-options]
+# No --dirty: keeps the resolved version derived from committed git state only, independent of the
+# work tree contents, so a build from a dirty/stripped tree never bumps an on-tag build to a dev
+# version.
+git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v*"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "infrahub_sdk/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["infrahub_sdk"]

--- a/uv.lock
+++ b/uv.lock
@@ -676,7 +676,6 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },
@@ -795,7 +794,7 @@ requires-dist = [
     { name = "ujson", specifier = ">=5" },
     { name = "whenever", specifier = ">=0.9.3,<0.10.0" },
 ]
-provides-extras = ["ctl", "all"]
+provides-extras = ["all", "ctl"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Why

Releasing the SDK today means hand-editing `[project].version` in `pyproject.toml` (and regenerating `uv.lock`), which churns on every release and produces recurring merge conflicts between `stable` and `develop`. A release should be declared by a git tag, not a tracked version string.

**Goal:** derive the package version at build time from the `v*` git tags via `hatch-vcs`, so a release is declared solely by an annotated tag and no version field is ever edited.

This is a port of infrahub **#9711** (dynamic versioning) and **#9860** (`--dirty` fix), INFP-566, adapted to the SDK's structure.

## What changed

- **The published version now comes from the latest reachable `v*` tag.** On an exact tag the build resolves to the clean version (e.g. `1.22.1`); off-tag it resolves to `<next>.devN+g<hash>`; with no tag it falls back to the static sentinel `0.0.0.dev0`.
- `pyproject.toml`: `version = "1.22.1"` → `dynamic = ["version"]`; `hatch-vcs` build dep; `[tool.hatch.version]` (`source = "vcs"`, `fallback-version = "0.0.0.dev0"`, `git_describe_command` matching `v*`, **without `--dirty`** so the version derives from committed state only); `version-file = "infrahub_sdk/_version.py"`.
- `.gitignore`: ignore the generated `infrahub_sdk/_version.py`.
- `uv.lock`: regenerated — the `infrahub-sdk` entry no longer records a static `version`.
- `release.yml`: fetch full history + tags on checkout; read the version via `importlib.metadata` instead of `uv version --short`; two publish guards (resolved-version-must-match-tag, reject-unreleased-fallback).
- `publish-pypi.yml`: fetch full history + tags so `uv build` stamps the real tag version.

**What stayed the same:** `infrahub_sdk.__version__` still reads `importlib.metadata` (unchanged); no API changes; SDK consumers see no behavioral difference.

**Scope / non-goals:** the SDK is a single package with `v*` tags and no Docker/compose/Helm, so the Dockerfile, compose-propagation workflow, testcontainers subpackage, and `/cut-release` command from infrahub #9711 have no counterpart here and were not ported.

## How to test

```bash
# On-tag build resolves to the clean tag version
git worktree add --detach /tmp/ontag v1.22.1 && (cd /tmp/ontag && uv build)   # -> infrahub_sdk-1.22.1
# Off-tag build (this branch) resolves to a dev version
uv build                                                                       # -> infrahub_sdk-<next>.devN+g<hash>
# Tag-less / no-git build falls back to the sentinel -> infrahub_sdk-0.0.0.dev0
# Runtime version after sync
uv sync && uv run python -c "import infrahub_sdk; print(infrahub_sdk.__version__)"
```

Verified locally: on-tag → `1.22.1`; off-tag → `1.22.2.dev31+g17483a0`; no-git → `0.0.0.dev0`; `_version.py` baked into wheel + sdist and gitignored; yamllint clean on both workflows.

## Impact & rollout

- **Backward compatibility:** no API change. After this lands, contributors must `git fetch --tags` on fresh clones, and editable installs pin the version at `uv sync` time (re-run `uv sync` after moving commits / fetching tags).
- **Deployment notes:** a release is now declared by pushing an annotated `v<version>` tag and publishing the GitHub release; no `pyproject.toml` edit. The New Release workflow's publish guards reject a fallback/dev version or a tag mismatch.
- **Config/env changes:** none.

## Checklist

- [ ] Tests added/updated — n/a (build/release plumbing; verified via the `uv build` resolution matrix above)
- [ ] Changelog entry — intentionally omitted (internal release plumbing, no user-facing change); labeled `ci/skip-changelog`
- [ ] External docs updated — n/a
- [ ] Internal .md docs updated — n/a (SDK has no release/versioning developer doc to update)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives `infrahub-sdk` version from `v*` git tags at build time via `hatch-vcs`, removing manual version bumps and merge conflicts. Releases are now tag-driven; CI blocks tag mismatches and fallback/dev/local builds.

- **Dependencies**
  - Use `hatch-vcs` with `dynamic = ["version"]`, fallback `0.0.0.dev0`, and no `--dirty`.
  - Write version to `infrahub_sdk/_version.py` and ignore it in git.
  - Keep `hatchling`; update `uv.lock` to drop the static version entry.

- **Release workflow**
  - `release.yml` and `publish-pypi.yml` fetch full history and tags; version resolved via `importlib.metadata`.
  - Publish guards: resolved version must match the release tag; reject fallback base versions and dev/local builds.
  - To release: push an annotated `v<version>` tag; no `pyproject.toml` edits needed.

<sup>Written for commit 4cad91b6d202cee30f47ba6177b4a00963b289aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

