### PR TITLE
fix: correct 'infrahub_integraton' to 'infrahub_integration' typo

### DIFF
--- a/infrahub_sdk/pytest_plugin/plugin.py
+++ b/infrahub_sdk/pytest_plugin/plugin.py
@@ -100,7 +100,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "infrahub_unit: Unit test for an Infrahub resource, works without dependencies")
     config.addinivalue_line(
         "markers",
-        "infrahub_integraton: Integation test for an Infrahub resource, depends on an Infrahub running instance",
+        "infrahub_integration: Integration test for an Infrahub resource, depends on an Infrahub running instance",
     )
     config.addinivalue_line("markers", "infrahub_check: Test related to an Infrahub Check")
     config.addinivalue_line("markers", "infrahub_graphql_query: Test related to an Infrahub GraphQL query")


### PR DESCRIPTION
## Summary
Fixes issue #1231 - corrects two misspellings in pytest plugin marker registration:
- `infrahub_integraton` → `infrahub_integration`
- `Integation` → `Integration`

## Changes
- `infrahub_sdk/pytest_plugin/plugin.py` line 103: corrected marker name and description

## Testing
`python3 -m py_compile infrahub_sdk/pytest_plugin/plugin.py` passes ✅

---
*Fix submitted via automated PR攻关 workflow*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pytest marker registration by renaming `infrahub_integraton` to `infrahub_integration` and correcting the description to “Integration”. This ensures the integration test marker is consistent and works as expected.

<sup>Written for commit 349b1411e44f6e574023e3e96bfc2509b9e993fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

