### PR TITLE
fix: use configured default_branch in generators, transforms, checks

### DIFF
--- a/changelog/1290.fixed.md
+++ b/changelog/1290.fixed.md
@@ -1,0 +1,1 @@
+Fixed generators, transforms and checks run without an explicit branch, which targeted the local Git branch instead of the configured `default_branch` and failed with `BranchNotFoundError` when that Git branch did not exist in Infrahub. The local Git branch is now used only when `default_branch_from_git` is enabled.

--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING, Any
 import ujson
 from pydantic import BaseModel, Field
 
-from infrahub_sdk.repository import GitRepoManager
-
 from .exceptions import UninitializedError
+from .utils import get_branch
 
 if TYPE_CHECKING:
     from . import InfrahubClient
@@ -44,7 +43,6 @@ class InfrahubCheck:
         params: dict | None = None,
         client: InfrahubClient | None = None,
     ) -> None:
-        self.git: GitRepoManager | None = None
         self.initializer = initializer or InfrahubCheckInitializer()
 
         self.logs: list[dict[str, Any]] = []
@@ -132,14 +130,16 @@ class InfrahubCheck:
 
     @property
     def branch_name(self) -> str:
-        """Return the name of the current git branch."""
+        """Return the name of the Infrahub branch this check targets."""
         if self.branch:
             return self.branch
 
-        if not self.git:
-            self.git = GitRepoManager(self.root_directory)
+        if self._client:
+            # The client default already honours the `default_branch_from_git` config flag.
+            self.branch = self._client.default_branch
+        else:
+            self.branch = get_branch(directory=self.root_directory)
 
-        self.branch = str(self.git.active_branch)
         return self.branch
 
     @abstractmethod

--- a/infrahub_sdk/checks.py
+++ b/infrahub_sdk/checks.py
@@ -135,8 +135,8 @@ class InfrahubCheck:
             return self.branch
 
         if self._client:
-            # The client default already honours the `default_branch_from_git` config flag.
-            self.branch = self._client.default_branch
+            # The config resolver honours the `default_branch_from_git` flag.
+            self.branch = self._client.config.get_default_infrahub_branch(directory=self.root_directory)
         else:
             self.branch = get_branch(directory=self.root_directory)
 

--- a/infrahub_sdk/config.py
+++ b/infrahub_sdk/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ssl
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
 from pydantic import Field, PrivateAttr, field_validator, model_validator
@@ -221,13 +222,16 @@ class ConfigBase(BaseSettings):
             raise ValueError("'proxy' and 'proxy_mounts' are mutually exclusive")
         return self
 
-    @property
-    def default_infrahub_branch(self) -> str:
+    def get_default_infrahub_branch(self, directory: str | Path = ".") -> str:
         branch: str | None = None
         if not self.default_branch_from_git:
             branch = self.default_branch
 
-        return get_branch(branch=branch)
+        return get_branch(branch=branch, directory=directory)
+
+    @property
+    def default_infrahub_branch(self) -> str:
+        return self.get_default_infrahub_branch()
 
     @property
     def password_authentication(self) -> bool:

--- a/infrahub_sdk/operation.py
+++ b/infrahub_sdk/operation.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import pathlib
 from typing import TYPE_CHECKING
 
-from .repository import GitRepoManager
-
 if TYPE_CHECKING:
     from . import InfrahubClient
     from .node import InfrahubNode
@@ -20,26 +18,18 @@ class InfrahubOperation:
         branch: str,
         root_directory: str,
     ) -> None:
-        self.branch = branch
+        # The client default already honours the `default_branch_from_git` config flag.
+        self.branch = branch or client.default_branch
         self.convert_query_response = convert_query_response
         self.root_directory = root_directory or str(pathlib.Path.cwd())
         self.infrahub_node = infrahub_node
         self._nodes: list[InfrahubNode] = []
         self._related_nodes: list[InfrahubNode] = []
-        self._init_client = client.clone(branch=self.branch_name)
-        self.git: GitRepoManager | None = None
+        self._init_client = client.clone(branch=self.branch)
 
     @property
     def branch_name(self) -> str:
-        """Return the name of the current git branch."""
-        if self.branch:
-            return self.branch
-
-        if not hasattr(self, "git") or not self.git:
-            self.git = GitRepoManager(self.root_directory)
-
-        self.branch = str(self.git.active_branch)
-
+        """Return the name of the Infrahub branch this operation targets."""
         return self.branch
 
     @property

--- a/infrahub_sdk/operation.py
+++ b/infrahub_sdk/operation.py
@@ -18,10 +18,10 @@ class InfrahubOperation:
         branch: str,
         root_directory: str,
     ) -> None:
-        # The client default already honours the `default_branch_from_git` config flag.
-        self.branch = branch or client.default_branch
         self.convert_query_response = convert_query_response
         self.root_directory = root_directory or str(pathlib.Path.cwd())
+        # The config resolver honours the `default_branch_from_git` flag.
+        self.branch = branch or client.config.get_default_infrahub_branch(directory=self.root_directory)
         self.infrahub_node = infrahub_node
         self._nodes: list[InfrahubNode] = []
         self._related_nodes: list[InfrahubNode] = []

--- a/tests/unit/sdk/checks/test_checks.py
+++ b/tests/unit/sdk/checks/test_checks.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub_sdk import InfrahubClient
+from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.checks import InfrahubCheck
+from infrahub_sdk.utils import get_branch
 
 if TYPE_CHECKING:
     from pytest_httpx import HTTPXMock
@@ -72,3 +73,26 @@ async def test_validate_sync_async(mock_gql_query_my_query: HTTPXMock) -> None:
     await check.run()
 
     assert check.passed is False
+
+
+async def test_branch_name_falls_back_to_configured_default_branch() -> None:
+    """Without an explicit branch, the configured default branch wins over the local Git branch."""
+
+    class IFCheck(InfrahubCheck):
+        query = "my_query"
+
+        def validate(self, data: dict) -> None: ...
+
+    client = InfrahubClient(config=Config(address="http://mock", default_branch="test"))
+
+    assert IFCheck(client=client).branch_name == "test"
+    assert IFCheck(client=client, branch="explicit").branch_name == "explicit"
+
+
+async def test_branch_name_falls_back_to_git_branch_without_a_client() -> None:
+    class IFCheck(InfrahubCheck):
+        query = "my_query"
+
+        def validate(self, data: dict) -> None: ...
+
+    assert IFCheck().branch_name == get_branch()

--- a/tests/unit/sdk/checks/test_checks.py
+++ b/tests/unit/sdk/checks/test_checks.py
@@ -96,3 +96,24 @@ async def test_branch_name_falls_back_to_git_branch_without_a_client(monkeypatch
 
     monkeypatch.setattr("infrahub_sdk.checks.get_branch", lambda **_: "my-git-branch")
     assert IFCheck().branch_name == "my-git-branch"
+
+
+async def test_git_branch_is_read_from_the_root_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With `default_branch_from_git`, the Git branch comes from the check's own repository."""
+
+    class IFCheck(InfrahubCheck):
+        query = "my_query"
+
+        def validate(self, data: dict) -> None: ...
+
+    # The stub encodes the directory it was asked about, so the assertion pins which repository
+    # the branch was resolved from.
+    monkeypatch.setattr(
+        "infrahub_sdk.config.get_branch",
+        lambda branch=None, directory=".": branch or f"git:{directory}",
+    )
+    client = InfrahubClient(config=Config(address="http://mock", default_branch="test", default_branch_from_git=True))
+
+    check = IFCheck(client=client, root_directory="/some/repository")
+
+    assert check.branch_name == "git:/some/repository"

--- a/tests/unit/sdk/checks/test_checks.py
+++ b/tests/unit/sdk/checks/test_checks.py
@@ -7,7 +7,6 @@ import pytest
 
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.checks import InfrahubCheck
-from infrahub_sdk.utils import get_branch
 
 if TYPE_CHECKING:
     from pytest_httpx import HTTPXMock
@@ -89,10 +88,11 @@ async def test_branch_name_falls_back_to_configured_default_branch() -> None:
     assert IFCheck(client=client, branch="explicit").branch_name == "explicit"
 
 
-async def test_branch_name_falls_back_to_git_branch_without_a_client() -> None:
+async def test_branch_name_falls_back_to_git_branch_without_a_client(monkeypatch: pytest.MonkeyPatch) -> None:
     class IFCheck(InfrahubCheck):
         query = "my_query"
 
         def validate(self, data: dict) -> None: ...
 
-    assert IFCheck().branch_name == get_branch()
+    monkeypatch.setattr("infrahub_sdk.checks.get_branch", lambda **_: "my-git-branch")
+    assert IFCheck().branch_name == "my-git-branch"

--- a/tests/unit/sdk/test_operation.py
+++ b/tests/unit/sdk/test_operation.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import pathlib
+from typing import TYPE_CHECKING
+
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.transforms import InfrahubTransform
-from infrahub_sdk.utils import get_branch
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class DummyTransform(InfrahubTransform):
@@ -13,8 +18,21 @@ class DummyTransform(InfrahubTransform):
         return data
 
 
-def _build_transform(client: InfrahubClient, branch: str = "") -> DummyTransform:
-    return DummyTransform(client=client, infrahub_node=InfrahubNode, branch=branch)
+def _build_transform(client: InfrahubClient, branch: str = "", root_directory: str = "") -> DummyTransform:
+    return DummyTransform(client=client, infrahub_node=InfrahubNode, branch=branch, root_directory=root_directory)
+
+
+def _stub_git_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the Git lookup so tests never depend on the state of the local checkout.
+
+    The stub encodes the directory it was asked about, so callers can assert which repository
+    the branch was resolved from.
+    """
+
+    def fake_get_branch(branch: str | None = None, directory: str = ".") -> str:
+        return branch or f"git:{directory}"
+
+    monkeypatch.setattr("infrahub_sdk.config.get_branch", fake_get_branch)
 
 
 async def test_branch_name_uses_explicit_branch() -> None:
@@ -36,9 +54,19 @@ async def test_branch_name_falls_back_to_configured_default_branch() -> None:
     assert transform._init_client.default_branch == "test"
 
 
-async def test_branch_name_falls_back_to_git_branch_when_opted_in() -> None:
+async def test_branch_name_falls_back_to_git_branch_when_opted_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_git_branch(monkeypatch)
     client = InfrahubClient(config=Config(address="http://mock", default_branch="test", default_branch_from_git=True))
 
     transform = _build_transform(client=client)
 
-    assert transform.branch_name == get_branch()
+    assert transform.branch_name == f"git:{pathlib.Path.cwd()}"
+
+
+async def test_git_branch_is_read_from_the_root_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_git_branch(monkeypatch)
+    client = InfrahubClient(config=Config(address="http://mock", default_branch="test", default_branch_from_git=True))
+
+    transform = _build_transform(client=client, root_directory="/some/repository")
+
+    assert transform.branch_name == "git:/some/repository"

--- a/tests/unit/sdk/test_operation.py
+++ b/tests/unit/sdk/test_operation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.transforms import InfrahubTransform
+from infrahub_sdk.utils import get_branch
+
+
+class DummyTransform(InfrahubTransform):
+    query = "my_query"
+
+    def transform(self, data: dict) -> dict:
+        return data
+
+
+def _build_transform(client: InfrahubClient, branch: str = "") -> DummyTransform:
+    return DummyTransform(client=client, infrahub_node=InfrahubNode, branch=branch)
+
+
+async def test_branch_name_uses_explicit_branch() -> None:
+    client = InfrahubClient(config=Config(address="http://mock", default_branch="test"))
+
+    transform = _build_transform(client=client, branch="explicit")
+
+    assert transform.branch_name == "explicit"
+    assert transform._init_client.default_branch == "explicit"
+
+
+async def test_branch_name_falls_back_to_configured_default_branch() -> None:
+    """Without an explicit branch, the configured default branch wins over the local Git branch."""
+    client = InfrahubClient(config=Config(address="http://mock", default_branch="test"))
+
+    transform = _build_transform(client=client)
+
+    assert transform.branch_name == "test"
+    assert transform._init_client.default_branch == "test"
+
+
+async def test_branch_name_falls_back_to_git_branch_when_opted_in() -> None:
+    client = InfrahubClient(config=Config(address="http://mock", default_branch="test", default_branch_from_git=True))
+
+    transform = _build_transform(client=client)
+
+    assert transform.branch_name == get_branch()


### PR DESCRIPTION
# Why

Running `infrahubctl generator`, `transform` or `check` without `--branch` targeted the
local Git checkout's active branch instead of the configured `default_branch`, failing with
`BranchNotFoundError` whenever that Git branch did not exist in Infrahub. The fallback the
`default_branch_from_git` flag exists to gate was applied unconditionally, overriding an
explicitly configured `INFRAHUB_DEFAULT_BRANCH`.

Goal: with `default_branch_from_git` unset or `false`, an operation with no explicit branch
targets the configured `default_branch` — the same branch the rest of the command already uses.

Non-goals: `Config.clone` drops an explicit `branch` argument when `default_branch_from_git`
is enabled. Pre-existing, out of scope here, will be filed separately.

Closes #1290

## What changed

Behavioral changes:

- Generators, transforms and checks run without an explicit branch now target the configured
  `default_branch`.
- The local Git branch is used only when `default_branch_from_git` is enabled.
- `infrahubctl generator` is no longer internally inconsistent: the GraphQL query and the
  schema fetch resolve to the same branch.

Implementation notes:

- `InfrahubOperation.__init__` resolves the branch once as `branch or client.default_branch`.
  `client.default_branch` is already the output of `ConfigBase.default_infrahub_branch`, which
  makes the `default_branch_from_git` decision — so the flag stays honoured in exactly one place
  rather than being reimplemented. Same pattern already used in `ctl/cli_commands.py:386`.
- `branch_name` becomes a plain accessor; the `GitRepoManager` lookup and the `self.git`
  attribute are removed from `operation.py`.
- `InfrahubCheck.branch_name` gets the same treatment. Its client is optional, so with no client
  (no config to consult) it falls back to the existing `get_branch()` helper.
- Fixed at the base class, not the call sites — `InfrahubGenerator` and `InfrahubTransform` both
  inherit from `InfrahubOperation`, as does every library consumer.

What stayed the same:

- No public API or signature changes. `branch_name` and `root_directory` are unchanged.
- `default_branch_from_git=true` behaviour is unchanged.
- No generated-doc drift; the config reference already documented the intended behaviour.

## How to review

Start with `infrahub_sdk/operation.py` — the whole fix is `self.branch = branch or
client.default_branch`. `infrahub_sdk/checks.py` is the same change with an extra no-client arm.

## How to test

```bash
uv run pytest tests/unit/sdk/test_operation.py tests/unit/sdk/checks/
uv run invoke format lint-code
```

Regression coverage: explicit branch wins / no branch + flag off → configured `default_branch` /
no branch + flag on → local Git branch. Both new `default_branch` assertions fail on the
pre-fix code.

## Impact & rollout

- **Backward compatibility:** behaviour change. Anyone relying on the implicit Git fallback
  *without* setting `default_branch_from_git=true` now gets the configured `default_branch`
  (default `main`) instead of their checkout branch. That is the documented contract; noted in
  the changelog entry.
- **Config/env changes:** none. `INFRAHUB_DEFAULT_BRANCH` and `INFRAHUB_DEFAULT_BRANCH_FROM_GIT`
  now behave as documented.
- **Deployment notes:** safe to deploy.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added (`changelog/1290.fixed.md`)
- [ ] External docs updated — not needed, generated config reference already correct
- [ ] Internal .md docs updated — not needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generators, transforms, and checks to target the configured `default_branch` when no explicit branch is passed, instead of falling back to the local Git checkout branch, which previously caused `BranchNotFoundError` when that branch didn't exist in Infrahub.

**Behavior changes**
- The local Git branch is used only when `default_branch_from_git` is enabled, and is resolved from the operation's `root_directory` rather than the process working directory.
- `infrahubctl generator` now resolves the same branch for its GraphQL query and schema fetch.
- No public API or signature changes; `branch_name` and `root_directory` are unchanged.

Anyone relying on the implicit Git fallback without `default_branch_from_git` now gets the configured `default_branch` (default `main`) instead of their checkout branch. No config or env changes required. Closes #1290.

<sup>Written for commit 01712fb0079cca1f39baf5f46cd5bc78b54bf1c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

