### PR TITLE
fix(ctl): import pyarrow lazily in the JSON importer

### DIFF
--- a/changelog/+lazy-pyarrow-import.fixed.md
+++ b/changelog/+lazy-pyarrow-import.fixed.md
@@ -1,0 +1,1 @@
+Import `pyarrow` lazily in the line-delimited JSON importer so that `infrahubctl` commands other than `object load` no longer require the `ctl` extra (and its heavy `pyarrow` dependency) to be installed.

--- a/infrahub_sdk/transfer/importer/json.py
+++ b/infrahub_sdk/transfer/importer/json.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import pyarrow.json as pa_json
 import ujson
 from rich.progress import Progress
 
@@ -53,6 +52,17 @@ class LineDelimitedJSONImporter(ImporterInterface):
             self.console.print(f"{end}")
 
     async def import_data(self, import_directory: Path, branch: str) -> None:
+        # pyarrow is a heavy, optional dependency used only to read the line-delimited JSON
+        # export. Import it lazily so the rest of infrahubctl works without it being installed;
+        # only `infrahubctl object load` reaches this code path.
+        try:
+            import pyarrow.json as pa_json  # noqa: PLC0415
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Loading objects requires pyarrow, install the 'ctl' extra of the infrahub-sdk "
+                "package, `pip install 'infrahub-sdk[ctl]'` or run `uv sync --extra ctl`."
+            ) from exc
+
         node_file = import_directory / "nodes.json"
         relationship_file = import_directory / "relationships.json"
         for f in (node_file, relationship_file):


### PR DESCRIPTION
## Why

`pyarrow` was imported at module top-level in the line-delimited JSON importer (`infrahub_sdk/transfer/importer/json.py`). That module is reached from `ctl.cli_commands` at `infrahubctl` startup, so **every** `infrahubctl` command required `pyarrow` (the `ctl` extra) to be importable — even `schema load`, `menu load`, and `run`, which don't touch pyarrow at all.

This breaks slim installs that intentionally omit the heavy `pyarrow` dependency (e.g. the Infrahub server container image), where `infrahubctl schema load` fails at startup with `Module pyarrow is not available`.

## What changed

- Import `pyarrow.json` lazily inside `LineDelimitedJSONImporter.import_data` — the only code path that uses it — instead of at module top-level.
- Raise a clear, actionable `ModuleNotFoundError` (pointing at the `ctl` extra) if pyarrow is missing when `object load` actually runs.

Only `infrahubctl object load` now requires the `ctl` extra; all other `infrahubctl` commands work without `pyarrow`.

## How to test

```bash
uv sync                      # without the ctl extra (no pyarrow)
infrahubctl schema load --help   # works (previously failed at import)
infrahubctl object load ...      # clear "install the 'ctl' extra" error
uv sync --extra ctl
infrahubctl object load ...      # works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load `pyarrow` in the line-delimited JSON importer so only `infrahubctl object load` requires the `ctl` extra; all other `infrahubctl` commands run without `pyarrow`. Fixes startup failures on slim installs (e.g., server image) where `pyarrow` isn’t installed.

- **Bug Fixes**
  - Moved `pyarrow.json` import into `LineDelimitedJSONImporter.import_data`.
  - Added clear `ModuleNotFoundError` with install hints: `pip install 'infrahub-sdk[ctl]'` or `uv sync --extra ctl`.

<sup>Written for commit e31a1dab1f1a00f40b43a4f2b779d645ad4b4c53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

