### PR TITLE
feat: add IPAddress attribute kind support [INFP-551]

### DIFF
--- a/changelog/+ipaddress-attribute-kind.added.md
+++ b/changelog/+ipaddress-attribute-kind.added.md
@@ -1,0 +1,1 @@
+Added support for the new `IPAddress` attribute kind. Values are exposed as bare `ipaddress.IPv4Address`/`IPv6Address` objects (no prefix) and serialized to a bare-address string when writing, alongside the existing `IPHost` and `IPNetwork` kinds.

--- a/infrahub_sdk/node/attribute.py
+++ b/infrahub_sdk/node/attribute.py
@@ -5,7 +5,14 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NamedTuple, get_args
 
 from ..uuidt import UUIDT
-from .constants import ATTRIBUTE_METADATA_OBJECT, IP_TYPES, PROPERTIES_FLAG, PROPERTIES_OBJECT, SAFE_VALUE
+from .constants import (
+    ATTRIBUTE_METADATA_OBJECT,
+    IP_ADDRESS_TYPES,
+    IP_TYPES,
+    PROPERTIES_FLAG,
+    PROPERTIES_OBJECT,
+    SAFE_VALUE,
+)
 from .property import NodeProperty
 
 if TYPE_CHECKING:
@@ -105,6 +112,7 @@ class Attribute:
             value_mapper: dict[str, Callable] = {
                 "IPHost": ipaddress.ip_interface,
                 "IPNetwork": ipaddress.ip_network,
+                "IPAddress": ipaddress.ip_address,
             }
             mapper = value_mapper.get(schema.kind, lambda value: value)
             self._value = mapper(data.get("value"))
@@ -160,7 +168,13 @@ class Attribute:
             )
 
         # Safe strings, IP types, and everything else
-        value = self.value.with_prefixlen if isinstance(self.value, get_args(IP_TYPES)) else self.value
+        if isinstance(self.value, get_args(IP_TYPES)):
+            value = self.value.with_prefixlen
+        elif isinstance(self.value, get_args(IP_ADDRESS_TYPES)):
+            # bare addresses have no prefix; serialize their canonical string form
+            value = str(self.value)
+        else:
+            value = self.value
         return _GraphQLPayloadAttribute(payload={"value": value}, variables={}, needs_metadata=True)
 
     def _generate_input_data(self) -> _GraphQLPayloadAttribute:

--- a/infrahub_sdk/node/constants.py
+++ b/infrahub_sdk/node/constants.py
@@ -18,6 +18,9 @@ SAFE_VALUE = re.compile(r"(^[\. /:a-zA-Z0-9_-]+$)|(^$)")
 
 IP_TYPES = ipaddress.IPv4Interface | ipaddress.IPv6Interface | ipaddress.IPv4Network | ipaddress.IPv6Network
 
+# Bare IP addresses (no prefix); serialized with str() rather than with_prefixlen
+IP_ADDRESS_TYPES = ipaddress.IPv4Address | ipaddress.IPv6Address
+
 ARTIFACT_FETCH_FEATURE_NOT_SUPPORTED_MESSAGE = (
     "calling artifact_fetch is only supported for nodes that are Artifact Definition target"
 )

--- a/infrahub_sdk/protocols_base.py
+++ b/infrahub_sdk/protocols_base.py
@@ -140,6 +140,14 @@ class IPNetworkOptional(Attribute):
     value: ipaddress.IPv4Network | ipaddress.IPv6Network | None
 
 
+class IPAddress(Attribute):
+    value: ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+class IPAddressOptional(Attribute):
+    value: ipaddress.IPv4Address | ipaddress.IPv6Address | None
+
+
 class Boolean(Attribute):
     value: bool
 

--- a/infrahub_sdk/protocols_generator/constants.py
+++ b/infrahub_sdk/protocols_generator/constants.py
@@ -17,6 +17,7 @@ ATTRIBUTE_KIND_MAP = {
     "Bandwidth": "Integer",
     "IPHost": "IPHost",
     "IPNetwork": "IPNetwork",
+    "IPAddress": "IPAddress",
     "Boolean": "Boolean",
     "Checkbox": "Boolean",
     "List": "ListAttribute",

--- a/infrahub_sdk/protocols_generator/template.j2
+++ b/infrahub_sdk/protocols_generator/template.j2
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
         IPHostOptional,
         IPNetwork,
         IPNetworkOptional,
+        IPAddress,
+        IPAddressOptional,
         JSONAttribute,
         JSONAttributeOptional,
         ListAttribute,

--- a/infrahub_sdk/schema/main.py
+++ b/infrahub_sdk/schema/main.py
@@ -61,6 +61,7 @@ class AttributeKind(str, Enum):
     BANDWIDTH = "Bandwidth"
     IPHOST = "IPHost"
     IPNETWORK = "IPNetwork"
+    IPADDRESS = "IPAddress"
     BOOLEAN = "Boolean"
     CHECKBOX = "Checkbox"
     LIST = "List"

--- a/tests/unit/sdk/conftest.py
+++ b/tests/unit/sdk/conftest.py
@@ -887,6 +887,21 @@ async def ipaddress_schema() -> NodeSchemaAPI:
 
 
 @pytest.fixture
+async def bare_ipaddress_schema() -> NodeSchemaAPI:
+    data = {
+        "name": "DnsRecord",
+        "namespace": "Infra",
+        "default_filter": "address__value",
+        "display_labels": ["address_value"],
+        "order_by": ["address_value"],
+        "attributes": [
+            {"name": "address", "kind": "IPAddress"},
+        ],
+    }
+    return NodeSchema(**data).convert_api()
+
+
+@pytest.fixture
 async def ipnetwork_schema() -> NodeSchemaAPI:
     data = {
         "name": "IPNetwork",

--- a/tests/unit/sdk/test_node.py
+++ b/tests/unit/sdk/test_node.py
@@ -1788,6 +1788,23 @@ async def test_create_input_data_with_IPHost_attribute(
 
 
 @pytest.mark.parametrize("client_type", client_types)
+async def test_create_input_data_with_IPAddress_attribute(
+    client: InfrahubClient, bare_ipaddress_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    data = {"address": {"value": ipaddress.ip_address("1.1.1.1"), "is_protected": True}}
+
+    if client_type == "standard":
+        dns_record = InfrahubNode(client=client, schema=bare_ipaddress_schema, data=data)
+    else:
+        dns_record = InfrahubNodeSync(client=client, schema=bare_ipaddress_schema, data=data)
+
+    # a bare address is serialized without any prefix
+    assert dns_record._generate_input_data()["data"] == {
+        "data": {"address": {"value": "1.1.1.1", "is_protected": True}}
+    }
+
+
+@pytest.mark.parametrize("client_type", client_types)
 async def test_create_input_data_with_IPNetwork_attribute(
     client: InfrahubClient, ipnetwork_schema: NodeSchemaAPI, client_type: str
 ) -> None:
@@ -2178,6 +2195,26 @@ async def test_node_IPHost_deserialization(
         ip_address = InfrahubNodeSync(client=client, schema=ipaddress_schema, data=data)
 
     assert ip_address.address.value == ipaddress.ip_interface("1.1.1.1/24")
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_node_IPAddress_deserialization(
+    client: InfrahubClient, bare_ipaddress_schema: NodeSchemaAPI, client_type: str
+) -> None:
+    data = {
+        "id": "aaaaaaaaaaaaaa",
+        "address": {
+            "value": "1.1.1.1",
+            "is_protected": True,
+        },
+    }
+    if client_type == "standard":
+        dns_record = InfrahubNode(client=client, schema=bare_ipaddress_schema, data=data)
+    else:
+        dns_record = InfrahubNodeSync(client=client, schema=bare_ipaddress_schema, data=data)
+
+    # a bare address deserializes to an ip_address object (no prefix)
+    assert dns_record.address.value == ipaddress.ip_address("1.1.1.1")
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
## Summary

Adds SDK support for the new `IPAddress` attribute kind (bare IP address, no netmask/prefix), alongside the existing `IPHost` and `IPNetwork` kinds. Part of the cross-stack work for Infrahub INFP-551 (targets the Infrahub 1.11 cycle).

| Kind | Python mapping | Value type | Stores |
|---|---|---|---|
| `IPAddress` (new) | `ipaddress.ip_address` | `IPv4Address \| IPv6Address` | bare `192.0.2.1` |
| `IPHost` | `ipaddress.ip_interface` | `IPv4Interface \| IPv6Interface` | `192.0.2.1/24` |
| `IPNetwork` | `ipaddress.ip_network` | `IPv4Network \| IPv6Network` | `192.0.2.0/24` |

## Changes

- `protocols_base.py`: new `IPAddress` / `IPAddressOptional` attribute types.
- `protocols_generator/constants.py`: `ATTRIBUTE_KIND_MAP` entry.
- `schema/main.py`: `AttributeKind.IPADDRESS`.
- `node/attribute.py` + `node/constants.py`: parse via `ipaddress.ip_address`; serialize bare addresses with `str()` (no `with_prefixlen`).
- `protocols_generator/template.j2`: import the new types so generated protocols reference them.
- Unit tests for input-data serialization and deserialization (async + sync).

## Testing

- `uv run pytest tests/unit/sdk/test_node.py` — 228 passed.
- ruff + mypy clean on changed files.
- Verified end-to-end against a live Infrahub instance built from the matching backend branch: `client.get(...)` returns a bare `IPv4Address`/`IPv6Address` for an `IPAddress` attribute, while `IPHost`/`IPNetwork` still return prefixed interface/network objects.

## Notes

Base branch is `infrahub-develop` (the branch the Infrahub `develop` submodule tracks). The Infrahub-side PR bumps the `python_sdk` submodule pointer only after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SDK support for a new IPAddress attribute kind to store and return bare IPv4/IPv6 addresses without a prefix. This fulfills INFP-551 by enabling schemas to validate and serialize plain IPs without the implicit /32 or /128.

- **New Features**
  - Added `AttributeKind.IPADDRESS` and mapping in protocol generator.
  - Introduced `IPAddress` and `IPAddressOptional` protocol types (`ipaddress.IPv4Address` | `IPv6Address`).
  - Parse with `ipaddress.ip_address`; serialize as a bare string (no prefix). `IPHost`/`IPNetwork` behavior unchanged.
  - Updated node attribute parsing and GraphQL payload generation to handle bare IPs.
  - Added unit tests for sync/async serialization and deserialization.

<sup>Written for commit 7997dd32493267282c48dccd4279fc6923a45930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

