### PR TITLE
fix: percent-encode branch name in GraphQL URL path (closes #1209)

### DIFF
--- a/changelog/1209.fixed.md
+++ b/changelog/1209.fixed.md
@@ -1,0 +1,1 @@
+Branch names containing URL-significant characters (such as `#` or `/`) are now percent-encoded in the GraphQL URL, so requests against those branches resolve correctly instead of returning a 404.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -11,7 +11,7 @@ from enum import Enum
 from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TypedDict, TypeVar, overload
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import httpx
 import ujson
@@ -278,7 +278,7 @@ class BaseClient:
     ) -> str:
         url = f"{self.config.address}/graphql"
         if branch_name:
-            url += f"/{branch_name}"
+            url += f"/{quote(branch_name, safe='')}"
 
         url_params = {}
         if at:

--- a/tests/unit/sdk/test_client.py
+++ b/tests/unit/sdk/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import ssl
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -872,3 +873,24 @@ async def test_execute_graphql_omits_operation_name_when_unset(
     assert len(post_requests) == 1
     payload = json.loads(post_requests[0].content)
     assert "operationName" not in payload
+
+
+@dataclass
+class GraphQLURLCase:
+    name: str
+    branch_name: str
+    expected_url: str
+
+
+GRAPHQL_URL_CASES = [
+    GraphQLURLCase(name="hash", branch_name="feature#123", expected_url="http://mock/graphql/feature%23123"),
+    GraphQLURLCase(name="slash", branch_name="feature/foo", expected_url="http://mock/graphql/feature%2Ffoo"),
+    GraphQLURLCase(name="plain", branch_name="main", expected_url="http://mock/graphql/main"),
+]
+
+
+@pytest.mark.parametrize("client_type", client_types)
+@pytest.mark.parametrize("case", [pytest.param(tc, id=tc.name) for tc in GRAPHQL_URL_CASES])
+async def test_graphql_url_encodes_branch_name(clients: BothClients, client_type: str, case: GraphQLURLCase) -> None:
+    client = clients.standard if client_type == "standard" else clients.sync
+    assert client._graphql_url(branch_name=case.branch_name) == case.expected_url


### PR DESCRIPTION
# Why

`InfrahubClient._graphql_url()` interpolated the branch name directly into the URL path without percent-encoding it. Branch names containing URL-significant characters therefore produced malformed URLs: a `#` (e.g. `feature#123`) was treated as a fragment so the path collapsed to `/graphql/feature`, and a `/` (e.g. `feature/foo`) injected an extra path segment — both resolving to the wrong branch and returning HTTP 404 / `URLNotFoundError`. Reported from the field.

Goal: any branch name Infrahub accepts also works through the SDK.

Non-goals: the `?branch=` query-string sites elsewhere in the SDK (schema, ctl) share the same class of issue but are out of scope for this fix — tracked separately.

Closes #1209

## What changed

- **Behavioral change:** the branch name is now percent-encoded as a single path segment (`quote(branch_name, safe="")`) before being appended to the GraphQL URL, so `feature#123` → `/graphql/feature%23123` and `feature/foo` → `/graphql/feature%2Ffoo`.
- **Implementation notes:** one-line change at the interpolation site in `BaseClient._graphql_url`, reusing `urllib.parse.quote`. `safe=""` is required so `/` is escaped too. Because `_graphql_url` lives on `BaseClient`, both `InfrahubClient` and `InfrahubClientSync` are covered by the single change.
- **What stayed the same:** plain branch names (e.g. `main`) are unchanged (no double-encoding); the `at` query parameter handling and all other URLs are untouched. No API contract change.

## How to review

Focus is `infrahub_sdk/client.py:281`. The rest is the reproduction test and a changelog fragment.

## How to test

```bash
uv run pytest tests/unit/sdk/test_client.py::test_graphql_url_encodes_branch_name -v
```

Expected: 6 passing cases (`#`, `/`, plain `main` × async/sync). The `#`/`/` cases fail on the pre-fix code.

## Impact & rollout

- **Backward compatibility:** none — plain branch names encode to themselves; only previously-broken special-character branches change behavior.
- **Performance:** negligible (one `quote()` call per URL build).
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/1209.fixed.md`)
- [ ] External docs updated (not user-facing beyond changelog)
- [ ] Internal .md docs updated (n/a)

<!-- AGENT_FIX_COMPLETE -->
