### PR TITLE
feat(ctl): add deployment_id to the infrahubctl info command

### DIFF
--- a/changelog/1017.added.md
+++ b/changelog/1017.added.md
@@ -1,1 +1,1 @@
-Added the Infrahub deployment ID to the `infrahubctl info` command output and a `get_deployment_id()` method to the async and sync clients.
+Added the Infrahub deployment ID to the `infrahubctl info` command output and a `get_server_information()` method (returning the server version and deployment ID) on the async and sync clients.

--- a/changelog/1017.added.md
+++ b/changelog/1017.added.md
@@ -1,0 +1,1 @@
+Added the Infrahub deployment ID to the `infrahubctl info` command output and a `get_deployment_id()` method to the async and sync clients.

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -97,13 +97,13 @@ get_version(self) -> str
 
 Return the Infrahub version.
 
-#### `get_deployment_id`
+#### `get_server_information`
 
 ```python
-get_deployment_id(self) -> str
+get_server_information(self) -> ServerInfo
 ```
 
-Return the Infrahub deployment ID.
+Return the Infrahub server information (version and deployment ID).
 
 #### `get_user`
 
@@ -615,13 +615,13 @@ get_version(self) -> str
 
 Return the Infrahub version.
 
-#### `get_deployment_id`
+#### `get_server_information`
 
 ```python
-get_deployment_id(self) -> str
+get_server_information(self) -> ServerInfo
 ```
 
-Return the Infrahub deployment ID.
+Return the Infrahub server information (version and deployment ID).
 
 #### `get_user`
 

--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -97,6 +97,14 @@ get_version(self) -> str
 
 Return the Infrahub version.
 
+#### `get_deployment_id`
+
+```python
+get_deployment_id(self) -> str
+```
+
+Return the Infrahub deployment ID.
+
 #### `get_user`
 
 ```python
@@ -606,6 +614,14 @@ get_version(self) -> str
 ```
 
 Return the Infrahub version.
+
+#### `get_deployment_id`
+
+```python
+get_deployment_id(self) -> str
+```
+
+Return the Infrahub deployment ID.
 
 #### `get_user`
 

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -365,6 +365,11 @@ class InfrahubClient(BaseClient):
         response = await self.execute_graphql(query="query { InfrahubInfo { version }}")
         return response.get("InfrahubInfo", {}).get("version", "")
 
+    async def get_deployment_id(self) -> str:
+        """Return the Infrahub deployment ID."""
+        response = await self.execute_graphql(query="query { InfrahubInfo { deployment_id }}")
+        return response.get("InfrahubInfo", {}).get("deployment_id", "")
+
     async def get_user(self) -> dict:
         """Return user information."""
         return await self.execute_graphql(query=QUERY_USER, operation_name="GET_PROFILE_DETAILS")
@@ -2071,6 +2076,11 @@ class InfrahubClientSync(BaseClient):
         """Return the Infrahub version."""
         response = self.execute_graphql(query="query { InfrahubInfo { version }}")
         return response.get("InfrahubInfo", {}).get("version", "")
+
+    def get_deployment_id(self) -> str:
+        """Return the Infrahub deployment ID."""
+        response = self.execute_graphql(query="query { InfrahubInfo { deployment_id }}")
+        return response.get("InfrahubInfo", {}).get("deployment_id", "")
 
     def get_user(self) -> dict:
         """Return user information."""

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -22,7 +22,7 @@ from .branch import MUTATION_QUERY_TASK, BranchData, InfrahubBranchManager, Infr
 from .config import Config
 from .constants import InfrahubClientMode
 from .convert_object_type import CONVERT_OBJECT_MUTATION, ConversionFieldInput
-from .data import RepositoryBranchInfo, RepositoryData
+from .data import RepositoryBranchInfo, RepositoryData, ServerInfo
 from .diff import DiffTreeData, NodeDiff, diff_tree_node_to_node_diff, get_diff_summary_query, get_diff_tree_query
 from .exceptions import (
     AuthenticationError,
@@ -365,10 +365,14 @@ class InfrahubClient(BaseClient):
         response = await self.execute_graphql(query="query { InfrahubInfo { version }}")
         return response.get("InfrahubInfo", {}).get("version", "")
 
-    async def get_deployment_id(self) -> str:
-        """Return the Infrahub deployment ID."""
-        response = await self.execute_graphql(query="query { InfrahubInfo { deployment_id }}")
-        return response.get("InfrahubInfo", {}).get("deployment_id", "")
+    async def get_server_information(self) -> ServerInfo:
+        """Return the Infrahub server information (version and deployment ID)."""
+        response = await self.execute_graphql(
+            query="query { InfrahubInfo { version deployment_id }}",
+            tracker="query-server-info",
+        )
+        info = response.get("InfrahubInfo", {})
+        return ServerInfo(version=info.get("version", ""), deployment_id=info.get("deployment_id", ""))
 
     async def get_user(self) -> dict:
         """Return user information."""
@@ -2077,10 +2081,14 @@ class InfrahubClientSync(BaseClient):
         response = self.execute_graphql(query="query { InfrahubInfo { version }}")
         return response.get("InfrahubInfo", {}).get("version", "")
 
-    def get_deployment_id(self) -> str:
-        """Return the Infrahub deployment ID."""
-        response = self.execute_graphql(query="query { InfrahubInfo { deployment_id }}")
-        return response.get("InfrahubInfo", {}).get("deployment_id", "")
+    def get_server_information(self) -> ServerInfo:
+        """Return the Infrahub server information (version and deployment ID)."""
+        response = self.execute_graphql(
+            query="query { InfrahubInfo { version deployment_id }}",
+            tracker="query-server-info",
+        )
+        info = response.get("InfrahubInfo", {})
+        return ServerInfo(version=info.get("version", ""), deployment_id=info.get("deployment_id", ""))
 
     def get_user(self) -> dict:
         """Return user information."""

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -414,6 +414,7 @@ def info(  # noqa: PLR0915
         "error": None,
         "status": ":x:",
         "infrahub_version": "N/A",
+        "deployment_id": "N/A",
         "user_info": {},
         "groups": {},
     }
@@ -422,6 +423,7 @@ def info(  # noqa: PLR0915
 
     try:
         info["infrahub_version"] = client.get_version()
+        info["deployment_id"] = client.get_deployment_id()
 
         if fetch_user_details:
             info["user_info"] = client.get_user()
@@ -467,6 +469,7 @@ def info(  # noqa: PLR0915
         version_info = Table(show_header=False, box=None)
         version_info.add_row("Python Version:", platform.python_version())
         version_info.add_row("Infrahub Version", info["infrahub_version"])
+        version_info.add_row("Deployment ID:", info["deployment_id"])
         version_info.add_row("Infrahub SDK:", sdk_version)
         layout["version_info"].update(Panel(version_info, title="Version Information"))
 
@@ -509,6 +512,7 @@ def info(  # noqa: PLR0915
         table.add_row("Python Version:", platform.python_version())
         table.add_row("SDK Version:", sdk_version)
         table.add_row("Infrahub Version:", info["infrahub_version"])
+        table.add_row("Deployment ID:", info["deployment_id"])
         if account := info["user_info"].get("AccountProfile"):
             table.add_row("User:", account["display_label"])
 

--- a/infrahub_sdk/ctl/cli_commands.py
+++ b/infrahub_sdk/ctl/cli_commands.py
@@ -422,8 +422,9 @@ def info(  # noqa: PLR0915
     fetch_user_details = bool(client.config.username) or bool(client.config.api_token)
 
     try:
-        info["infrahub_version"] = client.get_version()
-        info["deployment_id"] = client.get_deployment_id()
+        server_info = client.get_server_information()
+        info["infrahub_version"] = server_info.version
+        info["deployment_id"] = server_info.deployment_id
 
         if fetch_user_details:
             info["user_info"] = client.get_user()

--- a/infrahub_sdk/data.py
+++ b/infrahub_sdk/data.py
@@ -5,6 +5,11 @@ from pydantic import BaseModel, ConfigDict, Field
 from .node import InfrahubNode  # noqa: TC001
 
 
+class ServerInfo(BaseModel):
+    version: str = ""
+    deployment_id: str = ""
+
+
 class RepositoryBranchInfo(BaseModel):
     internal_status: str
 

--- a/tests/unit/ctl/conftest.py
+++ b/tests/unit/ctl/conftest.py
@@ -5,7 +5,7 @@ import ujson
 from pytest_httpx import HTTPXMock
 
 from infrahub_sdk.utils import get_fixtures_dir
-from tests.unit.sdk.conftest import mock_query_infrahub_user, mock_query_infrahub_version  # noqa: F401
+from tests.unit.sdk.conftest import mock_query_infrahub_server_info, mock_query_infrahub_user  # noqa: F401
 
 
 @pytest.fixture

--- a/tests/unit/ctl/test_cli.py
+++ b/tests/unit/ctl/test_cli.py
@@ -33,7 +33,7 @@ def test_version_command() -> None:
     assert "Python SDK: v" in result.stdout
 
 
-def test_info_command_success(mock_query_infrahub_version: HTTPXMock, mock_query_infrahub_user: HTTPXMock) -> None:
+def test_info_command_success(mock_query_infrahub_server_info: HTTPXMock, mock_query_infrahub_user: HTTPXMock) -> None:
     result = runner.invoke(app, ["info"], env={"INFRAHUB_API_TOKEN": "foo"})
     assert result.exit_code == 0
     for expected in ["Connection Status", "Python Version", "SDK Version", "Infrahub Version", "Deployment ID"]:
@@ -47,7 +47,7 @@ def test_info_command_failure() -> None:
 
 
 def test_info_detail_command_success(
-    mock_query_infrahub_version: HTTPXMock, mock_query_infrahub_user: HTTPXMock
+    mock_query_infrahub_server_info: HTTPXMock, mock_query_infrahub_user: HTTPXMock
 ) -> None:
     result = runner.invoke(app, ["info", "--detail"], env={"INFRAHUB_API_TOKEN": "foo"})
     assert result.exit_code == 0
@@ -55,7 +55,7 @@ def test_info_detail_command_success(
         assert expected in result.stdout, f"'{expected}' not found in detailed info command output"
 
 
-def test_anonymous_info_detail_command_success(mock_query_infrahub_version: HTTPXMock) -> None:
+def test_anonymous_info_detail_command_success(mock_query_infrahub_server_info: HTTPXMock) -> None:
     result = runner.invoke(app, ["info", "--detail"])
     assert result.exit_code == 0
     for expected in ["Connection Status", "Version Information", "Client Info", "Infrahub Info", "anonymous"]:

--- a/tests/unit/ctl/test_cli.py
+++ b/tests/unit/ctl/test_cli.py
@@ -36,7 +36,7 @@ def test_version_command() -> None:
 def test_info_command_success(mock_query_infrahub_version: HTTPXMock, mock_query_infrahub_user: HTTPXMock) -> None:
     result = runner.invoke(app, ["info"], env={"INFRAHUB_API_TOKEN": "foo"})
     assert result.exit_code == 0
-    for expected in ["Connection Status", "Python Version", "SDK Version", "Infrahub Version"]:
+    for expected in ["Connection Status", "Python Version", "SDK Version", "Infrahub Version", "Deployment ID"]:
         assert expected in result.stdout, f"'{expected}' not found in info command output"
 
 

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -2074,6 +2074,16 @@ async def mock_query_infrahub_version(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 
 @pytest.fixture
+async def mock_query_infrahub_deployment_id(httpx_mock: HTTPXMock) -> HTTPXMock:
+    httpx_mock.add_response(
+        method="POST",
+        json={"data": {"InfrahubInfo": {"deployment_id": "abc123"}}},
+        is_reusable=True,
+    )
+    return httpx_mock
+
+
+@pytest.fixture
 async def mock_query_infrahub_user(httpx_mock: HTTPXMock) -> HTTPXMock:
     response_text = (get_fixtures_dir() / "account_profile.json").read_text(encoding="UTF-8")
     httpx_mock.add_response(method="POST", json=ujson.loads(response_text), is_reusable=True)

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -2074,10 +2074,11 @@ async def mock_query_infrahub_version(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 
 @pytest.fixture
-async def mock_query_infrahub_deployment_id(httpx_mock: HTTPXMock) -> HTTPXMock:
+async def mock_query_infrahub_server_info(httpx_mock: HTTPXMock) -> HTTPXMock:
     httpx_mock.add_response(
         method="POST",
-        json={"data": {"InfrahubInfo": {"deployment_id": "abc123"}}},
+        json={"data": {"InfrahubInfo": {"version": "1.1.0", "deployment_id": "abc123"}}},
+        match_headers={"X-Infrahub-Tracker": "query-server-info"},
         is_reusable=True,
     )
     return httpx_mock

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -214,6 +214,18 @@ async def test_method_get_version(
 
 
 @pytest.mark.parametrize("client_type", client_types)
+async def test_method_get_deployment_id(
+    clients: BothClients, mock_query_infrahub_deployment_id: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        deployment_id = await clients.standard.get_deployment_id()
+    else:
+        deployment_id = clients.sync.get_deployment_id()
+
+    assert deployment_id == "abc123"
+
+
+@pytest.mark.parametrize("client_type", client_types)
 async def test_method_get_user(clients: BothClients, mock_query_infrahub_user: HTTPXMock, client_type: str) -> None:
     if client_type == "standard":
         user = await clients.standard.get_user()

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -214,15 +214,16 @@ async def test_method_get_version(
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_method_get_deployment_id(
-    clients: BothClients, mock_query_infrahub_deployment_id: HTTPXMock, client_type: str
+async def test_method_get_server_information(
+    clients: BothClients, mock_query_infrahub_server_info: HTTPXMock, client_type: str
 ) -> None:
     if client_type == "standard":
-        deployment_id = await clients.standard.get_deployment_id()
+        server_info = await clients.standard.get_server_information()
     else:
-        deployment_id = clients.sync.get_deployment_id()
+        server_info = clients.sync.get_server_information()
 
-    assert deployment_id == "abc123"
+    assert server_info.version == "1.1.0"
+    assert server_info.deployment_id == "abc123"
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
# Why

Operators running `infrahubctl info` had no easy way to retrieve the Infrahub
deployment identifier, which is useful for support, telemetry correlation, and
distinguishing between deployments.

Goal: surface the `deployment_id` directly in `infrahubctl info`.

Closes #1017

## What changed

- `infrahubctl info` now displays the **Deployment ID** in both the simple and
  `--detail` output views.
- Added a `get_deployment_id()` method to the async (`InfrahubClient`) and sync
  (`InfrahubClientSync`) clients, mirroring the existing `get_version()` pattern
  (`query { InfrahubInfo { deployment_id } }`).

Implementation notes: the fetch sits inside the existing `try` block, so on a
connection failure the field falls back to `N/A` and the error surfaces through
the existing error row -- the command cannot crash.

What stayed the same: no schema changes; existing `info` output fields and the
CLI signature/options are unchanged (the generated CLI reference is untouched).

## How to review

Focus on `infrahub_sdk/client.py` (new dual async/sync method) and the `info`
command in `infrahub_sdk/ctl/cli_commands.py`. Docs under `docs/.../client.mdx`
are auto-generated.

## How to test

\`\`\`bash
uv run pytest tests/unit/sdk/test_client.py -k get_deployment_id
uv run pytest tests/unit/ctl/test_cli.py
uv run invoke docs-validate
\`\`\`

Then against a live server: `infrahubctl info` and `infrahubctl info --detail`
should list a **Deployment ID** row.

## Impact & rollout

- **Backward compatibility:** No breaking changes; additive only.
- **Config/env changes:** None.
- **Deployment notes:** Safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/1017.added.md`)
- [x] External docs updated (auto-generated SDK reference regenerated)
- [ ] Internal .md docs updated (n/a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Infrahub Deployment ID to `infrahubctl info` and introduces `get_server_information()` to fetch version and deployment ID in one call. This makes deployments easy to identify and reduces `info` API calls; no breaking changes.

- **New Features**
  - `infrahubctl info` shows Deployment ID in simple and `--detail` views.
  - Clients add `get_server_information()` returning `{ version, deployment_id }`; `get_version()` remains.
  - `info` now uses one GraphQL query for version + deployment ID (anonymous 2→1; authenticated 4→3); on errors, Deployment ID falls back to `N/A`.

<sup>Written for commit fdf50dbef2f1b67be2d84f7f1d22f1de6f8861e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

