### PR TITLE
feat(sdk): expose task error and webhook delivery diagnostics

### DIFF
--- a/changelog/+task-diagnostics.added.md
+++ b/changelog/+task-diagnostics.added.md
@@ -1,0 +1,1 @@
+Added an opt-in `include_diagnostics` flag to the task manager's `all()`, `filter()`, and `get()` methods. When enabled, tasks expose an `error` field, and `webhook-send` tasks are returned as `WebhookDeliveryTask` instances carrying `http_request` / `http_response` delivery details.

--- a/infrahub_sdk/task/__init__.py
+++ b/infrahub_sdk/task/__init__.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
-from .models import Task, TaskAction, TaskActionName, TaskFilter, TaskLog, TaskRelatedNode, TaskState
+from .models import (
+    HttpRequest,
+    HttpResponse,
+    Task,
+    TaskAction,
+    TaskActionName,
+    TaskError,
+    TaskFilter,
+    TaskLog,
+    TaskRelatedNode,
+    TaskState,
+    WebhookDeliveryTask,
+)
 
 __all__ = [
+    "HttpRequest",
+    "HttpResponse",
     "Task",
     "TaskAction",
     "TaskActionName",
+    "TaskError",
     "TaskFilter",
     "TaskLog",
     "TaskRelatedNode",
     "TaskState",
+    "WebhookDeliveryTask",
 ]

--- a/infrahub_sdk/task/manager.py
+++ b/infrahub_sdk/task/manager.py
@@ -23,6 +23,7 @@ class InfraHubTaskManagerBase:
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
         offset: int | None = None,
         limit: int | None = None,
         count: bool = False,
@@ -78,6 +79,15 @@ class InfraHubTaskManagerBase:
                 "unavailability_reason": None,
             }
 
+        if include_diagnostics:
+            node = query["InfrahubTask"]["edges"]["node"]
+            node["error"] = {"status_class": None, "message": None, "remediation": None}
+            # node is a GraphQL interface; the string key renders as an inline fragment.
+            node["... on WebhookDeliveryTask"] = {
+                "http_request": {"url": None, "headers": None},
+                "http_response": {"status_code": None, "body": None, "latency_ms": None},
+            }
+
         return Query(query=query)
 
     @classmethod
@@ -124,6 +134,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Get all tasks.
 
@@ -135,6 +146,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
             include_logs: Whether to include the logs in the tasks. Defaults to False.
             include_related_nodes: Whether to include the related nodes in the tasks. Defaults to False.
             include_actions: Whether to include the available actions in the tasks. Defaults to False.
+            include_diagnostics: Whether to include the error and webhook delivery diagnostics in the tasks. Defaults to False.
 
         Returns:
             A list of tasks.
@@ -148,6 +160,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
             include_logs=include_logs,
             include_related_nodes=include_related_nodes,
             include_actions=include_actions,
+            include_diagnostics=include_diagnostics,
         )
 
     async def filter(
@@ -160,6 +173,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Filter tasks.
 
@@ -172,6 +186,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
             include_logs: Whether to include the logs in the tasks. Defaults to False.
             include_related_nodes: Whether to include the related nodes in the tasks. Defaults to False.
             include_actions: Whether to include the available actions in the tasks. Defaults to False.
+            include_diagnostics: Whether to include the error and webhook delivery diagnostics in the tasks. Defaults to False.
 
         Returns:
             A list of tasks.
@@ -190,6 +205,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
                     include_logs=include_logs,
                     include_related_nodes=include_related_nodes,
                     include_actions=include_actions,
+                    include_diagnostics=include_diagnostics,
                     count=False,
                 ),
                 1,
@@ -204,6 +220,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
                 include_logs=include_logs,
                 include_related_nodes=include_related_nodes,
                 include_actions=include_actions,
+                include_diagnostics=include_diagnostics,
             )
 
         return await self.process_non_batch(
@@ -214,16 +231,23 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
             include_logs=include_logs,
             include_related_nodes=include_related_nodes,
             include_actions=include_actions,
+            include_diagnostics=include_diagnostics,
         )
 
     async def get(
-        self, id: str, include_logs: bool = False, include_related_nodes: bool = False, include_actions: bool = False
+        self,
+        id: str,
+        include_logs: bool = False,
+        include_related_nodes: bool = False,
+        include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> Task:
         tasks = await self.filter(
             filter=TaskFilter(ids=[id]),
             include_logs=include_logs,
             include_related_nodes=include_related_nodes,
             include_actions=include_actions,
+            include_diagnostics=include_diagnostics,
             parallel=False,
         )
         if not tasks:
@@ -315,6 +339,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Process queries in parallel mode."""
         pagination_size = self.client.pagination_size
@@ -332,6 +357,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
                 include_logs=include_logs,
                 include_related_nodes=include_related_nodes,
                 include_actions=include_actions,
+                include_diagnostics=include_diagnostics,
                 count=False,
             )
             batch_process.add(
@@ -352,6 +378,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Process queries without parallel mode.
 
@@ -372,6 +399,7 @@ class InfrahubTaskManager(InfraHubTaskManagerBase):
                 include_logs=include_logs,
                 include_related_nodes=include_related_nodes,
                 include_actions=include_actions,
+                include_diagnostics=include_diagnostics,
                 count=True,
             )
             new_tasks, count = await self.process_page(
@@ -417,6 +445,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Get all tasks.
 
@@ -428,6 +457,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
             include_logs: Whether to include the logs in the tasks. Defaults to False.
             include_related_nodes: Whether to include the related nodes in the tasks. Defaults to False.
             include_actions: Whether to include the available actions in the tasks. Defaults to False.
+            include_diagnostics: Whether to include the error and webhook delivery diagnostics in the tasks. Defaults to False.
 
         Returns:
             A list of tasks.
@@ -441,6 +471,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
             include_logs=include_logs,
             include_related_nodes=include_related_nodes,
             include_actions=include_actions,
+            include_diagnostics=include_diagnostics,
         )
 
     def filter(
@@ -453,6 +484,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Filter tasks.
 
@@ -465,6 +497,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
             include_logs: Whether to include the logs in the tasks. Defaults to False.
             include_related_nodes: Whether to include the related nodes in the tasks. Defaults to False.
             include_actions: Whether to include the available actions in the tasks. Defaults to False.
+            include_diagnostics: Whether to include the error and webhook delivery diagnostics in the tasks. Defaults to False.
 
         Returns:
             A list of tasks.
@@ -483,6 +516,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
                     include_logs=include_logs,
                     include_related_nodes=include_related_nodes,
                     include_actions=include_actions,
+                    include_diagnostics=include_diagnostics,
                     count=False,
                 ),
                 1,
@@ -497,6 +531,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
                 include_logs=include_logs,
                 include_related_nodes=include_related_nodes,
                 include_actions=include_actions,
+                include_diagnostics=include_diagnostics,
             )
 
         return self.process_non_batch(
@@ -507,16 +542,23 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
             include_logs=include_logs,
             include_related_nodes=include_related_nodes,
             include_actions=include_actions,
+            include_diagnostics=include_diagnostics,
         )
 
     def get(
-        self, id: str, include_logs: bool = False, include_related_nodes: bool = False, include_actions: bool = False
+        self,
+        id: str,
+        include_logs: bool = False,
+        include_related_nodes: bool = False,
+        include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> Task:
         tasks = self.filter(
             filter=TaskFilter(ids=[id]),
             include_logs=include_logs,
             include_related_nodes=include_related_nodes,
             include_actions=include_actions,
+            include_diagnostics=include_diagnostics,
             parallel=False,
         )
         if not tasks:
@@ -608,6 +650,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Process queries in parallel mode."""
         pagination_size = self.client.pagination_size
@@ -625,6 +668,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
                 include_logs=include_logs,
                 include_related_nodes=include_related_nodes,
                 include_actions=include_actions,
+                include_diagnostics=include_diagnostics,
                 count=False,
             )
             batch_process.add(
@@ -645,6 +689,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
         include_logs: bool = False,
         include_related_nodes: bool = False,
         include_actions: bool = False,
+        include_diagnostics: bool = False,
     ) -> list[Task]:
         """Process queries without parallel mode.
 
@@ -665,6 +710,7 @@ class InfrahubTaskManagerSync(InfraHubTaskManagerBase):
                 include_logs=include_logs,
                 include_related_nodes=include_related_nodes,
                 include_actions=include_actions,
+                include_diagnostics=include_diagnostics,
                 count=True,
             )
             new_tasks, count = self.process_page(

--- a/infrahub_sdk/task/models.py
+++ b/infrahub_sdk/task/models.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field
+
+WEBHOOK_SEND_WORKFLOW = "webhook-send"
 
 
 class TaskState(str, Enum):
@@ -40,6 +43,25 @@ class TaskRelatedNode(BaseModel):
     kind: str
 
 
+class TaskError(BaseModel):
+    """Classified failure reason with a remediation hint; set only when a task failed with one."""
+
+    status_class: str
+    message: str
+    remediation: str
+
+
+class HttpRequest(BaseModel):
+    url: str
+    headers: dict[str, Any] | None = None  # secret values are masked by the server
+
+
+class HttpResponse(BaseModel):
+    status_code: int | None = None
+    body: str | None = None
+    latency_ms: float | None = None
+
+
 class Task(BaseModel):
     id: str
     title: str
@@ -55,6 +77,7 @@ class Task(BaseModel):
     related_nodes: list[TaskRelatedNode] = Field(default_factory=list)
     logs: list[TaskLog] = Field(default_factory=list)
     available_actions: list[TaskAction] = Field(default_factory=list)
+    error: TaskError | None = None
 
     @property
     def can_retry(self) -> bool:
@@ -68,6 +91,7 @@ class Task(BaseModel):
 
     @classmethod
     def from_graphql(cls, data: dict) -> Task:
+        data = dict(data)
         related_nodes: list[TaskRelatedNode] = []
         logs: list[TaskLog] = []
         available_actions: list[TaskAction] = []
@@ -87,7 +111,27 @@ class Task(BaseModel):
                 available_actions = [TaskAction(**item) for item in data["available_actions"]]
             del data["available_actions"]
 
-        return cls(**data, related_nodes=related_nodes, logs=logs, available_actions=available_actions)
+        # The workflow name selects the concrete type, mirroring the server's interface;
+        # pydantic coerces the remaining error / http_* dicts in `data` into their models.
+        target_cls = TASK_TYPES.get(data.get("workflow") or "", cls)
+        return target_cls(
+            **data,
+            related_nodes=related_nodes,
+            logs=logs,
+            available_actions=available_actions,
+        )
+
+
+class WebhookDeliveryTask(Task):
+    """Concrete task type for the ``webhook-send`` workflow, carrying delivery diagnostics."""
+
+    http_request: HttpRequest | None = None
+    http_response: HttpResponse | None = None
+
+
+TASK_TYPES: dict[str, type[Task]] = {
+    WEBHOOK_SEND_WORKFLOW: WebhookDeliveryTask,
+}
 
 
 class TaskFilter(BaseModel):

--- a/infrahub_sdk/task/models.py
+++ b/infrahub_sdk/task/models.py
@@ -48,7 +48,7 @@ class TaskError(BaseModel):
 
     status_class: str
     message: str
-    remediation: str
+    remediation: str | None = None
 
 
 class HttpRequest(BaseModel):

--- a/tests/unit/sdk/test_task.py
+++ b/tests/unit/sdk/test_task.py
@@ -304,6 +304,7 @@ async def test_error_parsed() -> None:
 
     assert task.error is not None
     assert task.error.status_class == "client_error"
+    assert task.error.message == "endpoint returned 404"
     assert task.error.remediation == "check the webhook URL"
 
 

--- a/tests/unit/sdk/test_task.py
+++ b/tests/unit/sdk/test_task.py
@@ -9,7 +9,7 @@ import pytest
 from infrahub_sdk.graphql import Mutation
 from infrahub_sdk.task.exceptions import TaskNotFoundError, TooManyTasksError
 from infrahub_sdk.task.manager import MUTATION_TASK_QUERY, InfraHubTaskManagerBase
-from infrahub_sdk.task.models import Task, TaskFilter, TaskState
+from infrahub_sdk.task.models import Task, TaskFilter, TaskState, WebhookDeliveryTask
 
 if TYPE_CHECKING:
     from pytest_httpx import HTTPXMock
@@ -90,6 +90,19 @@ async def test_filter_limit_forwards_include_actions(
 
     sent_query = json.loads(mock_query_tasks_03.get_requests()[-1].content)["query"]
     assert "available_actions" in sent_query
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_filter_limit_forwards_include_diagnostics(
+    clients: BothClients, mock_query_tasks_03: HTTPXMock, client_type: str
+) -> None:
+    if client_type == "standard":
+        await clients.standard.task.filter(limit=5, include_diagnostics=True)
+    else:
+        clients.sync.task.filter(limit=5, include_diagnostics=True)
+
+    sent_query = json.loads(mock_query_tasks_03.get_requests()[-1].content)["query"]
+    assert "... on WebhookDeliveryTask" in sent_query
 
 
 async def test_action_mutation_render() -> None:
@@ -202,6 +215,7 @@ async def test_method_get_full(clients: BothClients, mock_query_tasks_05: HTTPXM
         "available_actions": [],
         "branch": "main",
         "created_at": datetime(2025, 1, 18, 22, 12, 20, 228112, tzinfo=timezone.utc),
+        "error": None,
         "id": "32116fcd-9071-43a7-9f14-777901020b5b",
         "logs": [
             {
@@ -274,3 +288,55 @@ async def test_available_actions_absent_defaults_empty() -> None:
     assert task.available_actions == []
     assert task.can_retry is False
     assert task.can_cancel is False
+
+
+async def test_error_parsed() -> None:
+    task = Task.from_graphql(
+        {
+            **_base_task_data(),
+            "error": {
+                "status_class": "client_error",
+                "message": "endpoint returned 404",
+                "remediation": "check the webhook URL",
+            },
+        }
+    )
+
+    assert task.error is not None
+    assert task.error.status_class == "client_error"
+    assert task.error.remediation == "check the webhook URL"
+
+
+async def test_webhook_send_dispatches_to_webhook_task() -> None:
+    task = Task.from_graphql(
+        {
+            **_base_task_data(),
+            "workflow": "webhook-send",
+            "http_request": {"url": "https://example.com/hook", "headers": {"X-Signature": "***"}},
+            "http_response": {"status_code": 200, "body": "ok", "latency_ms": 42.5},
+        }
+    )
+
+    assert isinstance(task, WebhookDeliveryTask)
+    assert task.http_request is not None
+    assert task.http_request.url == "https://example.com/hook"
+    assert task.http_response is not None
+    assert task.http_response.status_code == 200
+    assert task.http_response.latency_ms == pytest.approx(42.5)
+
+
+async def test_generate_query_excludes_diagnostics_by_default() -> None:
+    query = InfraHubTaskManagerBase._generate_query().render()
+
+    assert "error {" not in query
+    assert "... on WebhookDeliveryTask {" not in query
+
+
+async def test_generate_query_includes_diagnostics_when_requested() -> None:
+    query = InfraHubTaskManagerBase._generate_query(include_diagnostics=True).render()
+
+    assert "error {" in query
+    assert "remediation" in query
+    assert "... on WebhookDeliveryTask {" in query
+    assert "http_request {" in query
+    assert "http_response {" in query


### PR DESCRIPTION
## Why

The server exposes task delivery diagnostics (an interface-wide `error`, plus `http_request`/`http_response` on `webhook-send` runs via a GraphQL interface), but the SDK's `Task` model and queries didn't surface them.

Closes [IFC-2920](https://opsmill.atlassian.net/browse/IFC-2920)

## What changed

- **New opt-in `include_diagnostics` flag** on the task manager's `all()`, `filter()`, and `get()` (async + sync). When enabled, the query requests `error` and, via an inline fragment, the webhook task's `http_request` / `http_response`.
- **Polymorphic task typing:** `Task.from_graphql` dispatches on the workflow name, so `webhook-send` runs deserialize into a new `WebhookDeliveryTask(Task)` subtype — mirroring the server's `TaskNodeInterface` / concrete-type design. New models: `TaskError`, `HttpRequest`, `HttpResponse`.
- **What stayed the same:** default `all()`/`filter()`/`get()` queries are unchanged (no `error`, no fragment), keeping the base query lean and the potentially large response body out of bulk listings — and compatible with servers that predate the interface.

## How to review

- `infrahub_sdk/task/models.py` — new models, `error` on base `Task`, `WebhookDeliveryTask`, and the `from_graphql` dispatch (relies on pydantic to coerce the `error`/`http_*` dicts).
- `infrahub_sdk/task/manager.py` — the `include_diagnostics` block in `_generate_query` (the `... on WebhookDeliveryTask` string key renders as an inline fragment) and the threading through the query paths.

## How to test

```bash
uv run pytest tests/unit/sdk/test_task.py
```

## Impact & rollout

- **Backward compatibility:** additive; default query behavior unchanged.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [ ] External docs updated (task manager isn't in the generated SDK reference)
- [x] Internal .md docs updated (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in way to fetch task errors and webhook delivery details in the SDK, making it easier to debug failures without increasing default payload size. Default behavior stays the same.

- **New Features**
  - Add `include_diagnostics` to `all()`, `filter()`, and `get()` (async and sync).
  - When enabled, include `error` on all tasks and `http_request`/`http_response` for `webhook-send`.
  - Add polymorphic tasks: `Task.from_graphql` dispatches by `workflow`; new `WebhookDeliveryTask`, `TaskError`, `HttpRequest`, `HttpResponse`.
  - Backward compatible; diagnostics excluded by default.

- **Bug Fixes**
  - Make `TaskError.remediation` optional to match server responses.

<sup>Written for commit d8f737adf81ef199868f84eebb3bc8fb020a7f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





[IFC-2920]: https://opsmill.atlassian.net/browse/IFC-2920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ