### PR TITLE
Send the SDK release dispatch to every repository listening for it

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -36,8 +36,17 @@ jobs:
         # Either a literal path, or the name of a secret...
         repo:
           - "opsmill/emma"
+          - "opsmill/infrahub-ansible"
+          - "opsmill/infrahub-arista-avd"
           - "opsmill/infrahub-demo-dc"
+          - "opsmill/infrahub-demo-otn"
+          - "opsmill/infrahub-demo-service-catalog"
+          - "opsmill/infrahub-demo-sp"
+          - "opsmill/infrahub-mcp"
+          - "opsmill/infrahub-solution-ai-dc"
           - "opsmill/infrahub-sync"
+          - "opsmill/infrahub-sync-lab"
+          - "opsmill/nornir-infrahub"
           - "INFRAHUB_CUSTOMER1_REPOSITORY"
 
     steps:


### PR DESCRIPTION
## Summary

When the SDK publishes a release, this workflow tells downstream repositories so they can open their own version-bump pull request. The matrix names four recipients. **Eleven** repositories carry a listener for `trigger-infrahub-sdk-python-update`, and only two of them are wired — `infrahub-demo-dc` and `infrahub-sync`. The other nine have bump workflows that have never once been triggered.

This adds the nine missing recipients, and flags one dispatch that goes nowhere.

## Key Changes

Added to the matrix:

- `opsmill/infrahub-ansible`
- `opsmill/infrahub-arista-avd`
- `opsmill/infrahub-demo-otn`
- `opsmill/infrahub-demo-service-catalog`
- `opsmill/infrahub-demo-sp`
- `opsmill/infrahub-mcp`
- `opsmill/infrahub-solution-ai-dc`
- `opsmill/infrahub-sync-lab`
- `opsmill/nornir-infrahub`

## One decision left for an owner: `opsmill/emma`

`emma` is dispatched to on every SDK release and has **no listener for this event at all**, so the dispatch is accepted and consumed by nothing.

## Related

Companion PR for the Infrahub-side matrix, which had the same defect: opsmill/infrahub#10510.

`opsmill/infrahub-demo-otn`'s listener for this event is in flight and lands before this is useful to it. A dispatch to a repository with no matching listener is a no-op rather than an error, so the ordering is safe either way.

## Base branch

Targeted at `stable` rather than `develop` on purpose: `release.yml` fires on `release: published`, so the file that executes is the one at the release tag, and the bot already syncs `stable` into `develop`. Please correct me if that is wrong for this repo — recent PRs here are split across `develop`, `infrahub-develop` and `stable`, so I reasoned it from the release trigger rather than from convention.

## Test Plan

Nothing to run: the change is a matrix list. Verification is on the next SDK release, where each newly added repository should show a run of its own bump workflow shortly after the release publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the SDK release dispatch to every repository listening for it. Only two of eleven listener repositories were wired before, so nine version-bump workflows never ran.

- Adds the nine missing repositories to the dispatch matrix.
- Leaves `opsmill/emma` in the matrix; its dispatch is a no-op, and whether it gains a listener or loses the dispatch is its owner's call.
- Records the search query that lists listeners in the matrix comment, so the next reconciliation is a diff instead of an audit.

<sup>Written for commit b341679a0e2f63012566ff7c01351e30dfb06a5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

