### PR TITLE
fix: stop client.branch.validate() requesting removed BranchValidate.messages field

### DIFF
--- a/changelog/1263.fixed.md
+++ b/changelog/1263.fixed.md
@@ -1,0 +1,1 @@
+Fixed `client.branch.validate()` and `infrahubctl branch validate`, which raised a `GraphQLError` against every supported Infrahub server because the mutation requested a `messages` field that was removed from `BranchValidate` in Infrahub 1.1.0.

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -133,14 +133,7 @@ class InfrahubBranchManager:
             }
         }
 
-        query_data = {
-            "ok": None,
-            "messages": None,
-            "object": {
-                "id": None,
-                "name": None,
-            },
-        }
+        query_data = {"ok": None}
 
         query = Mutation(mutation="BranchValidate", input_data=input_data, query=query_data)
         response = await self.client.execute_graphql(query=query.render(), tracker="mutation-branch-validate")
@@ -288,14 +281,7 @@ class InfrahubBranchManagerSync:
             }
         }
 
-        query_data = {
-            "ok": None,
-            "messages": None,
-            "object": {
-                "id": None,
-                "name": None,
-            },
-        }
+        query_data = {"ok": None}
 
         query = Mutation(mutation="BranchValidate", input_data=input_data, query=query_data)
         response = self.client.execute_graphql(query=query.render(), tracker="mutation-branch-validate")

--- a/tests/integration/test_infrahub_client.py
+++ b/tests/integration/test_infrahub_client.py
@@ -63,6 +63,9 @@ class TestInfrahubNode(TestInfrahubDockerClient, SchemaAnimal):
         assert async_branch in pre_delete
         assert async_branch not in post_delete
 
+    async def test_branch_validate(self, client: InfrahubClient, base_dataset: None) -> None:
+        assert await client.branch.validate(branch_name="branch01") is True
+
     async def test_get_all(self, client: InfrahubClient, base_dataset: None) -> None:
         nodes = await client.all(kind=TESTING_CAT)
         assert len(nodes) == 2

--- a/tests/integration/test_infrahub_client_sync.py
+++ b/tests/integration/test_infrahub_client_sync.py
@@ -60,7 +60,7 @@ class TestInfrahubClientSync(TestInfrahubDockerClient, SchemaAnimal):
         assert sync_branch not in post_delete
 
     def test_branch_validate(self, client_sync: InfrahubClientSync, base_dataset: None) -> None:
-        assert client_sync.branch.validate(branch_name="branch01") is True
+        assert client_sync.branch.validate(branch_name="sync-branch01") is True
 
     def test_get_all(self, client_sync: InfrahubClientSync, base_dataset: None) -> None:
         nodes = client_sync.all(kind=TESTING_CAT)

--- a/tests/integration/test_infrahub_client_sync.py
+++ b/tests/integration/test_infrahub_client_sync.py
@@ -59,6 +59,9 @@ class TestInfrahubClientSync(TestInfrahubDockerClient, SchemaAnimal):
         assert sync_branch in pre_delete
         assert sync_branch not in post_delete
 
+    def test_branch_validate(self, client_sync: InfrahubClientSync, base_dataset: None) -> None:
+        assert client_sync.branch.validate(branch_name="branch01") is True
+
     def test_get_all(self, client_sync: InfrahubClientSync, base_dataset: None) -> None:
         nodes = client_sync.all(kind=TESTING_CAT)
         assert len(nodes) == 2

--- a/tests/unit/sdk/test_branch.py
+++ b/tests/unit/sdk/test_branch.py
@@ -50,6 +50,33 @@ async def test_get_branches(clients: BothClients, mock_branches_list_query: HTTP
 
 
 @pytest.mark.parametrize("client_type", client_types)
+async def test_branch_validate_query_excludes_removed_fields(
+    httpx_mock: HTTPXMock, clients: BothClients, client_type: str
+) -> None:
+    """validate() must only request fields the BranchValidate mutation still exposes.
+
+    The server removed the `messages` field from BranchValidate, so the rendered
+    mutation must not request it, otherwise the server rejects the whole query.
+    """
+    httpx_mock.add_response(
+        method="POST",
+        json={"data": {"BranchValidate": {"ok": True}}},
+        match_headers={"X-Infrahub-Tracker": "mutation-branch-validate"},
+    )
+
+    if client_type == "standard":
+        result = await clients.standard.branch.validate(branch_name="branch01")
+    else:
+        result = clients.sync.branch.validate(branch_name="branch01")
+
+    assert result is True
+
+    post_requests = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert len(post_requests) == 1
+    assert b"messages" not in post_requests[0].content
+
+
+@pytest.mark.parametrize("client_type", client_types)
 async def test_branch_merge_enforces_minimum_timeout(
     httpx_mock: HTTPXMock, clients: BothClients, client_type: str
 ) -> None:


### PR DESCRIPTION
# Why

`client.branch.validate()` and `infrahubctl branch validate` have been broken
against every supported Infrahub server since Infrahub 1.1.0 (2024-12-30). Both
`validate()` variants request a `messages` field in the `BranchValidate`
mutation, but that field was removed from the server's `BranchValidate` type in
1.1.0, so every call fails with:

    GraphQLError: Cannot query field 'messages' on type 'BranchValidate'

It went unnoticed for ~20 months because no unit or integration test exercised
`branch.validate()`.

Closes #1263

## What changed

- `client.branch.validate()` (async and sync) now succeeds against current
  Infrahub servers.
- The mutation requests only `ok`, the single field the method actually returns.
  The stale `messages` field and the unused `object { id name }` selection are
  dropped from both variants.

No API surface change: signatures and the `bool` return value are unchanged.

Deliberately out of scope (noted in #1263): the `-> BranchData` return
annotation on `validate()`/`rebase()` is wrong (both return `bool`), and the
CLI help text still reads "(NOT IMPLEMENTED YET)". Left for a separate issue.

## How to review

- `infrahub_sdk/branch.py` - the two `query_data` blocks reduced to `{"ok": None}`.
- `tests/unit/sdk/test_branch.py` - regression test asserts the rendered mutation
  body no longer contains `messages` (a mock returning `{"ok": true}` alone would
  pass even with the broken query, so it inspects the outgoing request).
- `tests/integration/test_infrahub_client*.py` - one `test_branch_validate`
  method added to each existing branch test class, reusing the shared
  `base_dataset` fixture (no new container setup).

## How to test

```bash
uv run pytest tests/unit/sdk/test_branch.py
# integration (needs docker/testcontainers):
uv run pytest tests/integration/test_infrahub_client.py -k test_branch_validate
```

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/1263.fixed.md`)
- [ ] External docs updated (no user-facing doc change; behaviour restored)
- [x] Internal .md docs updated (n/a)
