### PR TITLE
chore(agents): add comment/reference rule, drop no-push guardrail

### DIFF
--- a/.agents/rules/code-comments.md
+++ b/.agents/rules/code-comments.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "**/*"
+---
+
+# Comment and reference rules
+
+## Comment sparingly
+
+- Prefer clear code over explanation. Add a comment only when it conveys intent the code cannot — a non-obvious tradeoff, gotcha, or "why".
+- Keep comments as short as possible — one line where you can.
+- Do not restate what the code plainly does.
+
+## Do not reference ephemeral artifacts
+
+Do not reference specs, tasks, plans, tickets, issue numbers, user stories, or the current spec-kit command/feature name in any file — including code, comments, docstrings, `AGENTS.md`, and `CLAUDE.md`. These artifacts are archived over time; every file must stand on its own.
+
+## Type-ignore comments
+
+Use the standard `# type: ignore[<code>]` form (for example `# type: ignore[arg-type]`), never `# ty: ignore`. Only `# type: ignore[...]` is honored by mypy, pyright, and pytype, so a `# ty:` comment suppresses nothing and is dead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,6 @@ When editing `.md` or `.mdx` files (`uv run invoke lint-docs` enforces these):
 
 🚫 **Never**
 
-- Push to GitHub automatically (always wait for user approval)
 - Mix async/sync inappropriately
 - Modify generated code (protocols.py)
 - Bypass type checking without justification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ When editing `.md` or `.mdx` files (`uv run invoke lint-docs` enforces these):
 
 🚫 **Never**
 
+- Update `CLAUDE.md` (it is a thin `@AGENTS.md` router — edit `AGENTS.md` instead)
 - Mix async/sync inappropriately
 - Modify generated code (protocols.py)
 - Bypass type checking without justification


### PR DESCRIPTION
## Summary
Tightens the guidance coding agents follow, based on behaviors observed across recent PRs, and retires one stale guardrail now that agents operate more autonomously.

## Key Changes
- Agents comment sparingly — only where code can't convey intent, kept short — instead of adding verbose low-value comments.
- Agents never reference ephemeral artifacts (specs, tasks, tickets, issue numbers, user stories, or the current spec-kit command name) in any file, including `AGENTS.md` and `CLAUDE.md`, so archived planning docs don't leak into the codebase.
- Type-ignore comments use the standard `# type: ignore[<code>]` form that mypy/pyright/pytype honor, never the dead `# ty: ignore`.
- Removed the "never push to GitHub automatically" boundary from `AGENTS.md`.

## Test Plan
- `uv run invoke lint-docs` passes (rumdl reports no issues).
- New rule surfaces through the adapter symlink: `ls -L .claude/rules/` lists `code-comments.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global rule for agent comments and references with standardized `# type: ignore[...]` usage. Replaces the stale "no auto-push" boundary with a "never edit `CLAUDE.md`" rule to route edits to `AGENTS.md`.

- **Refactors**
  - Added `.agents/rules/code-comments.md` (applies to all files): comment sparingly; never reference ephemeral artifacts; use `# type: ignore[<code>]` only.
  - Updated `AGENTS.md`: removed "never push to GitHub automatically"; added "never update `CLAUDE.md` (edit `AGENTS.md` instead)".

<sup>Written for commit 89ebe4be9b9f2eb751b79d3b8ce076d935733207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

