### PR TITLE
chore(ruff): adopt google docstring convention and enforce DOC102/DOC402

### DIFF
--- a/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
+++ b/docs/docs/python-sdk/sdk_ref/infrahub_sdk/client.mdx
@@ -986,7 +986,7 @@ Allocate a new IP prefix by using the provided resource pool.
 
 - `resource_pool`: Node corresponding to the pool to allocate resources from.
 - `identifier`: Value to perform idempotent allocation, the same resource will be returned for a given identifier.
-- `size`: Length of the prefix to allocate.
+- `prefix_length`: Length of the prefix to allocate.
 - `member_type`: Member type of the prefix to allocate.
 - `prefix_type`: Kind of the prefix to allocate.
 - `data`: A key/value map to use to set attributes values on the allocated prefix.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1461,6 +1461,9 @@ class InfrahubClient(BaseClient):
         Returns an async context manager that yields the streaming response.
         Use this for downloading large files without loading into memory.
 
+        Yields:
+            httpx.Response: The streaming HTTP response.
+
         Raises:
             ServerNotReachableError: If we are not able to connect to the server.
             ServerNotResponsiveError: If the server didn't respond before the timeout expired.
@@ -3446,7 +3449,7 @@ class InfrahubClientSync(BaseClient):
         Args:
             resource_pool (InfrahubNodeSync): Node corresponding to the pool to allocate resources from.
             identifier (str, optional): Value to perform idempotent allocation, the same resource will be returned for a given identifier.
-            size (int, optional): Length of the prefix to allocate.
+            prefix_length (int, optional): Length of the prefix to allocate.
             member_type (str, optional): Member type of the prefix to allocate.
             prefix_type (str, optional): Kind of the prefix to allocate.
             data (dict, optional): A key/value map to use to set attributes values on the allocated prefix.
@@ -3528,6 +3531,9 @@ class InfrahubClientSync(BaseClient):
 
         Returns a context manager that yields the streaming response.
         Use this for downloading large files without loading into memory.
+
+        Yields:
+            httpx.Response: The streaming HTTP response.
 
         Raises:
             ServerNotReachableError: If we are not able to connect to the server.

--- a/infrahub_sdk/ctl/config.py
+++ b/infrahub_sdk/ctl/config.py
@@ -81,8 +81,8 @@ class ConfiguredSettings:
         In such cases, a message is printed to the screen indicating the settings which don't pass validation.
 
         Args:
-            config_file_name (str, optional): [description]. Defaults to "pyprojectctl.toml".
-            config_data (dict, optional): [description]. Defaults to None.
+            config_file (str | Path, optional): Path to the configuration file. Defaults to "infrahubctl.toml".
+            config_data (dict, optional): In-memory configuration overriding the file contents. Defaults to None.
 
         """
         try:

--- a/infrahub_sdk/pytest_plugin/loader.py
+++ b/infrahub_sdk/pytest_plugin/loader.py
@@ -66,7 +66,11 @@ class InfrahubYamlFile(pytest.File):
         return resource_config
 
     def collect_group(self, group: InfrahubTestGroup) -> Iterable[pytest.Item]:
-        """Collect all items for a group."""
+        """Collect all items for a group.
+
+        Yields:
+            pytest.Item: Each collected test item for the group.
+        """
         marker = MARKER_MAPPING[group.resource]
         resource_config = self.get_resource_config(group)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,8 +304,8 @@ ignore = [
     "CPY",    # flake8-copyright
     "T201",   # use of `print`
     "COM812", # missing-trailing-comma
-    "D203",     # incorrect-blank-line-before-class (incompatible with D211)
-    "D213",     # multi-line-summary-second-line (incompatible with D212)
+    # D203/D213/D401/D404 are handled by the google convention set in
+    # [tool.ruff.lint.pydocstyle]; they don't need to be listed here.
 
     ##################################################################################################
     # Rules below needs to be Investigated                                                           #
@@ -350,13 +350,9 @@ ignore = [
     "D104",    # Missing docstring in public package
     "D105",    # Missing docstring in magic method
     "D107",    # Missing docstring in `__init__`
-    "D301",    # Use `r"""` if any backslashes in a docstring
-    "D401",    # First line of docstring should be in imperative mood
-    "D404",    # First word of the docstring should not be "This"
+    "D301",    # Use `r"""` if any backslashes in a docstring — conflicts with Typer's `\b` no-wrap marker in CLI command docstrings, which must stay a real escape (not a raw string)
     "D417",    # Missing argument description in the docstring
-    "DOC102",  # Docstring contains extraneous parameter(s)
     "DOC201",  # `return` is not documented in docstring
-    "DOC402",  # `yield` is not documented in docstring
     "DOC502",  # Raised exception is not explicitly raised (false positives for transitive raises through helpers)
 ]
 
@@ -381,6 +377,12 @@ ignorelist = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["infrahub_sdk", "infrahub_ctl"]
+
+[tool.ruff.lint.pydocstyle]
+# Docstrings are Google-style. This also lets the DOC (pydoclint) rules parse
+# Args/Returns/Yields sections correctly, and disables the convention's excluded
+# rules (D203, D213, D401, D404, ...) so they don't need manual ignores above.
+convention = "google"
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 150

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,8 +304,6 @@ ignore = [
     "CPY",    # flake8-copyright
     "T201",   # use of `print`
     "COM812", # missing-trailing-comma
-    # D203/D213/D401/D404 are handled by the google convention set in
-    # [tool.ruff.lint.pydocstyle]; they don't need to be listed here.
 
     ##################################################################################################
     # Rules below needs to be Investigated                                                           #
@@ -379,9 +377,7 @@ ignorelist = [
 known-first-party = ["infrahub_sdk", "infrahub_ctl"]
 
 [tool.ruff.lint.pydocstyle]
-# Docstrings are Google-style. This also lets the DOC (pydoclint) rules parse
-# Args/Returns/Yields sections correctly, and disables the convention's excluded
-# rules (D203, D213, D401, D404, ...) so they don't need manual ignores above.
+# Also lets the DOC (pydoclint) rules parse Args/Returns/Yields sections correctly.
 convention = "google"
 
 [tool.ruff.lint.pycodestyle]

--- a/tests/unit/sdk/test_repository.py
+++ b/tests/unit/sdk/test_repository.py
@@ -13,7 +13,11 @@ from infrahub_sdk.utils import get_fixtures_dir
 
 @pytest.fixture
 def temp_dir() -> Generator[str]:
-    """Fixture to create a temporary directory for testing."""
+    """Fixture to create a temporary directory for testing.
+
+    Yields:
+        str: Path to the temporary directory.
+    """
     with tempfile.TemporaryDirectory() as tmp_dir:
         yield tmp_dir
 


### PR DESCRIPTION
# Why

The SDK's docstrings aren't verified against the code, so parameters, return/yield
sections, and descriptions can drift out of sync silently. We're turning on ruff's
`D`/`DOC` (pydocstyle + pydoclint) rules incrementally — this is the first
enforceable slice, focused on docstring-vs-signature *accuracy*.

Non-goals: clearing the large "missing docstring" (D10x) backlog — those stay
parked for later phases.

## What changed

- **Docstring accuracy is now CI-enforced for two rules:** DOC102 (a documented
  parameter that isn't in the signature) and DOC402 (a generator whose `yield`
  isn't documented).
- **Set the pydocstyle convention to `google`** (matches the codebase). Beyond
  style, this lets the DOC rules correctly parse `Args`/`Returns`/`Yields`
  sections — which cleared ~35 false-positive DOC201 findings and let
  D203/D213/D401/D404 drop from manual ignores.
- **Fixed the violations this surfaced:** corrected a stale `size` param (actually
  `prefix_length`) and placeholder/incorrect param docs in `ConfiguredSettings`,
  and documented the yields of the streaming HTTP context managers and two
  generators.
- **D301 intentionally left parked:** its fix (raw docstring) would turn Typer's
  `\b` no-wrap marker into literal text and break CLI `--help` formatting.

No runtime behavior changes — only docstrings, regenerated CLI/SDK reference docs,
and lint config.

## How to test

```bash
uv run ruff check                          # clean
uv run ruff check --select DOC102,DOC402   # 0 findings — enforced and clean
uv run invoke docs-validate                # generated docs in sync
```

## Impact & rollout

- **Backward compatibility:** none; docstring/lint-only.
- **Config/env changes:** ruff `convention = "google"`; DOC102/DOC402 enforced going forward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts the Google docstring convention in `ruff` and enforces docstring/signature accuracy with `DOC102` and `DOC402`. Fixes mismatched params and adds missing Yields docs; no runtime changes.

- **Refactors**
  - Enable `DOC102`/`DOC402` in CI; keep `D301` ignored due to Typer `\b`.
  - Set `[tool.ruff.lint.pydocstyle].convention = "google"`; drop manual ignores for D203/D213/D401/D404; trim redundant comments in `pyproject.toml`.
  - `infrahub_sdk.client`: rename `size` to `prefix_length` in docs; add `Yields` for streaming (sync/async).
  - `infrahub_sdk/ctl/config.py`: correct param name to `config_file`; clarify `config_data`.
  - Pytest plugin and tests: add `Yields` docs for generators.
  - Regenerated SDK reference to reflect `prefix_length`.

<sup>Written for commit f176345c9739c5bd32add12c571921781b7d6c10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

