### PR TITLE
chore(schema): add commit to the CoreGenericRepository protocol [IFC-2954]

### DIFF
--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -130,6 +130,7 @@ class CoreGenericRepository(CoreNode):
     location: String
     internal_status: Dropdown
     operational_status: Dropdown
+    commit: StringOptional
     sync_status: Dropdown
     credential: RelatedNode
     tags: RelationshipManager
@@ -735,6 +736,7 @@ class CoreGenericRepositorySync(CoreNodeSync):
     location: String
     internal_status: Dropdown
     operational_status: Dropdown
+    commit: StringOptional
     sync_status: Dropdown
     credential: RelatedNodeSync
     tags: RelationshipManagerSync


### PR DESCRIPTION
## What

Regenerated `infrahub_sdk/protocols.py` so `CoreGenericRepository` (and its `Sync` counterpart) declares `commit: StringOptional`.

This goes hand in hand with https://github.com/opsmill/infrahub/pull/10387, but I'd want to merge this PR first.

## Why

The Infrahub core schema now defines `commit` on the `CoreGenericRepository` generic, in addition to the two concrete repository kinds that already declared it. `protocols.py` is generated from those definitions by `invoke backend.generate` in the Infrahub repository, so this file has to move with them.

Both concrete kinds continue to override the attribute with their own branch scope (`local` for `CoreRepository`, `aware` for `CoreReadOnlyRepository`), so no runtime behaviour changes for either.

## Notes

- Generated output only, no hand-written changes. Following the precedent of b76594a, there is no changelog fragment for a protocols regeneration.
- This PR is a prerequisite for the matching Infrahub PR: `invoke backend.validate-generated` there runs `git -C python_sdk diff --exit-code infrahub_sdk/protocols.py`, which stays red until the submodule pointer includes this commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare commit on the `CoreGenericRepository` and `CoreGenericRepositorySync` protocols to align the SDK with the updated core schema and allow generic-typed repositories to expose commit. Previously the generic lacked this attribute; now it is `StringOptional`. Concrete kinds still override it, so runtime behavior does not change.

- Generated change in `infrahub_sdk/protocols.py` only; no hand-written logic or changelog.
- Unblocks core validation that diffs the SDK protocols; required for IFC-2954.
- Enables removing type suppressions where commit was accessed on a generic-typed repository.

<sup>Written for commit 2c58b4b504bdcd72b884eb5a659ad0c173077119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

