### PR TITLE
fix: allow a task related node to have no kind

### DIFF
--- a/changelog/+task-related-node-nullable-kind.fixed.md
+++ b/changelog/+task-related-node-nullable-kind.fixed.md
@@ -1,0 +1,1 @@
+Fixed a validation error when reading tasks with `include_related_nodes=True`. A task can reference a node that no longer exists in the graph, for which the server cannot resolve a kind, so `TaskRelatedNode.kind` is now optional and defaults to `None`.

--- a/infrahub_sdk/task/models.py
+++ b/infrahub_sdk/task/models.py
@@ -26,7 +26,8 @@ class TaskLog(BaseModel):
 
 class TaskRelatedNode(BaseModel):
     id: str
-    kind: str
+    # A related node whose vertex is gone from the graph has no recoverable kind.
+    kind: str | None = None
 
 
 class Task(BaseModel):

--- a/tests/unit/sdk/test_task.py
+++ b/tests/unit/sdk/test_task.py
@@ -161,3 +161,24 @@ async def test_method_get_full(clients: BothClients, mock_query_tasks_05: HTTPXM
         "updated_at": datetime(2025, 1, 18, 22, 12, 22, 44921, tzinfo=timezone.utc),
         "workflow": "import-python-files",
     }
+
+
+def test_from_graphql_related_node_without_kind() -> None:
+    task = Task.from_graphql(
+        {
+            "id": "32116fcd-9071-43a7-9f14-777901020b5b",
+            "title": "Import Python file",
+            "state": "COMPLETED",
+            "created_at": "2025-01-18T22:12:20.228112+00:00",
+            "updated_at": "2025-01-18T22:12:22.044921+00:00",
+            "related_nodes": [
+                {"id": "1808d478-e51e-7504-d0ef-c513f1cd69a5", "kind": "CoreReadOnlyRepository"},
+                {"id": "1808d478-e51e-7504-aaaa-c513f1cd69a5", "kind": None},
+            ],
+        }
+    )
+
+    assert [(node.id, node.kind) for node in task.related_nodes] == [
+        ("1808d478-e51e-7504-d0ef-c513f1cd69a5", "CoreReadOnlyRepository"),
+        ("1808d478-e51e-7504-aaaa-c513f1cd69a5", None),
+    ]


### PR DESCRIPTION
## Problem

Reading tasks with `include_related_nodes=True` raises a Pydantic `ValidationError` when a task
references a node that no longer exists in the graph.

A task outlives the nodes it references. When a related node's vertex is gone, the server cannot
resolve a kind for it and returns `kind: null`. `TaskRelatedNode.kind` was typed as a required
`str`, so `Task.from_graphql` failed while constructing the model:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for TaskRelatedNode
kind
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

The path is `manager.py` selecting `{"id": None, "kind": None}` for `related_nodes`, then
`Task.from_graphql` doing `TaskRelatedNode(**item)` on each entry.

This turns a server-side condition the API now handles gracefully into a client-side crash.

## Server side

Infrahub previously declared `TaskRelatedNode.kind` non-null, so this case surfaced as a GraphQL
error rather than a null value. That is being corrected in
opsmill/infrahub#10075, which makes the field nullable. This change is the SDK half: without it,
the same tasks fail with a validation error instead.

The two are intentionally not coupled by a submodule bump, so this can land and be released on its
own schedule.

## Change

`TaskRelatedNode.kind` is now `str | None = None`.

## Tests

Added `test_from_graphql_related_node_without_kind`, which parses a task carrying one resolvable
and one unresolvable related node. Verified to fail before the change with the exact
`ValidationError` above.

`tests/unit/sdk/test_task.py` passes 16/16. `ruff check`, `ruff format --check` and `mypy` are
clean on the touched files.

The full unit suite reports 3 failures — `test_repository_app.py::test_repo_list`,
`test_repository_app.py::test_repo_init` and `test_task_app.py::test_task_list_command` — which
reproduce identically on unmodified `stable`, so they are pre-existing and unrelated.

## Backporting

Targeting `stable`. To be backported to `develop` and `infrahub-develop`, both of which still carry
the required `kind: str`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `TaskRelatedNode.kind` optional to prevent crashes when reading tasks with `include_related_nodes=True` that reference deleted nodes. The SDK now accepts `kind: null` from the server without a validation error.

- **Bug Fixes**
  - Set `TaskRelatedNode.kind` to `str | None = None` in `infrahub_sdk/task/models.py`.
  - Added `test_from_graphql_related_node_without_kind` to cover null `kind` values.

<sup>Written for commit 1cb2a6d633053f6cf79165af6b19db595e9d8e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

