### PR TITLE
fix(packaging): split the testing extras and stop publishing testcontainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,20 @@ The ctl extra provides the `infrahubctl` command, which allows you to intera
 pip install 'infrahub-sdk[ctl]'
 ```
 
-#### tests
+#### testing
 
-The tests extra provides all the components for the testing framework of Transforms, Queries and Checks.
+The testing extra provides the components for the testing framework of Transforms, Queries and Checks.
 
 ```bash
-pip install 'infrahub-sdk[tests]'
+pip install 'infrahub-sdk[testing]'
+```
+
+#### testcontainers
+
+The testcontainers extra provides infrahub_sdk.testing.docker, which starts a real Infrahub in containers so tests can run against a live instance.
+
+```bash
+pip install 'infrahub-sdk[testcontainers]'
 ```
 
 #### all

--- a/changelog/+dependency-lower-bounds.changed.md
+++ b/changelog/+dependency-lower-bounds.changed.md
@@ -4,4 +4,4 @@ If you pin `pydantic` to 2.0, 2.0.1 or 2.0.2, installing the SDK now fails while
 
 `anyio` and `typing-extensions` are now installed as direct requirements of the SDK itself. It has always imported them but relied on other packages to pull them in, so a minimal or heavily constrained environment could end up with the SDK installed and unusable. No action is needed, installs simply become reliable.
 
-`packaging` is now a direct requirement of the `tests` extra, which is where the `infrahub_sdk.testing` helpers that import it live. A plain `pip install infrahub-sdk` does not install it.
+`packaging` is now a direct requirement of the `testcontainers` extra, which is where the `infrahub_sdk.testing.docker` helper that imports it lives. A plain `pip install infrahub-sdk` does not install it.

--- a/changelog/+testing-extras.changed.md
+++ b/changelog/+testing-extras.changed.md
@@ -1,0 +1,7 @@
+Two extras now cover testing, replacing the `tests` extra.
+
+`pip install 'infrahub-sdk[testing]'` installs pytest and enables the bundled `pytest-infrahub` plugin, which is what you want to test your own Transforms, Queries and Checks. `pip install 'infrahub-sdk[testcontainers]'` additionally provides `infrahub_sdk.testing.docker`, which starts a real Infrahub in containers so your tests can run against a live instance instead of mocked responses.
+
+They are kept apart because the container tooling is a much heavier install. `[testing]` adds four packages on top of a plain install; `[testcontainers]` adds around sixty, among them Docker, FastAPI and Prefect client libraries. Previously you would have had to take all of it to get either.
+
+The `tests` extra is gone. It stopped installing anything in 1.16.0 while the documentation carried on advertising it, so since then `pip install 'infrahub-sdk[tests]'` has warned about an unknown extra and installed only the base package. If you are coming from 1.15.2 or earlier, `[testing]` is the direct replacement for what `[tests]` gave you.

--- a/changelog/+tests-extra.added.md
+++ b/changelog/+tests-extra.added.md
@@ -1,5 +1,0 @@
-`pip install 'infrahub-sdk[tests]'` now works. The `tests` extra is described in the installation guide but was never actually published, so the command warned that no such extra existed and installed nothing beyond the base package.
-
-Install it if you use the `pytest-infrahub` plugin to test Transforms, Queries and Checks, or the `infrahub_sdk.testing` helpers. Previously you had to work out the missing requirements and declare them yourself.
-
-Be aware that it is a large install, adding around 61 packages on top of the base SDK, among them Docker, FastAPI and Prefect client libraries. These come from the `infrahub_sdk.testing` helpers, which run Infrahub in containers. If you only need the `infrahubctl` CLI, install `infrahub-sdk[ctl]` instead. `infrahub-sdk[all]` now covers both `ctl` and `tests`, so it pulls in considerably more than it used to.

--- a/docs/docs/python-sdk/guides/installation.mdx
+++ b/docs/docs/python-sdk/guides/installation.mdx
@@ -29,19 +29,31 @@ pip install 'infrahub-sdk[ctl]'
 
 <!-- vale off -->
 
-### tests
+### testing
 
 <!-- vale on -->
 
-The `tests` extra provides all the components for the testing framework of Transforms, Queries and Checks.
+The `testing` extra provides the components for the testing framework of Transforms, Queries and Checks. It installs `pytest` and enables the bundled `pytest-infrahub` plugin, which discovers the `infrahub_tests` blocks in your repository's `.infrahub.yml` and turns them into test cases.
 
 ```shell
-pip install 'infrahub-sdk[tests]'
+pip install 'infrahub-sdk[testing]'
+```
+
+<!-- vale off -->
+
+### testcontainers
+
+<!-- vale on -->
+
+The `testcontainers` extra provides `infrahub_sdk.testing.docker`, which starts a real Infrahub in containers so your tests can run against a live instance rather than mocked responses. Inherit `TestInfrahubDockerClient` to get a client connected to that instance.
+
+```shell
+pip install 'infrahub-sdk[testcontainers]'
 ```
 
 :::note
 
-This extra is much larger than the others. The `infrahub_sdk.testing` helpers run Infrahub in containers, which adds roughly 61 packages on top of the base SDK. Install the `ctl` extra on its own if you only need the `infrahubctl` command.
+This extra is considerably larger than the others, since running Infrahub in containers pulls in Docker, FastAPI and Prefect client libraries. Install `testing` on its own if you only need to test Transforms, Queries and Checks.
 
 :::
 

--- a/docs/docs/python-sdk/introduction.mdx
+++ b/docs/docs/python-sdk/introduction.mdx
@@ -120,7 +120,7 @@ Extras are available for additional functionality:
 
 ```bash
 uv add 'infrahub-sdk[ctl]'    # Adds the infrahubctl CLI
-uv add 'infrahub-sdk[tests]'  # Adds the testing framework for transforms and checks
+uv add 'infrahub-sdk[testing]'  # Adds the testing framework for transforms and checks
 uv add 'infrahub-sdk[all]'    # Everything
 ```
 
@@ -135,7 +135,7 @@ Extras are available for additional functionality:
 
 ```bash
 pip install 'infrahub-sdk[ctl]'    # Adds the infrahubctl CLI
-pip install 'infrahub-sdk[tests]'  # Adds the testing framework for transforms and checks
+pip install 'infrahub-sdk[testing]'  # Adds the testing framework for transforms and checks
 pip install 'infrahub-sdk[all]'    # Everything
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,18 +57,23 @@ ctl = [
     "ariadne-codegen==0.18.0",
 ]
 
-# The user-facing testing surface: `infrahub_sdk.testing` and the bundled `pytest-infrahub`
-# plugin. Both ship in the wheel but import packages that no other extra installs. Distinct from
-# the `tests` dependency group below, which is the tooling used to test the SDK itself.
-tests = [
+# The bundled `pytest-infrahub` plugin and the schemas under `infrahub_sdk.testing`, for writing
+# tests against your own Transforms, Queries and Checks.
+testing = [
+    "pytest>=7.0",
+]
+
+# `infrahub_sdk.testing.docker`, which starts a real Infrahub in containers. Kept apart from
+# `testing` because it is the only module that needs it and it is a far heavier install.
+testcontainers = [
+    "infrahub-sdk[testing]",
     "infrahub-testcontainers>=1.7.3",
     "packaging>=21.0",
-    "pytest>=7.0",
 ]
 
 # Self-referential so it cannot drift out of sync with the extras it aggregates.
 all = [
-    "infrahub-sdk[ctl,tests]",
+    "infrahub-sdk[ctl,testing,testcontainers]",
 ]
 
 [dependency-groups]

--- a/tests/unit/test_packaging_metadata.py
+++ b/tests/unit/test_packaging_metadata.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import ast
 import re
 import sys
-from collections.abc import Container, Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeGuard
@@ -34,10 +34,13 @@ BASE_SECTION = "project.dependencies"
 
 # Modules that ship in the wheel but are allowed to need an extra, mapped to the extra that
 # supplies them. `ctl/` is the CLI; `async_typer` and `graphql/plugin.py` sit outside it but are
-# only reachable from it. Everything else must import on a plain install.
+# only reachable from it. Everything else must import on a plain install, which is why the entries
+# are per-file where a package is split: `testing/repository.py` needs nothing beyond the core
+# dependencies, so it is deliberately absent and held to the base install.
 EXTRA_ONLY_MODULES = {
     "ctl": ("ctl/", "async_typer.py", "graphql/plugin.py"),
-    "tests": ("pytest_plugin/", "testing/"),
+    "testing": ("pytest_plugin/", "testing/schemas/"),
+    "testcontainers": ("testing/docker.py",),
 }
 
 # Operators that establish a floor. A requirement without one of these lets a resolver reach back
@@ -137,13 +140,29 @@ def _requirement_cases() -> list[RequirementCase]:
     ]
 
 
-def _declared_in(sections: Container[str]) -> set[str]:
-    """The distributions installed by the given sections of `pyproject.toml`."""
-    return {
-        _normalize(requirement.name)
-        for requirement in (Requirement(case.requirement) for case in _requirement_cases() if case.section in sections)
-        if not _is_self_reference(requirement)
-    }
+def _declared_in(sections: Iterable[str]) -> set[str]:
+    """The distributions installed by the given sections of `pyproject.toml`.
+
+    Self-referential extras are followed, so asking for `testcontainers` also returns whatever
+    the `testing` extra it references installs. Without that, an extra defined by self-reference
+    would look as though it installed nothing.
+    """
+    cases = _requirement_cases()
+    pending, seen, declared = [_normalize(section) for section in sections], set(), set()
+    while pending:
+        section = pending.pop()
+        if section in seen:
+            continue
+        seen.add(section)
+        for case in cases:
+            if _normalize(case.section) != section:
+                continue
+            requirement = Requirement(case.requirement)
+            if _is_self_reference(requirement):
+                pending.extend(_normalize(extra) for extra in requirement.extras)
+            else:
+                declared.add(_normalize(requirement.name))
+    return declared
 
 
 def _surface_of(relative_path: Path) -> str | None:

--- a/uv.lock
+++ b/uv.lock
@@ -775,9 +775,12 @@ ctl = [
     { name = "ruamel-yaml" },
     { name = "typer" },
 ]
-tests = [
+testcontainers = [
     { name = "infrahub-testcontainers" },
     { name = "packaging" },
+    { name = "pytest" },
+]
+testing = [
     { name = "pytest" },
 ]
 
@@ -847,17 +850,18 @@ requires-dist = [
     { name = "graphql-core", specifier = ">=3.1,<3.3" },
     { name = "httpx", specifier = ">=0.20" },
     { name = "infrahub-testcontainers", marker = "extra == 'all'", specifier = ">=1.7.3" },
-    { name = "infrahub-testcontainers", marker = "extra == 'tests'", specifier = ">=1.7.3" },
+    { name = "infrahub-testcontainers", marker = "extra == 'testcontainers'", specifier = ">=1.7.3" },
     { name = "jinja2", specifier = ">=3" },
     { name = "netutils", specifier = ">=1.0.0" },
     { name = "packaging", marker = "extra == 'all'", specifier = ">=21.0" },
-    { name = "packaging", marker = "extra == 'tests'", specifier = ">=21.0" },
+    { name = "packaging", marker = "extra == 'testcontainers'", specifier = ">=21.0" },
     { name = "pyarrow", marker = "extra == 'all'", specifier = ">=14" },
     { name = "pyarrow", marker = "extra == 'ctl'", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2.0.3,!=2.1.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'all'", specifier = ">=7.0" },
-    { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'testcontainers'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=7.0" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "rich", specifier = ">=12" },
     { name = "ruamel-yaml", marker = "extra == 'all'", specifier = ">=0.18" },
@@ -869,7 +873,7 @@ requires-dist = [
     { name = "ujson", specifier = ">=5" },
     { name = "whenever", specifier = ">=0.9.3,<0.10.0" },
 ]
-provides-extras = ["all", "ctl", "tests"]
+provides-extras = ["all", "ctl", "testcontainers", "testing"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Short version

Some time ago we had an option to install with `pip install infrahub-sdk[tests]` that has been broken for some time. Here we replace it with `pip install infrahub-sdk[testing]` this is to avoid confusion with the dependency groups as we also have a "tests" group for development dependency. We also move out the infrahub-testcontainers into its own group with `pip install infrahub-sdk[testcontsiners]`.  So:

* testing: Anything needed to run our own pytest plugin for transforms etc
* testcontainers: When you need to do anything with Docker integration tests

# Why

The `tests` extra added in #1277 bundled `infrahub-testcontainers`, and it should not have. That package has never been shipped to users by any release of this SDK: it has been a dev dependency since Damien added it in `e4d190f1` (2024-12-24), for the SDK's own integration tests. Publishing it took the extra from the four packages it historically installed to sixty-one, including `amplitude-analytics`, for anyone who only wanted to test a Transform.

Worth being clear about how that happened, since it says something about the check added in the same PR. The new per-surface import test flagged `infrahub_sdk/testing/docker.py` importing a package nothing declared, and the resolution taken was to declare it in a user-facing extra. The correct reading was that the module is dev scaffolding which merely happens to live inside the package directory. A published API was changed to satisfy a test written minutes earlier.

Nothing has released yet, so this is free to correct. `[tests]` exists only on `infrahub-develop`.

**Goal:** two extras that each mean one thing to a user, with the heavy container tooling opt-in.

**Non-goals:** whether `infrahub_sdk.testing` should ship in the wheel at all. It is undocumented, and a base class in it (`TestInfrahubDockerClient`) looks like something a downstream consumer would inherit. That deserves a decision from whoever owns the module, not a packaging change here.

## What changed

Behavioral changes:

- `pip install 'infrahub-sdk[testing]'` installs pytest and enables the bundled `pytest-infrahub` plugin. Four packages on top of a plain install.
- `pip install 'infrahub-sdk[testcontainers]'` additionally provides `infrahub_sdk.testing.docker`, which starts a real Infrahub in containers. Around sixty packages, and now only reached by asking for it by name.
- The `tests` extra is gone. It installed nothing at all from 1.16.0 (2025-12-01) onwards while the docs kept advertising it, so there is no working install to preserve. `[testing]` is the direct replacement for what `[tests]` gave users up to 1.15.2.
- `infrahub-sdk[all]` now aggregates `ctl`, `testing` and `testcontainers`.

Implementation notes:

- Only `docker.py` needs the container tooling, so `EXTRA_ONLY_MODULES` in the import check is now per-file rather than per-package. `testing/repository.py` is deliberately absent from it and held to the base install, because that is the truth: it needs nothing beyond the core dependencies, and `tests/unit/sdk/test_repository.py` imports it today.
- The check now follows self-referential extras. Without that, `testcontainers` looked as though it installed nothing, since its pytest requirement arrives via `infrahub-sdk[testing]`. The check caught this itself on the first run.
- `tests` is dropped rather than kept as an alias for `testing`. Two near-identical names would only invite installing the wrong one, and there is no functioning install behind the old name to keep working.

Verified behaviour, installing the built wheel into a clean environment for each:

| Install | Packages | plugin | `testing.docker` | `testing.repository` |
| --- | --- | --- | --- | --- |
| base | 27 | - | - | yes |
| `[testing]` | 31 | yes | - | yes |
| `[testcontainers]` | 88 | yes | yes | yes |
| `[all]` | 93 | yes | yes | yes |

What stayed the same: no runtime code changed. Packaging metadata, the import check's surface map, docs, and changelog.

## How to review

Start with `pyproject.toml`, then the `EXTRA_ONLY_MODULES` and `_declared_in` changes in `tests/unit/test_packaging_metadata.py`. Docs and changelog follow from those.

The judgement call worth scrutiny is dropping `tests` outright. The case for it: broken for nine months across nineteen releases, so no meaningful population depends on it resolving. The case against: it did work up to 1.15.2, and 1.15 is a maintained line, so someone upgrading from there sees a removal. That is why the changelog entry names the replacement explicitly.

## How to test

```bash
uv run pytest tests/unit/test_packaging_metadata.py
uv run invoke lint-code
uv lock --locked --offline
uv run towncrier build --draft --version 1.24.0
```

Verified locally: ruff, ty and mypy 2.3.1 clean; unit suite 1859 passed with 2 failures that reproduce identically on the base branch (macOS-only Rich wrapping of long temp paths, in files this PR does not touch); 33 passed on both 3.10 and 3.12 for the metadata module; lock consistent; `docs-validate` exit 0; `lint-docs` unchanged at its 20 pre-existing errors.

## Changelog

The fragments from #1277 are unreleased, so they were corrected rather than supplemented, to stop the 1.24 notes announcing `[tests]` and then retracting it:

- `+tests-extra.added.md` removed, replaced by `+testing-extras.changed.md` describing the final state and the migration from `[tests]`
- `+dependency-lower-bounds.changed.md` now attributes `packaging` to the `testcontainers` extra rather than `tests`
- `+core-template-dependencies.fixed.md`, `+rich-upper-bound.changed.md` and `+packaging-metadata-tests.housekeeping.md` re-read and left alone; all three are still accurate

## Documentation Updates

- `docs/docs/python-sdk/guides/installation.mdx`: `tests` section replaced by `testing` and `testcontainers`, each explaining what it gives you. The size note added in #1277 moves to `testcontainers`, where it is now true.
- `docs/docs/python-sdk/introduction.mdx`: both the uv and pip tabs updated.
- `README.md`: same treatment as the installation guide.

## Impact & rollout

- **Backward compatibility:** removes an extra that has installed nothing since 1.16.0, and reshapes one that has never been released. No published install changes behaviour. Anyone on 1.15.2 or earlier using `[tests]` should move to `[testing]`.
- **Performance:** no runtime impact.
- **Config/env changes:** none.
- **Deployment notes:** safe to merge independently. Should land before 1.24 ships, after which removing `tests` would need a deprecation.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] External docs updated (if user-facing or ops-facing change)
- [ ] Internal .md docs updated (internal knowledge and AI code tools knowledge)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the testing extras so `infrahub-sdk[tests]` no longer publishes `infrahub-testcontainers` (a dev dependency never meant for users). The `tests` extra is replaced by `testing` for pytest support and `testcontainers` for running Infrahub in containers.

- `pip install 'infrahub-sdk[testing]'` installs pytest and enables the bundled plugin; `[testcontainers]` adds the container-based `infrahub_sdk.testing.docker`.
- The old `tests` extra has installed nothing since 1.16.0, so no working install is affected.
- The import check now maps `testing/docker.py` to the `testcontainers` extra per-file and follows self-referential extras.
- Docs and changelog updated to name the new extras; anyone on 1.15.2 or earlier should use `[testing]`.

<sup>Written for commit 546dc8270aef55ab932e841ec6e5da7dd2aeff6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

