### PR TITLE
docs: expand Python typing guide with real-world protocol examples

### DIFF
--- a/docs/docs/python-sdk/guides/python-typing.mdx
+++ b/docs/docs/python-sdk/guides/python-typing.mdx
@@ -109,10 +109,9 @@ Protocols make the most difference in generators, transforms, and checks, where 
 ```python
 from .protocols import NetworkDevice
 
-# `kind` is the generated class, not a string, so attributes are type-checked
-leaf_switches: list[NetworkDevice] = await client.filters(
-    kind=NetworkDevice, role__value="leaf", include=["interfaces"]
-)
+# Passing the generated class as `kind` makes `filters()` return `list[NetworkDevice]`,
+# so `switch` is fully typed without annotating the variable yourself
+leaf_switches = await client.filters(kind=NetworkDevice, role__value="leaf", include=["interfaces"])
 
 for switch in leaf_switches:
     switch.name.value  # autocompleted, and checked against the schema

--- a/docs/docs/python-sdk/guides/python-typing.mdx
+++ b/docs/docs/python-sdk/guides/python-typing.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Overview
 
-This guide explains how to use Python's type system effectively with the Infrahub SDK, focusing on the use of Protocols for type-safe development.
+Use Python's type system with the Infrahub SDK to catch schema mismatches while you write code, not when it runs. This guide shows how to type your SDK calls with Protocols, generate typed classes from your own schema, and generate Pydantic models from your GraphQL queries.
 
 :::note What is Python Typing
 
@@ -101,6 +101,32 @@ my_object = client.get(MyOwnObject, name__value="example")
 ```
 
 > if you don't have your own Python module, it's possible to use relative path by having the `protocols.py` in the same directory as your script/transform/generator
+
+### Using protocols in generators and transforms
+
+Protocols make the most difference in generators, transforms, and checks, where you traverse relationships and set attributes across many object kinds. Import the generated class, pass it as the `kind` argument, and use it as a type hint:
+
+```python
+from .protocols import NetworkDevice
+
+# `kind` is the generated class, not a string, so attributes are type-checked
+leaf_switches: list[NetworkDevice] = await client.filters(
+    kind=NetworkDevice, role__value="leaf", include=["interfaces"]
+)
+
+for switch in leaf_switches:
+    switch.name.value  # autocompleted, and checked against the schema
+```
+
+### Keep protocols in sync with your schema
+
+The generated file is a build artifact: regenerate it whenever your schema changes, and commit the result. When the schema changes and you regenerate, your type checker reports every line that no longer matches the schema, so you find the mismatch while you write code instead of at runtime.
+
+Regenerate with the same command you used to create the file:
+
+```shell
+infrahubctl protocols --out lib/protocols.py
+```
 
 ## Generating Pydantic models from GraphQL queries
 


### PR DESCRIPTION
## Summary
Enrich the Python SDK "Strict Typing in Python" guide. The page already documents the protocols mechanics; this adds the real-world usage and the "keep protocols in sync" framing that were missing.

## Key changes
- **Overview**: rewrote the opener as a capability lead (removed "This guide explains…").
- **New subsection — "Using protocols in generators and transforms"**: a multi-kind example (`client.filters(kind=NetworkDevice, …)` with a `list[NetworkDevice]` type hint) showing where protocols matter most.
- **New subsection — "Keep protocols in sync with your schema"**: the generated file is a build artifact; regenerate on schema change; the type checker surfaces drift at development time.

## What needs reviewer attention
- The two new subsections in `docs/docs/python-sdk/guides/python-typing.mdx` (all other lines unchanged). New prose only; the example uses documented SDK APIs.

## What didn't change
- All existing content preserved; no factual claims altered.
- The `infrahubctl protocols` reference page is auto-generated — untouched.

## Out of scope (deferred)
- [ ] Voice cleanup of the "Generating Pydantic models from GraphQL queries" section (stacked-benefit bullets + "excellent type safety") — pre-existing prose, not in a section this PR touches. Fix in a follow-up if desired.

## Test plan
- `cd docs && npm run build` succeeds
- Vale: 0 errors/warnings on the changed file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the Python SDK typing guide with real-world `Protocol` usage to catch schema mismatches before runtime, add a generator/transform example using `client.filters(kind=NetworkDevice, ...)` that infers `list[NetworkDevice]` (no redundant annotation), document regenerating protocols with `infrahubctl protocols`, and update the overview to lead with capability.

<sup>Written for commit 581d30ea9fc33dfc3b45e58ca3da087d2af23c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

