### PR TITLE
chore: narrow over-broad mypy and ty error suppressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ invalid-assignment = "ignore" # 1 violation in importer/json.py
 include = ["infrahub_sdk/node/node.py"]
 
 [tool.ty.overrides.rules]
-invalid-argument-type = "ignore" # 9 violations - lines 776, 855, 859, 862
+invalid-argument-type = "ignore" # 8 violations
 
 
 [[tool.ty.overrides]]
@@ -183,7 +183,6 @@ unused-ignore-comment = "ignore" # Clashes with mypy's type ignore comments
 include = ["tests/fixtures/**"]
 
 [tool.ty.overrides.rules]
-invalid-argument-type = "ignore" # Test fixtures - dynamic mock data
 possibly-missing-attribute = "ignore" # Test fixtures use dynamic attributes
 
 # Test-specific overrides - tests have more lenient type checking
@@ -231,9 +230,8 @@ include = [
 ]
 
 [tool.ty.overrides.rules]
-invalid-argument-type = "ignore" # 29 violations
+invalid-argument-type = "ignore" # 25 violations
 invalid-assignment = "ignore"
-no-matching-overload = "ignore"
 possibly-missing-attribute = "ignore"
 
 [[tool.ty.overrides]]
@@ -276,7 +274,7 @@ disable_error_code = ["call-overload"]
 
 [[tool.mypy.overrides]]
 module = "infrahub_sdk.utils"
-disable_error_code = ["arg-type", "attr-defined", "return-value", "union-attr"]
+disable_error_code = ["attr-defined", "return-value", "union-attr"]
 
 [[tool.mypy.overrides]]
 # ``main.py`` intentionally narrows the ``attributes``/``relationships``/``choices`` fields inherited
@@ -290,7 +288,7 @@ disable_error_code = ["assignment"]
 # The generated read models expose ``kind`` via ``@computed_field`` stacked on ``@property``. mypy
 # does not support decorators on top of ``@property`` and flags it, but pydantic requires this order.
 module = "infrahub_sdk.schema.generated.read"
-disable_error_code = ["misc"]
+disable_error_code = ["prop-decorator"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
# Why

mypy's `misc` code was disabled for the whole `infrahub_sdk.schema.generated.read` module in order to silence a single decorated-property error. `misc` is a catch-all, so that override also hid unrelated real problems (bad overrides, unsupported dynamic base classes, duplicate definitions) in a module that gets regenerated over time.

Goal: every type-checker suppression names the narrowest code that actually fires.

Non-goals: this does not attempt to *fix* any underlying violation, and it leaves the module-wide mypy overrides on `infrahub_sdk.utils` and `infrahub_sdk.ctl.check` in place (see How to review).

## What changed

No behavioral change: config only, no runtime code touched.

- `schema.generated.read`: `misc` -> `prop-decorator`. mypy split the decorated-property diagnostic into its own code in 1.11, the version pinned here, so the broad code was never needed.
- Removed three suppressions that match zero violations: mypy `arg-type` on `infrahub_sdk.utils`, ty `invalid-argument-type` on `tests/fixtures/**`, and ty `no-matching-overload` on the `spec/test_object.py` group.
- Corrected two stale counts in ty comments (`node/node.py` 9 -> 8, and one group 29 -> 25). Dropped the line numbers on `node/node.py`, since all four had rotted: it recorded 776/855/859/862 against actual lines 1024/1294/1298/1301/2259/2525/2527/2529.

Confirmed unchanged: `prop-decorator` is the only diagnostic the generated read module produces, so the narrower code loses no coverage. Upgrading mypy would not remove the need for the suppression either, as the error reproduces on 1.11.2, 1.13.0, 1.15.0, 1.18.2, 2.0.0 and 2.3.1.

## How to review

Each suppression was audited by removing it and re-running the checker, which is the only way these surface, since a config-level ignore is otherwise invisible. One gotcha worth knowing for future audits: `ty check --error <RULE>` does **not** override per-file `overrides.rules`. It reports "All checks passed" while hiding all 1026 latent diagnostics, so the audit needed a temporary `pyproject.toml` edit instead.

Two module-wide mypy overrides are deliberately left alone, because narrowing them means touching source rather than config:

- `infrahub_sdk.ctl.check` disables `call-overload` module-wide for exactly one error, at `infrahub_sdk/ctl/check.py:159`.
- `infrahub_sdk.utils` disables three codes module-wide, but all seven errors sit in `extract_fields` at `infrahub_sdk/utils.py:297-308`.

## How to test

```bash
uv run invoke lint-code
```

All three checkers pass: ruff, ty, and mypy (158 source files).

## Impact & rollout

- **Backward compatibility:** no runtime change; suppression scope only.
- **Config/env changes:** `pyproject.toml` type-checker config only.
- **Deployment notes:** safe to merge.

## Checklist

- [ ] Tests added/updated: n/a, no runtime code changed
- [ ] Changelog entry: n/a, internal tooling config (labelled `ci/skip-changelog`)
- [ ] External docs updated: n/a, not user-facing
- [ ] Internal .md docs updated: n/a, no docs reference these settings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens type-checker suppressions so they only target the diagnostics that actually fire, preventing unrelated errors from being hidden. Previously `mypy` disabled `misc` for the entire generated read module; now it only disables `prop-decorator`. No runtime changes.

- Switch `infrahub_sdk.schema.generated.read`: `mypy` `misc` -> `prop-decorator` (supported since `mypy` 1.11); confirmed no other diagnostics are suppressed there.
- Remove dead suppressions: `mypy` `arg-type` on `infrahub_sdk.utils`, `ty` `invalid-argument-type` for `tests/fixtures/**`, and `ty` `no-matching-overload` in the `spec/test_object.py` group.
- Correct stale `ty` counts: `node/node.py` invalid-argument-type 9 -> 8; spec group 29 -> 25. Drop rotted line numbers for `node/node.py`.
- Leave two module-wide overrides unchanged: `infrahub_sdk.ctl.check` (`mypy` `call-overload`) and `infrahub_sdk.utils` (multiple `mypy` codes) to avoid source changes.
- Validation: all linters pass (`ruff`, `ty`, `mypy`); run with uv run invoke lint-code.

<sup>Written for commit 3518107f59dc234794601b7d42105f35e91888f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

