### PR TITLE
chore: gitignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ infrahub_sdk/_version.py
 # SpecKit internal cache
 .specify/**/.cache/
 .specify/feature.json
+
+# Claude Code per-developer local settings (shared config stays tracked)
+.claude/settings.local.json


### PR DESCRIPTION
## What

Ignore `.claude/settings.local.json` - Claude Code's per-developer local settings file (personal permission allowlists and local overrides).

## Why

- It's the "local, not shared" counterpart to `.claude/settings.json` and is meant to stay out of version control.
- The repo intentionally tracks the shared parts of `.claude/` (`commands`, `rules`, `skills`), so `.claude/` isn't blanket-ignored; this adds a surgical ignore for just the local settings file.
- Without it, the file shows up as untracked/modified in `git status` for every developer and risks being committed by accident.

Verified `.claude/settings.local.json` is not currently tracked, so the ignore rule alone is sufficient (no `git rm --cached` needed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores Claude Code's per-developer local settings file (`.claude/settings.local.json`) so it no longer appears in `git status` or risks being committed. Shared `.claude/` config stays tracked, and since the file isn't currently tracked, no `git rm --cached` is needed.

<sup>Written for commit dbb080dd13304b7db3ec2c81cd69faf0beb41a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

