### PR TITLE
refactor(sdk): type group members access via _get_relationship_many

### DIFF
--- a/changelog/+query-groups-typed-members-accessor.housekeeping.md
+++ b/changelog/+query-groups-typed-members-accessor.housekeeping.md
@@ -1,0 +1,1 @@
+Routed the two remaining `existing_group.members.peer_ids` accesses in `infrahub_sdk/query_groups.py` through the typed `_get_relationship_many(name="members")` accessor, removing the last two `# type: ignore[union-attr]` suppressions in that module. Internal typing hygiene with no behavioural change.

--- a/infrahub_sdk/query_groups.py
+++ b/infrahub_sdk/query_groups.py
@@ -175,7 +175,9 @@ class InfrahubGroupContext(InfrahubGroupContextBase):
             return
 
         # Calculate how many nodes should be deleted
-        self.unused_member_ids = list(set(existing_group.members.peer_ids) - set(members))  # type: ignore[union-attr]
+        self.unused_member_ids = list(
+            set(existing_group._get_relationship_many(name="members").peer_ids) - set(members)
+        )
 
         if not self.delete_unused_nodes:
             return
@@ -267,7 +269,9 @@ class InfrahubGroupContextSync(InfrahubGroupContextBase):
             return
 
         # Calculate how many nodes should be deleted
-        self.unused_member_ids = list(set(existing_group.members.peer_ids) - set(members))  # type: ignore[union-attr]
+        self.unused_member_ids = list(
+            set(existing_group._get_relationship_many(name="members").peer_ids) - set(members)
+        )
 
         if not self.delete_unused_nodes:
             return


### PR DESCRIPTION
# Why

`infrahub_sdk/query_groups.py` had two `existing_group.members.peer_ids` accesses, each silenced with `# type: ignore[union-attr]` because `.members` is typed as a union that includes `None`.

PR #412 introduced `_get_relationship_many(name="members")` *specifically* to type this access, and applied it at the two `.peers` call sites (L108 / L206) — but the two `.peer_ids` sites (L178 / L270) were left behind with their suppressions. This finishes that migration.

Non-goals: no change to grouping behaviour, no public API change, no new accessor added (none was needed — see below).

Jira: [INBOX-28](https://opsmill.atlassian.net/browse/INBOX-28)
Source: https://github.com/opsmill/infrahub-sdk-python/pull/412#discussion_r2095499806

## What changed

**Behavioral changes:** none. This is a like-for-like typing substitution.

- Routed both `existing_group.members.peer_ids` sites through `existing_group._get_relationship_many(name="members").peer_ids`.
- Deleted both `# type: ignore[union-attr]` suppressions — the last two in this module.

**Implementation note:** the card left open whether a `peer_ids` helper would need adding. It does not — `peer_ids` is defined on `RelationshipManagerBase` (`infrahub_sdk/node/relationship.py:61`), so it resolves for both the async `RelationshipManager` and the sync `RelationshipManagerSync` that `_get_relationship_many` returns. Both the async (`InfrahubGroupContext`) and sync (`InfrahubGroupContextSync`) twins get the identical treatment, so the twins stay in sync.

**What stayed the same:** no schema changes, no API contract changes, no dependency changes, no CI changes, no generated files. The diff is 2 files: one source file and one changelog fragment.

## How to review

The whole change is 6 lines in one file. The only thing worth checking is that `peer_ids` is genuinely available on the base class (linked above) so the async and sync paths are both really typed rather than newly ignored.

## How to test

```bash
# The card's stated verifier — project-wide, as CI runs it:
uv run mypy --show-error-codes infrahub_sdk/

# Lint:
uv run ruff check . && uv run ruff format --check .

# Tests covering the changed module:
uv run pytest tests/unit/sdk/test_group_context.py
```

Results on this branch:

| Check | Result |
|---|---|
| `mypy --show-error-codes infrahub_sdk/` | **Success: no issues found in 152 source files** |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 332 files already formatted |
| `pytest tests/unit/sdk/test_group_context.py` | **11 passed** |
| `pytest tests/unit/sdk/` | 1064 passed, 3 failed |

The 3 failures are in `tests/unit/sdk/test_schema.py` (`test_display_schema_load_errors_details_*`) and are **pre-existing and unrelated** — they assert on plain strings while Rich emits ANSI colour codes in this environment. Verified by stashing this change and re-running on the clean base commit: the same 3 fail identically there.

`ty check .` reports 48 `unresolved-import` diagnostics in this environment only, because the `tests` dependency group could not be installed locally (`ruamel-yaml-clib` has no cp314 wheel and needs `Python.h`, which isn't present on this machine). None of them are in `query_groups.py`. CI installs the full group, so this is a local environment artifact.

## Impact & rollout

- **Backward compatibility:** no breaking changes — internal typing only.
- **Performance:** no measurable change; the accessor is a dict lookup on already-fetched relationship data.
- **Config/env changes:** none.
- **Deployment notes:** safe to deploy.

## Checklist

- [ ] Tests added/updated — not applicable; this is a typing-only change with no new behaviour to cover, and `mypy` is the verifier. Existing `test_group_context.py` coverage exercises both changed code paths.
- [x] Changelog entry added (`changelog/+query-groups-typed-members-accessor.housekeeping.md`)
- [x] External docs updated (if user-facing or ops-facing change) — n/a, not user-facing
- [x] Internal .md docs updated — n/a, no convention change

🤖 Generated with Claude Code


[INBOX-28]: https://opsmill.atlassian.net/browse/INBOX-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the typed `existing_group._get_relationship_many(name="members").peer_ids` in `infrahub_sdk/query_groups.py` to replace the last `existing_group.members.peer_ids` usages, removing two `# type: ignore[union-attr]` suppressions. No behavior change; fulfills INBOX-28.

<sup>Written for commit d36aa57e2fca09b8d3e1062a52ddb161f93ac601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

