### PR TITLE
ci: gate integration tests on unit-test success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.python == 'true'
-    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
+    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "unit-tests"]
     runs-on:
       group: "huge-runners"
     timeout-minutes: 40
@@ -355,7 +355,7 @@ jobs:
   #     !contains(needs.*.result, 'cancelled') &&
   #     needs.files-changed.outputs.python == 'true' &&
   #     (github.base_ref == 'stable' || github.base_ref == 'develop')
-  #   needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
+  #   needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "unit-tests"]
   #   runs-on:
   #     group: "huge-runners"
   #   timeout-minutes: 30


### PR DESCRIPTION
## What

Gate the integration-test job on unit-test success so CI fails fast.

`integration-tests-latest-infrahub` (which runs on the `huge-runners` group with a 40-minute timeout) previously listed only:

```yaml
needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
```

Its guard `!contains(needs.*.result, 'failure')` therefore never inspected the `unit-tests` matrix, so the expensive integration job started in parallel with unit tests and kept running even when unit tests were red.

## Change

Add `unit-tests` to that `needs` list. The existing `!contains(needs.*.result, 'failure')` / `'cancelled')` guards then gate the integration job on unit-test success automatically - a matrix job aggregates to `failure` if any Python-version leg fails, so a single failing leg skips integration. The `always()` prefix keeps the guard evaluating when `unit-tests` is skipped (no Python changes), where the `python == 'true'` clause already skips integration.

The commented-out `integration-tests-local-infrahub` job's `needs` is updated to match so it stays correct if re-enabled.

## Tradeoff (deliberate and accepted)

This serializes what used to run in parallel: integration tests now start only after every unit-test matrix leg (Python 3.10-3.14) has finished, rather than concurrently with them.

- On green runs, total pipeline wall-clock increases by roughly the unit-test stage duration, since integration no longer overlaps it.
- On red runs, we save an entire huge-runner integration pass (up to the 40-minute timeout) that would previously have run - and often finished - alongside already-failing unit tests.

The added latency on passing runs is a known, accepted cost. The goal is to stop spending scarce `huge-runners` capacity on branches whose unit tests are already failing, where the integration result would not change the outcome.
