### PR TITLE
prep release 1.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [1.22.3](https://github.com/opsmill/infrahub-sdk-python/tree/v1.22.3) - 2026-08-19
+
+### Fixed
+
+- Register the `infrahub_integration` pytest marker under its real name. It was registered as `infrahub_integraton`, so integration tests raised a `PytestUnknownMarkWarning` on every run and failed to collect under `--strict-markers`. ([#1231](https://github.com/opsmill/infrahub-sdk-python/issues/1231))
+- Fixed the `load` and `check` command descriptions in the `infrahubctl schema` help output and generated docs, which were cut off mid-sentence.
+
 ## [1.22.2](https://github.com/opsmill/infrahub-sdk-python/tree/v1.22.2) - 2026-07-27
 
 ### Added

--- a/changelog/+schema-cli-short-help.fixed.md
+++ b/changelog/+schema-cli-short-help.fixed.md
@@ -1,1 +1,0 @@
-Fixed the `load` and `check` command descriptions in the `infrahubctl schema` help output and generated docs, which were cut off mid-sentence.

--- a/changelog/1231.fixed.md
+++ b/changelog/1231.fixed.md
@@ -1,1 +1,0 @@
-Register the `infrahub_integration` pytest marker under its real name. It was registered as `infrahub_integraton`, so integration tests raised a `PytestUnknownMarkWarning` on every run and failed to collect under `--strict-markers`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-sdk"
-version = "1.22.2"
+version = "1.22.3"
 description = "Python Client to interact with Infrahub"
 authors = [
     {name = "OpsMill", email = "info@opsmill.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -676,7 +676,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-sdk"
-version = "1.22.2"
+version = "1.22.3"
 source = { editable = "." }
 dependencies = [
     { name = "dulwich" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepares `infrahub-sdk` 1.22.3. Fixes a mis-registered pytest marker that caused warnings and strict collection failures, and corrects truncated `infrahubctl schema` help text. Old marker: `infrahub_integraton`; new marker: `infrahub_integration`. This removes PytestUnknownMarkWarning and failures under `--strict-markers`.

- Update `pyproject.toml` and `uv.lock` to 1.22.3; update `CHANGELOG.md` and remove consumed towncrier fragments.
- No runtime code changes. No migration or config changes required.

<sup>Written for commit dbf698667eb81af41b8b32ec4c3a58da349640c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

