### PR TITLE
fix: register the infrahub_integration pytest marker under its real name

### DIFF
--- a/changelog/1231.fixed.md
+++ b/changelog/1231.fixed.md
@@ -1,0 +1,1 @@
+Register the `infrahub_integration` pytest marker under its real name. It was registered as `infrahub_integraton`, so integration tests raised a `PytestUnknownMarkWarning` on every run and failed to collect under `--strict-markers`.

--- a/infrahub_sdk/pytest_plugin/plugin.py
+++ b/infrahub_sdk/pytest_plugin/plugin.py
@@ -100,7 +100,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "infrahub_unit: Unit test for an Infrahub resource, works without dependencies")
     config.addinivalue_line(
         "markers",
-        "infrahub_integraton: Integation test for an Infrahub resource, depends on an Infrahub running instance",
+        "infrahub_integration: Integration test for an Infrahub resource, depends on an Infrahub running instance",
     )
     config.addinivalue_line("markers", "infrahub_check: Test related to an Infrahub Check")
     config.addinivalue_line("markers", "infrahub_graphql_query: Test related to an Infrahub GraphQL query")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
     "ignore:Deprecated call to",
 ]
-addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope"
+addopts = "-vs --strict-markers --cov-report term-missing --cov-report xml --dist loadscope"
 
 [tool.ty]
 

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -1,5 +1,7 @@
 import pytest
 
+from infrahub_sdk.pytest_plugin.loader import MARKER_MAPPING
+
 
 def test_help_message(pytester: pytest.Pytester) -> None:
     """Make sure that the plugin is loaded by capturing an option it adds in the help message."""
@@ -28,8 +30,26 @@ def test_emptyconfig(pytester: pytest.Pytester) -> None:
     result.assert_outcomes()
 
 
-def test_markers_are_registered(pytester: pytest.Pytester) -> None:
-    """Every marker the plugin applies must be registered, otherwise --strict-markers rejects it."""
+def test_resource_markers_are_registered(pytester: pytest.Pytester) -> None:
+    """The resource markers are built when the loader is imported, before a config exists.
+
+    `--strict-markers` only validates a marker created once a config is attached, so it never sees
+    these. Compare them against the registered list instead.
+    """
+    result = pytester.runpytest("--markers")
+
+    registered = {
+        line.removeprefix("@pytest.mark.").split(":")[0].split("(")[0]
+        for line in result.stdout.lines
+        if line.startswith("@pytest.mark.")
+    }
+    missing = {mark.markname for mark in MARKER_MAPPING.values()} - registered
+
+    assert not missing, f"markers applied by the loader but never registered: {sorted(missing)}"
+
+
+def test_type_markers_are_registered(pytester: pytest.Pytester) -> None:
+    """The type markers are applied during collection, so --strict-markers rejects an unregistered one."""
     pytester.makefile(
         ".yml",
         test_markers="""

--- a/tests/unit/pytest_plugin/test_plugin.py
+++ b/tests/unit/pytest_plugin/test_plugin.py
@@ -28,6 +28,54 @@ def test_emptyconfig(pytester: pytest.Pytester) -> None:
     result.assert_outcomes()
 
 
+def test_markers_are_registered(pytester: pytest.Pytester) -> None:
+    """Every marker the plugin applies must be registered, otherwise --strict-markers rejects it."""
+    pytester.makefile(
+        ".yml",
+        test_markers="""
+        ---
+        version: "1.0"
+        infrahub_tests:
+          - resource: "Jinja2Transform"
+            resource_name: "bgp_config"
+            tests:
+              - name: "smoke"
+                spec:
+                  kind: "jinja2-transform-smoke"
+              - name: "unit"
+                spec:
+                  kind: "jinja2-transform-unit-render"
+              - name: "integration"
+                spec:
+                  kind: "jinja2-transform-integration"
+                  variables: {}
+    """,
+    )
+    pytester.makefile(
+        ".yml",
+        infrahub_config="""
+        ---
+        jinja2_transforms:
+          - name: bgp_config
+            description: "Template for BGP config base"
+            query: "bgp_sessions"
+            template_path: "templates/bgp_config.j2"
+    """,
+    )
+    pytester.makefile(".json", input="{}")
+
+    result = pytester.runpytest("--infrahub-repo-config=infrahub_config.yml", "--strict-markers", "--collect-only")
+
+    assert result.ret == pytest.ExitCode.OK
+    result.stdout.fnmatch_lines(
+        [
+            "*infrahub_jinja2_transform__bgp_config__smoke*",
+            "*infrahub_jinja2_transform__bgp_config__unit*",
+            "*infrahub_jinja2_transform__bgp_config__integration*",
+        ]
+    )
+
+
 def test_jinja2_transform_config_missing_directory(pytester: pytest.Pytester) -> None:
     """Make sure tests raise errors if directories are not found."""
     pytester.makefile(


### PR DESCRIPTION
Fixes #1231

The pytest plugin registered `infrahub_integraton`, with a missing `i`, but the loader applies `infrahub_integration`. So the marker we really use was never registered, and the one we registered was never used. The description had the same kind of typo, `Integation`.

Two things this fixes for users:

- Integration tests no longer raise `PytestUnknownMarkWarning` on a normal run. A user running with `filterwarnings = error` was turning that warning into a failure.
- Collection no longer fails under `--strict-markers` with `'infrahub_integration' not found in markers configuration option`.

`pytest --markers` also stops listing a marker that nothing applies.

## Guard against a repeat

I turned on `--strict-markers` for our own test run. An unregistered marker now fails the build instead of passing with a warning nobody reads. I checked it is safe, the full suite still collects with no marker error.

The new test collects a smoke, a unit and an integration item with `--strict-markers` on. It fails on the old code with the exact error above.

## Test

- `tests/unit/pytest_plugin/`: 9 passed
- `tests/unit/`: 4 failures, all present on `stable` without this change (`test_repo_list`, `test_repo_init`, `test_task_list_command`, `test_gitrepo_init`)
- `invoke format lint-code`: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register the `infrahub_integration` `pytest` marker under its correct name to stop UnknownMark warnings and strict collection failures. Also enable `--strict-markers` and add tests to prevent regressions, including resource marker coverage.

- **Bug Fixes**
  - Register `infrahub_integration` correctly and fix the marker description typo.
  - Eliminate `PytestUnknownMarkWarning` and failures under `--strict-markers`; `pytest --markers` no longer lists an unused marker.

- **Refactors**
  - Enable `--strict-markers` in test configuration to catch unregistered markers early.
  - Add tests: verify smoke/unit/integration items collect with `--strict-markers`, and check all resource markers from `MARKER_MAPPING` are registered via `pytest --markers`.

<sup>Written for commit ec8ae227c6ee44178ae5052b4a1e99a5b587f490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

