### PR TITLE
docs: ratify project constitution v1.0.0 (#1144)

### DIFF
--- a/dev/constitution.md
+++ b/dev/constitution.md
@@ -115,7 +115,9 @@ Every feature and bug fix MUST ship with tests in the same change; tests are nev
 deferred to a follow-up. A bug fix MUST include a test that reproduces the bug (fails
 before the fix, passes after). New public surface MUST test both the async and sync paths
 (see Principle I). Unit tests MUST be fast, mocked, and free of external dependencies;
-behavior that needs a real server belongs in integration tests (testcontainers).
+behavior that needs a real server belongs in integration tests (testcontainers). Tests
+MUST assert concrete expected values, not mere truthiness or non-null — an assertion that
+cannot fail for the right reason is not evidence.
 
 Rationale: tests written with the change, and reproduction tests for bugs, are the only
 evidence a reviewer or agent can check that behavior is actually pinned.

--- a/dev/constitution.md
+++ b/dev/constitution.md
@@ -1,59 +1,195 @@
-# [PROJECT_NAME] Constitution
+<!--
+Sync Impact Report
+==================
+Version change: (template placeholder) → 1.0.0
+Rationale: Initial ratification. The file previously contained only unfilled
+template tokens ([PRINCIPLE_1_NAME], [GOVERNANCE_RULES], ...); this is the first
+concrete constitution, so it starts at 1.0.0 (MINOR/PATCH bumps do not apply to a
+first ratification).
 
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+Principles defined (all new):
+  - I.   Async/Sync Dual API Parity
+  - II.  Backward Compatibility & Public API Stability
+  - III. Layered Architecture
+  - IV.  Type Safety & Typed Errors
+  - V.   Test-First Development
+  - VI.  Format & Lint Before Commit
+  - VII. Documentation Accuracy (NON-NEGOTIABLE)
+
+Sections added:
+  - Core Principles (7 articles)
+  - Additional Constraints (tech stack + boundaries)
+  - Development Workflow & Quality Gates
+  - Governance
+
+Templates / artifacts reviewed for consistency:
+  - .specify/templates/plan-template.md ...... ✅ no change needed
+      (Constitution Check gate uses generic "[Gates determined based on
+       constitution file]"; it reads this file at plan time, no hardcoded
+       principle list to update)
+  - .specify/templates/spec-template.md ...... ✅ no change needed (no constitution refs)
+  - .specify/templates/tasks-template.md ..... ✅ no change needed (no constitution refs)
+  - AGENTS.md / dev/knowledge/* .............. ✅ referenced as operational how-to; not duplicated
+
+Deferred TODOs: none.
+-->
+
+# Infrahub Python SDK Constitution
+
+The Infrahub Python SDK is a foundational library that abstracts the Infrahub API so
+developers work with infrastructure data as native Python objects. It is consumed by
+`infrahubctl`, the Infrahub Ansible collection, and external Python applications. Because
+so much depends on it, the principles below are non-negotiable defaults, not aspirations.
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
+### I. Async/Sync Dual API Parity
 
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+Every public feature MUST ship on both `InfrahubClient` (async) and `InfrahubClientSync`
+(sync) with matching method names, signatures, and behavior. The only sanctioned
+asymmetry is functionality that is physically meaningless in one mode (e.g. a
+concurrency/streaming helper with no coherent sync analog); such an exception MUST be
+justified in the pull request and documented in the method's docstring. Internal helpers
+(leading-underscore, not exported) are exempt.
 
-### [PRINCIPLE_2_NAME]
+Enforcement: surface parity is asserted by `tests/unit/sdk/test_client.py`
+(`test_validate_method_signature`, `test_method_count`). New behavior MUST be exercised
+by tests on **both** the async and sync path.
 
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+Rationale: the dual client is the SDK's signature contract. Divergence silently breaks
+sync consumers and is the single most likely regression when new surface is added.
 
-### [PRINCIPLE_3_NAME]
+### II. Backward Compatibility & Public API Stability
 
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+The SDK makes a tiered stability promise:
 
-### [PRINCIPLE_4_NAME]
+- **Guaranteed**: names exported from `infrahub_sdk/__init__.py` (`__all__`), the public
+  (non-underscore) methods of those classes, and documented `Config` fields.
+- **Not guaranteed**: underscore-prefixed names and modules reached by deep imports that
+  are not re-exported at top level. These may change in a MINOR release.
 
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+Breaking or removing a *guaranteed* surface MUST follow a deprecation path: first ship a
+release that emits `DeprecationWarning` naming the replacement, keep the deprecated path
+working for **at least one MINOR release**, and remove it only in a **MAJOR** release.
+Breaking changes without this path require explicit maintainer approval (see the
+`AGENTS.md` "ask first" gate on changing public API signatures).
 
-### [PRINCIPLE_5_NAME]
+Rationale: `infrahubctl`, the Ansible collection, and external applications pin and import
+this library; an unannounced break is a break for all of them at once.
 
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+### III. Layered Architecture
 
-## [SECTION_2_NAME]
+Reusable logic — API interaction, data transformation, and domain rules — MUST live in
+the SDK (`infrahub_sdk/`). Every first-party consumer (the CLI, the Ansible collection,
+external apps) is a thin layer over it. Concretely, the CLI (`infrahub_sdk/ctl/`) is
+limited to: argument parsing and local-only input validation, calls into SDK methods,
+presentation via Rich, and error-to-exit-code handling via `@catch_exception`. It MUST NOT
+use plain `print()` or instantiate `InfrahubClient` directly (use `initialize_client()`).
 
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+Test for a violation: *"Would a non-CLI consumer have to duplicate this logic to get the
+same behavior?"* If yes, it belongs in the SDK, not the CLI. Detailed CLI rules — including
+"don't pre-validate what the server validates" — live in
+`dev/knowledge/cli-design-principles.md` and `dev/knowledge/cli-architecture.md`.
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+Rationale: logic stranded in the CLI is invisible to every other consumer and drifts from
+the server it duplicates.
 
-## [SECTION_3_NAME]
+### IV. Type Safety & Typed Errors
 
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+All function signatures MUST carry type hints; both `ty` and `mypy` MUST pass clean.
+Pydantic v2 models are used at configuration, API, and data boundaries. A type-check
+suppression (`# type: ignore`, override) requires an inline justification.
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+Errors that a consumer could reasonably catch MUST be raised from the
+`infrahub_sdk.exceptions` hierarchy (rooted at `Error`), using a **specific** subclass; a
+new failure mode gets a new subclass rather than a bare `Exception`, `RuntimeError`, or a
+generic reuse. Standard-library exceptions (`ValueError`, `TypeError`) are acceptable only
+for local/programming errors a consumer would never be expected to catch.
+
+Rationale: precise types and a typed exception hierarchy are the contract that lets
+consumers handle failures deterministically instead of string-matching messages.
+
+### V. Test-First Development
+
+Every feature and bug fix MUST ship with tests in the same change; tests are never
+deferred to a follow-up. A bug fix MUST include a test that reproduces the bug (fails
+before the fix, passes after). New public surface MUST test both the async and sync paths
+(see Principle I). Unit tests MUST be fast, mocked, and free of external dependencies;
+behavior that needs a real server belongs in integration tests (testcontainers).
+
+Rationale: tests written with the change, and reproduction tests for bugs, are the only
+evidence a reviewer or agent can check that behavior is actually pinned.
+
+### VI. Format & Lint Before Commit
+
+Python code and documentation MUST pass the project's format and lint pipeline before
+being committed — `uv run invoke format lint-code` for code and `uv run invoke lint-docs`
+for documentation — and CI enforces the same pipeline. Nothing merges while these checks
+are red, and linters or type-checkers MUST NOT be silenced without an inline
+justification (see Principle IV).
+
+The concrete tool list is intentionally kept out of this document (it changes over time);
+it is defined by the invoke tasks and `AGENTS.md`.
+
+Rationale: a green, uniformly formatted baseline keeps diffs about behavior, not style,
+and keeps the review signal trustworthy.
+
+### VII. Documentation Accuracy (NON-NEGOTIABLE)
+
+Documentation MUST describe behavior that actually exists.
+
+- **Generated docs**: whenever CLI commands, SDK configuration, or Python docstrings
+  change, `uv run invoke docs-generate` MUST be run and the result committed;
+  `docs-validate` MUST pass in CI. Generated artifacts — `protocols.py` and generated
+  docs — are NEVER hand-edited.
+- **Hand-written docs & examples**: MUST describe only behavior that exists (no
+  aspirational or planned behavior presented as working), and MUST be updated in the
+  **same pull request** as the behavior change they document.
+
+Rationale: this is a public SDK for network automation engineers; an inaccurate example
+does not merely confuse — it ships broken automation downstream. This principle is
+non-negotiable and is not waived for schedule pressure.
+
+## Additional Constraints
+
+- **Tech stack**: Python 3.10–3.13, UV for dependency management, pydantic >= 2.0, httpx,
+  graphql-core. Adding a new runtime dependency is an "ask first" decision (`AGENTS.md`).
+- **Generated code**: `protocols.py` and generated documentation are produced by tooling
+  and MUST NOT be edited by hand (reinforces Principles III and VII).
+- **Boundaries of record**: `AGENTS.md` and the subdirectory guides
+  (`infrahub_sdk/ctl/AGENTS.md`, `infrahub_sdk/pytest_plugin/AGENTS.md`,
+  `tests/AGENTS.md`) hold the operational Always/Ask-first/Never lists that implement
+  these principles.
+
+## Development Workflow & Quality Gates
+
+- Run `uv run invoke format lint-code` before committing Python code (Principle VI).
+- Run `uv run invoke docs-generate` after creating, modifying, or deleting CLI commands,
+  SDK config, or Python docstrings; run `uv run invoke lint-docs` before committing
+  markdown (Principle VII).
+- New features follow the async/sync dual pattern and ship with both-path tests
+  (Principles I, V).
+- Pull requests — whether authored by a human or a Spec Kit agent — MUST be reviewable
+  against each principle above. A deviation MUST be called out and justified in the PR
+  description (and, for complexity, in the plan's Complexity Tracking table).
 
 ## Governance
 
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
+This constitution supersedes conflicting practices. Where it and `AGENTS.md` /
+`dev/knowledge/*` disagree, this constitution wins; otherwise the constitution holds the
+non-negotiable principles and those documents hold the operational how-to — they
+cross-reference rather than duplicate.
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+**Compliance**: every pull request and review (including automated Spec Kit reviews of
+specs, plans, and implementations) verifies compliance with these principles. Unjustified
+deviations block merge.
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+**Amendments**: changes require a written proposal, maintainer approval, and an adoption
+note describing any migration impact. The constitution is versioned with semantic
+versioning:
+
+- **MAJOR**: a principle is removed or redefined in a backward-incompatible way.
+- **MINOR**: a new principle or section is added, or guidance is materially expanded.
+- **PATCH**: clarifications, wording, and non-semantic refinements.
+
+**Version**: 1.0.0 | **Ratified**: 2026-07-10 | **Last Amended**: 2026-07-10


### PR DESCRIPTION
# Why

The Spec Kit constitution (`dev/constitution.md`, symlinked from
`.specify/memory/constitution.md`) shipped as an unfilled template
(`[PRINCIPLE_1_NAME]`, `[GOVERNANCE_RULES]`, …). With it empty, Spec Kit had no
project-specific guardrails, so specs/plans/implementations generated through it
could drift from the SDK's established conventions.

Goal: ratify a concrete constitution that encodes the SDK's non-negotiables, each
with enforcement teeth a reviewer or Spec Kit agent can check against a diff.

Non-goals: no changes to `AGENTS.md` or `dev/knowledge/*` (referenced as the
operational how-to layer, not duplicated); no new CI checks; no code changes.

Closes #1144

## What changed

Populated the constitution with seven principles, each stated as a testable rule
with a named enforcement mechanism:

- **I. Async/Sync Dual API Parity** — both clients, matching signatures; enforced by
  `test_validate_method_signature` / `test_method_count`.
- **II. Backward Compatibility & Public API Stability** — tiered public API
  (`__all__`), deprecate → survive ≥1 minor → remove only in a major.
- **III. Layered Architecture** — reusable logic in the SDK; CLI stays thin
  (the "would a non-CLI consumer duplicate this?" test).
- **IV. Type Safety & Typed Errors** — `ty`/`mypy` clean; errors use the
  `infrahub_sdk.exceptions` `Error` hierarchy.
- **V. Test-First Development** — tests ship with the change; bug fixes need a
  reproduction test; assertions verify concrete values, not truthiness.
- **VI. Format & Lint Before Commit** — tool-agnostic; CI is the gate.
- **VII. Documentation Accuracy (NON-NEGOTIABLE)** — `docs-validate` green +
  hand-written docs describe only real behavior, updated in the same PR.

Plus Additional Constraints, Development Workflow & Quality Gates, and a
Governance section (supremacy, SemVer amendment rules, v1.0.0 ratification).

Authored via `/speckit.constitution`. Dependent templates reviewed
(`plan-template.md`'s Constitution Check reads this file at plan time; spec/tasks
templates carry no constitution refs) — no template edits needed.

## How to review

Single file: `dev/constitution.md`. The Sync Impact Report is an HTML comment at
the top summarizing version, principles, and template review.

## How to test

\`\`\`bash
uv run rumdl check dev/constitution.md   # passes clean
\`\`\`

## Impact & rollout

- **Backward compatibility:** docs-only; no code or API changes.
- **Deployment notes:** safe to merge; no runtime impact.

## Checklist

- [x] Internal .md docs updated (this is the constitution itself)
- [ ] Tests added/updated — N/A (docs-only)
- [ ] Changelog entry — N/A (`ci/skip-changelog`; no user-facing change)
- [ ] External docs updated — N/A (no user-facing behavior change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ratifies the Infrahub Python SDK constitution v1.0.0 in `dev/constitution.md`, replacing the empty template. Sets seven enforceable principles and governance to keep the SDK, CLI, and docs aligned; docs-only with no code or CI changes.

- **New Features**
  - Seven core principles with enforcement: async/sync API parity (`InfrahubClient`/`InfrahubClientSync`); public API stability via `__all__` and deprecation windows; SDK‑first layered architecture; strict typing and `infrahub_sdk.exceptions`; test‑first with meaningful assertions; format/lint gates; documentation accuracy with generated/validated docs.
  - Adds Additional Constraints, Development Workflow & Quality Gates, and Governance (constitution supremacy, SemVer for amendments, v1.0.0 ratified).

<sup>Written for commit 90e2327d0f9051af9280a4dd730c616ed38755d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

