### PR TITLE
fix(branch): correct rebase() and validate() return annotations to bool

### DIFF
--- a/changelog/1308.fixed.md
+++ b/changelog/1308.fixed.md
@@ -1,0 +1,1 @@
+Corrected the return type annotations of `rebase()` and `validate()` on both `InfrahubClient.branch` and `InfrahubClientSync.branch`. They were declared as `-> BranchData` but have always returned the mutation's `ok` boolean, so the annotations now read `-> bool` to match the actual behaviour and align with `merge()`.

--- a/infrahub_sdk/branch.py
+++ b/infrahub_sdk/branch.py
@@ -116,7 +116,7 @@ class InfrahubBranchManager:
         response = await self.client.execute_graphql(query=query.render(), tracker="mutation-branch-delete")
         return response["BranchDelete"]["ok"]
 
-    async def rebase(self, branch_name: str) -> BranchData:
+    async def rebase(self, branch_name: str) -> bool:
         input_data = {
             "data": {
                 "name": branch_name,
@@ -126,7 +126,7 @@ class InfrahubBranchManager:
         response = await self.client.execute_graphql(query=query.render(), tracker="mutation-branch-rebase")
         return response["BranchRebase"]["ok"]
 
-    async def validate(self, branch_name: str) -> BranchData:
+    async def validate(self, branch_name: str) -> bool:
         input_data = {
             "data": {
                 "name": branch_name,
@@ -264,7 +264,7 @@ class InfrahubBranchManagerSync:
 
         return response["BranchMerge"]["ok"]
 
-    def rebase(self, branch_name: str) -> BranchData:
+    def rebase(self, branch_name: str) -> bool:
         input_data = {
             "data": {
                 "name": branch_name,
@@ -274,7 +274,7 @@ class InfrahubBranchManagerSync:
         response = self.client.execute_graphql(query=query.render(), tracker="mutation-branch-rebase")
         return response["BranchRebase"]["ok"]
 
-    def validate(self, branch_name: str) -> BranchData:
+    def validate(self, branch_name: str) -> bool:
         input_data = {
             "data": {
                 "name": branch_name,


### PR DESCRIPTION
## What

Corrects the return type annotations of `rebase()` and `validate()` on both `InfrahubClient.branch` (`AsyncBranchManager`) and `InfrahubClientSync.branch` (`BranchManagerSync`) from `-> BranchData` to `-> bool`.

Fixes #1308.

## Why

Both methods have always returned the mutation's `ok` boolean:

```python
return response["BranchRebase"]["ok"]
return response["BranchValidate"]["ok"]
```

but declared `-> BranchData`. A caller trusting the annotation would write `result.name` and hit `AttributeError: 'bool' object has no attribute 'name'` at runtime, and a type checker could not flag it because it believed the declaration. `validate()` only requests `{"ok": None}`, so there is no branch data to return regardless.

This is the safe, non-breaking fix recommended in the issue: it matches what the methods actually do and aligns them with `merge()`, which already declares `-> bool`. Existing integration tests already assert the result `is True`, and the `infrahubctl` CLI callers ignore the return value, so no behaviour changes.

## Changes

- `infrahub_sdk/branch.py`: `rebase()` and `validate()` on both managers now annotated `-> bool`.
- Added changelog fragment `changelog/1308.fixed.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the return type annotations of `rebase()` and `validate()` on both `AsyncBranchManager` and `BranchManagerSync` from `BranchData` to `bool` to match what they actually return (the mutation's `ok` boolean).

- Fixes #1308; no behavior changes, and the annotations now align with `merge()`, which already returns `bool`.

<sup>Written for commit 4d65d703194b922d93f83a8694c18f415d0927c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

