### PR TITLE
Add the refresh tokens relationship to the account protocols

### DIFF
--- a/infrahub_sdk/protocols.py
+++ b/infrahub_sdk/protocols.py
@@ -121,6 +121,7 @@ class CoreGenericAccount(CoreNode):
     account_type: Enum
     status: Dropdown
     tokens: RelationshipManager
+    refresh_tokens: RelationshipManager
     external_identities: RelationshipManager
 
 
@@ -726,6 +727,7 @@ class CoreGenericAccountSync(CoreNodeSync):
     account_type: Enum
     status: Dropdown
     tokens: RelationshipManagerSync
+    refresh_tokens: RelationshipManagerSync
     external_identities: RelationshipManagerSync
 
 


### PR DESCRIPTION
# Why

Infrahub declares a `refresh_tokens` relationship on `CoreGenericAccount`, so that
the delete of an account also removes its refresh tokens. This file is generated
from that schema, so it has to carry the same relationship. Without it,
`invoke backend.generate` in the Infrahub repository leaves this file dirty and the
`validate-generated` job stays red.

Needed by opsmill/infrahub#10435, which fixes opsmill/infrahub#10304.

## What changed

- `refresh_tokens` is added to `CoreGenericAccount` and `CoreGenericAccountSync`.

Nothing else. The file is rendered by `invoke backend.generate` in the Infrahub
repository, not written by hand.

## How to review

One commit on top of `stable`, two lines. The Infrahub submodule already pins the
`stable` head, so the pointer bump on that side moves by this commit alone.
