### PR TITLE
ci: run every job when CI plumbing changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,13 +1,16 @@
 ---
+# A bad edit to a workflow or to this filter file can silently skip jobs, so
+# every filter below folds in *ci_config: any change to the CI plumbing runs the
+# full pipeline.
 ci_config: &ci_config
-  - ".github/workflows/ci.yml"
+  - ".github/workflows/**"
   - ".github/file-filters.yml"
 
 coverage_config: &coverage_config
   - "codecov.yml"
 
 github_workflows: &github_workflows
-  - ".github/workflows/*.yml"
+  - *ci_config
 
 development_files: &development_files
   - "development/**"
@@ -43,6 +46,8 @@ documentation_all:
   - *development_files
   - *doc_files
   - *markdown_all
+  - *ci_config
 
 documentation_generated_all:
   - *infrahub_reference_generated
+  - *ci_config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      (needs.files-changed.outputs.python == 'true') || (needs.files-changed.outputs.documentation_generated == 'true')
+      (needs.files-changed.outputs.python == 'true' || needs.files-changed.outputs.documentation_generated == 'true')
     needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint"]
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5


### PR DESCRIPTION
# Why

Path filtering in `files-changed` decides which jobs run. Today a change to the CI plumbing itself does not turn on every job, so a bad edit to a workflow can land green and then break the next unrelated PR - the job that would have caught it was skipped on the PR that introduced it.

Three concrete gaps, confirmed by simulating `dorny/paths-filter` with picomatch against the current filters:

| Changed file | Jobs that silently skipped |
| --- | --- |
| `.github/workflows/ci.yml` | `documentation` |
| `.github/file-filters.yml` | `markdown-lint`, `action-lint`, `uv-lock-check`, `documentation` |
| `.github/workflows/define-versions.yml` | `python-lint`, `unit-tests`, `integration-tests`, `validate-generated-documentation`, `documentation` |

The third is the worst of them: `define-versions.yml` pins the `UV_VERSION` that every Python job consumes, and a bad pin there was never exercised by unit or integration tests.

This is observable in history. [#1192](https://github.com/opsmill/infrahub-sdk-python/pull/1192), a `ci.yml`-only PR, shows `documentation` skipped in [run 29730072415](https://github.com/opsmill/infrahub-sdk-python/actions/runs/29730072415).

**Goal:** any change to the CI plumbing runs the full pipeline.

**Non-goals:** no change to job selectivity for ordinary code, docs, or dependency PRs. Scoped to workflows and the filter file, not all of `.github/**` - `dependabot.yml`, `labeler.yml`, `CODEOWNERS`, and issue templates do not affect whether a job runs correctly, and including them would mean a full pipeline on every label tweak.

## What changed

Behavioral changes:

- Any change under `.github/workflows/**` or to `.github/file-filters.yml` now runs every CI job, so a broken job definition fails on the PR that introduces it.
- Selectivity is otherwise untouched: python-only, docs-only, and generated-docs-only PRs run exactly the same job set as before.

Implementation notes:

- `.github/file-filters.yml`: widened `ci_config` to `.github/workflows/**` plus `.github/file-filters.yml`, pointed `github_workflows` at it, and folded it into `documentation_all` and `documentation_generated_all`. Every output that gates a job now includes `*ci_config`.
- `.github/workflows/ci.yml`: parenthesized the `validate-generated-documentation` condition. It read `... && A || B`, and `&&` binds tighter than `||`, so `documentation_generated == 'true'` alone satisfied the whole expression and bypassed the `always() && !cancelled() && !contains(needs.*.result, 'failure')` guards. Latent before this PR; the filter change makes that output true on every CI-config change, which would have started firing it.

What stayed the same: no job definitions, runners, timeouts, or `needs` edges changed. The only `ci.yml` edit is the parenthesization above.

## How to review

Two files, 8 insertions. The load-bearing question is whether the widened `ci_config` over-triggers - see the simulation table below for the answer.

Worth extra scrutiny: `github_workflows` is now an alias to `ci_config`, so `action-lint` also fires on `.github/file-filters.yml` changes. That is intentional (actionlint lints the whole workflow directory regardless of what changed) but it does widen that job's trigger.

## How to test

This PR is its own test case: it changes both `ci.yml` and `file-filters.yml`, so every job in the pipeline should run on it. Previously `documentation` would have been skipped.

Static checks:

```bash
uv run yamllint -s .
bash <(curl -sL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) && ./actionlint -color
```

Both pass. Filter behavior was verified by flattening the YAML anchors and matching sample changed-file sets with `picomatch` using `{dot: true}`, the same options `dorny/paths-filter` uses:

| Changed file | Skipped before | Skipped after |
| --- | --- | --- |
| `.github/workflows/ci.yml` | `documentation` | none |
| `.github/file-filters.yml` | `markdown-lint`, `action-lint`, `uv-lock-check`, `documentation` | none |
| `.github/workflows/define-versions.yml` | `python-lint`, `documentation`, `validate-generated-documentation`, `unit-tests`, `integration-tests` | none |
| `infrahub_sdk/client.py` | `yaml-lint`, `markdown-lint`, `action-lint`, `uv-lock-check`, `documentation` | unchanged |
| `docs/docs/guides/foo.mdx` | 7 jobs | unchanged |
| `docs/docs/infrahubctl/branch.mdx` | 6 jobs | unchanged |

## Impact & rollout

- **Backward compatibility:** no behavior change outside CI.
- **Performance:** CI-config PRs now also run the `documentation` job (roughly 5 minutes, `ubuntu-22.04`), and `define-versions.yml` PRs now run unit and integration tests. That is the point of the change: CI-config PRs are rare, and the alternative is discovering the breakage on someone else's PR.
- **Config/env changes:** none.
- **Deployment notes:** safe to merge.

## Checklist

- [x] Tests added/updated - N/A, CI configuration only. Filter behavior verified by simulation (table above).
- [x] Changelog entry added - N/A, no user-facing change (`ci/skip-changelog`).
- [x] External docs updated - N/A, no user-facing or ops-facing change.
- [x] Internal .md docs updated - N/A, `AGENTS.md` documents local commands, not CI path filtering.

## Follow-up, not in this PR

`ci.yml` exports `helm: ${{ steps.changes.outputs.helm_all }}`, but no `helm_all` filter exists and nothing consumes the output, so it is always empty. Harmless today, but it is the kind of line someone later gates a job on. Deliberately left out of scope.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes any change to the CI plumbing run the full pipeline. Previously, editing a workflow or the path-filter file could silently skip jobs — for example, a `define-versions.yml`-only change skipped unit and integration tests, letting a bad `UV_VERSION` pin land and break the next unrelated PR.

- Widened `ci_config` from `ci.yml` alone to all of `.github/workflows/**` plus `.github/file-filters.yml`, and folded it into every output that gates a job.
- Pointed `github_workflows` at `ci_config`, so `action-lint` also fires when the filter file changes.
- Parenthesized the `validate-generated-documentation` condition, which previously read `... && A || B` and let the docs check bypass the `always() && !cancelled() && !contains(...)` guards.

<sup>Written for commit f1552a89a81dc8e565f0dfa4524d44492559a22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

