### PR TITLE
fix: emit loadable YAML for cardinality-many relationships

### DIFF
--- a/changelog/1274.fixed.md
+++ b/changelog/1274.fixed.md
@@ -1,0 +1,1 @@
+Fixed YAML output for populated cardinality-many relationships so it can be loaded by `infrahubctl object load`.

--- a/infrahub_sdk/ctl/formatters/yaml.py
+++ b/infrahub_sdk/ctl/formatters/yaml.py
@@ -100,7 +100,7 @@ class YamlFormatter:
                 peers = getattr(rel, "peers", None) or []
                 refs = [r for p in peers if (r := _related_node_ref(p)) is not None]
                 if refs:
-                    entry[rel_name] = {"data": refs}
+                    entry[rel_name] = refs
 
         return entry
 

--- a/tests/integration/test_enduser_cli.py
+++ b/tests/integration/test_enduser_cli.py
@@ -7,9 +7,11 @@ the existing ``test_infrahubctl.py`` integration tests.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 import yaml
@@ -23,6 +25,8 @@ from infrahub_sdk.testing.schemas.animal import SchemaAnimal
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from pathlib import Path
+    from typing import Any
 
     from infrahub_sdk import InfrahubClient
     from infrahub_sdk.node import InfrahubNode
@@ -207,6 +211,46 @@ class TestEnduserCliWrite(_EnduserCliBase):
         """Create without --set or --file fails."""
         result = runner.invoke(app, ["object", "create", "TestingPerson"])
         assert result.exit_code != 0
+
+    async def test_get_yaml_round_trips_attribute_many_relationship(
+        self,
+        base_dataset: None,
+        client: InfrahubClient,
+        schema_extension_01: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        """Round-trip cardinality-many attribute relationships through the CLI."""
+        response = await client.schema.load(schemas=[schema_extension_01], wait_until_converged=True)
+        assert not response.errors
+
+        suffix = uuid4().hex
+        tag_names = [f"yaml-round-trip-{suffix}-one", f"yaml-round-trip-{suffix}-two"]
+        tags = []
+        for tag_name in tag_names:
+            tag = await client.create(kind="BuiltinTag", name=tag_name)
+            await tag.save()
+            tags.append(tag)
+
+        rack_name = f"yaml-round-trip-rack-{suffix}"
+        rack = await client.create(kind="InfraRack", name=rack_name, tags=tags)
+        await rack.save()
+
+        get_result = await asyncio.to_thread(
+            runner.invoke,
+            app,
+            ["object", "get", "InfraRack", "--filter", f"name__value={rack_name}", "--output", "yaml"],
+        )
+        assert get_result.exit_code == 0, f"object get failed: {get_result.output}"
+
+        object_file = tmp_path / "infra-rack.yaml"
+        object_file.write_text(get_result.stdout, encoding="utf-8")
+        load_result = await asyncio.to_thread(runner.invoke, app, ["object", "load", str(object_file)])
+        assert load_result.exit_code == 0, f"object load failed: {load_result.output}"
+
+        fetched_rack = await client.get(kind="InfraRack", id=rack.id)
+        fetched_tags = fetched_rack._get_relationship_many(name="tags")
+        await fetched_tags.fetch()
+        assert sorted(peer.hfid or [] for peer in fetched_tags.peers) == sorted([[name] for name in tag_names])
 
     def test_update_inline(self, base_dataset: None) -> None:
         """Update a person's height using --set."""

--- a/tests/integration/test_enduser_cli.py
+++ b/tests/integration/test_enduser_cli.py
@@ -220,37 +220,45 @@ class TestEnduserCliWrite(_EnduserCliBase):
         tmp_path: Path,
     ) -> None:
         """Round-trip cardinality-many attribute relationships through the CLI."""
-        response = await client.schema.load(schemas=[schema_extension_01], wait_until_converged=True)
-        assert not response.errors
+        tags: list[InfrahubNode] = []
+        rack: InfrahubNode | None = None
+        try:
+            response = await client.schema.load(schemas=[schema_extension_01], wait_until_converged=True)
+            assert not response.errors
 
-        suffix = uuid4().hex
-        tag_names = [f"yaml-round-trip-{suffix}-one", f"yaml-round-trip-{suffix}-two"]
-        tags = []
-        for tag_name in tag_names:
-            tag = await client.create(kind="BuiltinTag", name=tag_name)
-            await tag.save()
-            tags.append(tag)
+            suffix = uuid4().hex
+            tag_names = [f"yaml-round-trip-{suffix}-one", f"yaml-round-trip-{suffix}-two"]
+            for tag_name in tag_names:
+                tag = await client.create(kind="BuiltinTag", name=tag_name)
+                await tag.save()
+                tags.append(tag)
 
-        rack_name = f"yaml-round-trip-rack-{suffix}"
-        rack = await client.create(kind="InfraRack", name=rack_name, tags=tags)
-        await rack.save()
+            rack_name = f"yaml-round-trip-rack-{suffix}"
+            created_rack = await client.create(kind="InfraRack", name=rack_name, tags=tags)
+            await created_rack.save()
+            rack = created_rack
 
-        get_result = await asyncio.to_thread(
-            runner.invoke,
-            app,
-            ["object", "get", "InfraRack", "--filter", f"name__value={rack_name}", "--output", "yaml"],
-        )
-        assert get_result.exit_code == 0, f"object get failed: {get_result.output}"
+            get_result = await asyncio.to_thread(
+                runner.invoke,
+                app,
+                ["object", "get", "InfraRack", "--filter", f"name__value={rack_name}", "--output", "yaml"],
+            )
+            assert get_result.exit_code == 0, f"object get failed: {get_result.output}"
 
-        object_file = tmp_path / "infra-rack.yaml"
-        object_file.write_text(get_result.stdout, encoding="utf-8")
-        load_result = await asyncio.to_thread(runner.invoke, app, ["object", "load", str(object_file)])
-        assert load_result.exit_code == 0, f"object load failed: {load_result.output}"
+            object_file = tmp_path / "infra-rack.yaml"
+            object_file.write_text(get_result.stdout, encoding="utf-8")
+            load_result = await asyncio.to_thread(runner.invoke, app, ["object", "load", str(object_file)])
+            assert load_result.exit_code == 0, f"object load failed: {load_result.output}"
 
-        fetched_rack = await client.get(kind="InfraRack", id=rack.id)
-        fetched_tags = fetched_rack._get_relationship_many(name="tags")
-        await fetched_tags.fetch()
-        assert sorted(peer.hfid or [] for peer in fetched_tags.peers) == sorted([[name] for name in tag_names])
+            fetched_rack = await client.get(kind="InfraRack", id=rack.id)
+            fetched_tags = fetched_rack._get_relationship_many(name="tags")
+            await fetched_tags.fetch()
+            assert sorted(peer.hfid or [] for peer in fetched_tags.peers) == sorted([[name] for name in tag_names])
+        finally:
+            if rack is not None:
+                await rack.delete()
+            for tag in reversed(tags):
+                await tag.delete()
 
     def test_update_inline(self, base_dataset: None) -> None:
         """Update a person's height using --set."""

--- a/tests/integration/test_enduser_cli.py
+++ b/tests/integration/test_enduser_cli.py
@@ -222,6 +222,7 @@ class TestEnduserCliWrite(_EnduserCliBase):
         """Round-trip cardinality-many attribute relationships through the CLI."""
         tags: list[InfrahubNode] = []
         rack: InfrahubNode | None = None
+        body_succeeded = False
         try:
             response = await client.schema.load(schemas=[schema_extension_01], wait_until_converged=True)
             assert not response.errors
@@ -254,11 +255,21 @@ class TestEnduserCliWrite(_EnduserCliBase):
             fetched_tags = fetched_rack._get_relationship_many(name="tags")
             await fetched_tags.fetch()
             assert sorted(peer.hfid or [] for peer in fetched_tags.peers) == sorted([[name] for name in tag_names])
+            body_succeeded = True
         finally:
+            cleanup_errors: list[Exception] = []
             if rack is not None:
-                await rack.delete()
+                try:
+                    await rack.delete()
+                except Exception as exc:
+                    cleanup_errors.append(exc)
             for tag in reversed(tags):
-                await tag.delete()
+                try:
+                    await tag.delete()
+                except Exception as exc:
+                    cleanup_errors.append(exc)
+            if body_succeeded and cleanup_errors:
+                raise cleanup_errors[0]
 
     def test_update_inline(self, base_dataset: None) -> None:
         """Update a person's height using --set."""

--- a/tests/unit/ctl/formatters/test_yaml.py
+++ b/tests/unit/ctl/formatters/test_yaml.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import yaml  # pyright: ignore[reportMissingModuleSource]
 
 from infrahub_sdk.ctl.formatters.yaml import YamlFormatter
+from infrahub_sdk.schema import RelationshipCardinality, RelationshipSchemaAPI
+from infrahub_sdk.spec.object import InfrahubObjectFileData, RelationshipDataFormat, get_relationship_info
 
 
 def _make_mock_schema(
@@ -327,7 +329,48 @@ class TestYamlFormatterEdgeCases:
 
         result = formatter.format_detail(node, schema)
         parsed = yaml.safe_load(result)
-        assert parsed["spec"]["data"][0]["tags"] == {"data": ["tag1", "tag2"]}
+        assert parsed["spec"]["data"][0]["tags"] == ["tag1", "tag2"]
+
+    async def test_rel_cardinality_many_output_is_loadable_reference(self) -> None:
+        """Cardinality-many YAML output is accepted by the object loader as HFID references."""
+        schema = MagicMock()
+        schema.kind = "TestKind"
+        schema.attribute_names = []
+        schema.relationship_names = ["tags"]
+        rel_schema = RelationshipSchemaAPI(
+            name="tags",
+            peer="BuiltinTag",
+            cardinality=RelationshipCardinality.MANY,
+        )
+        schema.get_relationship.return_value = rel_schema
+
+        peer1 = MagicMock(display_label="tag1", hfid=["tag1"])
+        peer2 = MagicMock(display_label="tag2", hfid=["tag2"])
+        node = MagicMock()
+        node.tags.peers = [peer1, peer2]
+
+        parsed = yaml.safe_load(YamlFormatter().format_detail(node, schema))
+        relationship_value = parsed["spec"]["data"][0]["tags"]
+
+        peer_schema = MagicMock(human_friendly_id=["name"])
+        client = MagicMock()
+        client.schema.get = AsyncMock(return_value=peer_schema)
+        rel_info = await get_relationship_info(
+            client=client,
+            schema=schema,
+            name="tags",
+            value=relationship_value,
+        )
+        errors = await InfrahubObjectFileData.validate_related_nodes(
+            client=client,
+            position=[1, "tags"],
+            rel_info=rel_info,
+            data=relationship_value,
+        )
+
+        assert rel_info.format == RelationshipDataFormat.MANY_REF
+        assert rel_info.is_reference
+        assert errors == []
 
     def test_rel_multi_component_hfid(self) -> None:
         """Multi-component HFID renders as a list."""

--- a/tests/unit/ctl/formatters/test_yaml.py
+++ b/tests/unit/ctl/formatters/test_yaml.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import json
+from unittest.mock import MagicMock
 
 import yaml  # pyright: ignore[reportMissingModuleSource]
 
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.config import Config
 from infrahub_sdk.ctl.formatters.yaml import YamlFormatter
-from infrahub_sdk.schema import RelationshipCardinality, RelationshipSchemaAPI
 from infrahub_sdk.spec.object import InfrahubObjectFileData, RelationshipDataFormat, get_relationship_info
+from tests.helpers.fixtures import read_fixture
 
 
 def _make_mock_schema(
@@ -333,28 +336,18 @@ class TestYamlFormatterEdgeCases:
 
     async def test_rel_cardinality_many_output_is_loadable_reference(self) -> None:
         """Cardinality-many YAML output is accepted by the object loader as HFID references."""
-        schema = MagicMock()
-        schema.kind = "TestKind"
-        schema.attribute_names = []
-        schema.relationship_names = ["tags"]
-        rel_schema = RelationshipSchemaAPI(
-            name="tags",
-            peer="BuiltinTag",
-            cardinality=RelationshipCardinality.MANY,
-        )
-        schema.get_relationship.return_value = rel_schema
+        client = InfrahubClient(config=Config(address="http://mock"))
+        client.schema.set_cache(json.loads(read_fixture("schema_01.json")), branch="main")
+        schema = await client.schema.get(kind="CoreGraphQLQuery", branch="main")
 
-        peer1 = MagicMock(display_label="tag1", hfid=["tag1"])
-        peer2 = MagicMock(display_label="tag2", hfid=["tag2"])
-        node = MagicMock()
-        node.tags.peers = [peer1, peer2]
+        peer1 = await client.create(kind="BuiltinTag", name="tag1")
+        peer2 = await client.create(kind="BuiltinTag", name="tag2")
+        node = await client.create(
+            kind="CoreGraphQLQuery", name="query1", query="query Test { ok }", tags=[peer1, peer2]
+        )
 
         parsed = yaml.safe_load(YamlFormatter().format_detail(node, schema))
         relationship_value = parsed["spec"]["data"][0]["tags"]
-
-        peer_schema = MagicMock(human_friendly_id=["name"])
-        client = MagicMock()
-        client.schema.get = AsyncMock(return_value=peer_schema)
         rel_info = await get_relationship_info(
             client=client,
             schema=schema,
@@ -368,6 +361,7 @@ class TestYamlFormatterEdgeCases:
             data=relationship_value,
         )
 
+        assert relationship_value == ["tag1", "tag2"]
         assert rel_info.format == RelationshipDataFormat.MANY_REF
         assert rel_info.is_reference
         assert errors == []


### PR DESCRIPTION
Fixes #1274.

`object get --output yaml` wraps populated cardinality-many HFID references in a `data` dictionary, which the loader reserves for nested objects and therefore rejects when it contains a string list. Emit the already-supported plain HFID list instead and cover the formatter-to-loader path with a regression test.

Cardinality-one output, empty-relationship omission, and multi-component HFIDs are unchanged. Generic-kind relationship omission is excluded and remains tracked in #1275.

Tested with:
- `uv run pytest -q tests/unit/ctl/formatters/test_yaml.py tests/unit/sdk/spec/test_object.py` (49 passed)
- `COLUMNS=140 uv run pytest -q tests/unit` (1819 passed, 1 xfailed)
- `uv run invoke format`
- `uv run invoke lint-code`
- `uv run invoke docs-validate`
- `uv run invoke lint-docs`
- `uv run towncrier build --draft --version 1.23.2`
