### PR TITLE
fix: return Self from Timestamp add/subtract instead of Timestamp

### DIFF
--- a/infrahub_sdk/timestamp.py
+++ b/infrahub_sdk/timestamp.py
@@ -5,7 +5,7 @@ import warnings
 from datetime import datetime, timezone
 from typing import Literal, TypedDict
 
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, Self
 from whenever import Date, Instant, OffsetDateTime, PlainDateTime, Time, ZonedDateTime
 
 from .exceptions import TimestampFormatError
@@ -147,7 +147,7 @@ class Timestamp:
     def __hash__(self) -> int:
         return hash(self.to_string())
 
-    def add_delta(self, hours: int = 0, minutes: int = 0, seconds: int = 0, microseconds: int = 0) -> Timestamp:
+    def add_delta(self, hours: int = 0, minutes: int = 0, seconds: int = 0, microseconds: int = 0) -> Self:
         warnings.warn(
             "add_delta() is deprecated. Use add() instead.",
             UserWarning,
@@ -168,7 +168,7 @@ class Timestamp:
         microseconds: float = 0,
         nanoseconds: int = 0,
         disambiguate: Literal["compatible"] = "compatible",
-    ) -> Timestamp:
+    ) -> Self:
         return self.__class__(
             self._obj.add(
                 years=years,
@@ -198,7 +198,7 @@ class Timestamp:
         microseconds: float = 0,
         nanoseconds: int = 0,
         disambiguate: Literal["compatible"] = "compatible",
-    ) -> Timestamp:
+    ) -> Self:
         return self.__class__(
             self._obj.subtract(
                 years=years,


### PR DESCRIPTION
## Problem

`Timestamp.add()`, `Timestamp.subtract()` and `Timestamp.add_delta()` all build their result with `self.__class__(...)`, so at runtime a subclass gets an instance of *itself* back. The annotations claimed `Timestamp`.

Any subclass — Infrahub's own `Timestamp` among them — therefore loses its type as soon as it does arithmetic, and callers have to cast or `# type: ignore` before touching anything the subclass adds.

## Change

Annotate the three methods as returning `Self`, which is what they already do.

`Self` is imported from `typing_extensions`, not `typing`: `typing.Self` is 3.11+ and this package supports 3.10 (`requires-python = ">=3.10"`). The module already imports `NotRequired` from `typing_extensions`.

Annotations only — no runtime behaviour changes.

## Verification

- `uv run invoke format lint-code` — clean (ruff + mypy pass; the pre-existing `ty` unresolved-import diagnostics in unrelated test modules are an incomplete local venv, not this change)
- Confirmed at runtime that a subclass gets its own type back from all three methods

Skipping a changelog fragment — annotation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates Timestamp.add(), Timestamp.subtract(), and Timestamp.add_delta() to return Self instead of Timestamp, preserving subclass types. Runtime behavior is unchanged; these methods already return self.__class__.

- Imports `Self` from `typing_extensions` to support Python 3.10.
- Improves type checking for subclasses; remove any casts or type: ignore related to these returns.
- Scope: changes limited to infrahub_sdk/timestamp.py.
- No runtime or public API behavior change; no rollout steps required.

<sup>Written for commit ae7b4d3e4e3dc5878c7fcad250d839b048aaeb3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

