### PR TITLE
fix(diff): report GetDiffSummary operationName for get_diff_summary()

### DIFF
--- a/changelog/1313.fixed.md
+++ b/changelog/1313.fixed.md
@@ -1,0 +1,1 @@
+Fixed `get_diff_summary()` reporting its request under the GraphQL `operationName` `GetDiffTree`, the same name used by `get_diff_tree()`. The summary query now sends `GetDiffSummary`, so the two methods are distinguishable in server-side query logs, traces, and observability tooling keyed on `operationName`.

--- a/infrahub_sdk/client.py
+++ b/infrahub_sdk/client.py
@@ -1987,7 +1987,7 @@ class InfrahubClient(BaseClient):
             timeout=timeout,
             tracker=tracker,
             variables=input_data,
-            operation_name="GetDiffTree",
+            operation_name="GetDiffSummary",
             priority=priority,
         )
 
@@ -3600,7 +3600,7 @@ class InfrahubClientSync(BaseClient):
             timeout=timeout,
             tracker=tracker,
             variables=input_data,
-            operation_name="GetDiffTree",
+            operation_name="GetDiffSummary",
             priority=priority,
         )
 

--- a/infrahub_sdk/diff.py
+++ b/infrahub_sdk/diff.py
@@ -51,7 +51,7 @@ class DiffTreeData(TypedDict):
 
 def get_diff_summary_query() -> str:
     return """
-        query GetDiffTree($branch_name: String!, $name: String, $from_time: DateTime, $to_time: DateTime) {
+        query GetDiffSummary($branch_name: String!, $name: String, $from_time: DateTime, $to_time: DateTime) {
             DiffTree(branch: $branch_name, name: $name, from_time: $from_time, to_time: $to_time) {
                 nodes {
                     uuid

--- a/tests/unit/sdk/test_diff_summary.py
+++ b/tests/unit/sdk/test_diff_summary.py
@@ -1,10 +1,11 @@
+import json
 from datetime import datetime, timezone
 
 import pytest
 from pytest_httpx import HTTPXMock
 
 from infrahub_sdk import InfrahubClient
-from infrahub_sdk.diff import get_diff_tree_query
+from infrahub_sdk.diff import get_diff_summary_query, get_diff_tree_query
 from tests.unit.sdk.conftest import BothClients
 
 client_types = ["standard", "sync"]
@@ -393,3 +394,42 @@ async def test_get_diff_tree_time_validation(clients: BothClients, client_type: 
                 from_time=from_time,
                 to_time=to_time,
             )
+
+
+def test_get_diff_summary_query_operation_name() -> None:
+    """The summary query must declare its own operation, distinct from the diff tree query."""
+    rendered = get_diff_summary_query()
+
+    assert "query GetDiffSummary" in rendered
+    assert "GetDiffTree" not in rendered
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_get_diff_summary_reports_own_operation_name(
+    clients: BothClients, mock_diff_tree_query: HTTPXMock, client_type: str
+) -> None:
+    """get_diff_summary() must send its own operationName, not get_diff_tree()'s."""
+    if client_type == "standard":
+        await clients.standard.get_diff_summary(branch="branch2", tracker="query-difftree")
+    else:
+        clients.sync.get_diff_summary(branch="branch2", tracker="query-difftree")
+
+    payload = json.loads(mock_diff_tree_query.get_requests()[-1].content)
+    assert payload["operationName"] == "GetDiffSummary"
+    # The payload operationName must match the operation named in the query document.
+    assert f"query {payload['operationName']}" in payload["query"]
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_get_diff_tree_reports_own_operation_name(
+    clients: BothClients, mock_diff_tree_with_metadata: HTTPXMock, client_type: str
+) -> None:
+    """get_diff_tree() keeps reporting GetDiffTree, so the two methods stay distinguishable."""
+    if client_type == "standard":
+        await clients.standard.get_diff_tree(branch="feature-branch", tracker="query-difftree-metadata")
+    else:
+        clients.sync.get_diff_tree(branch="feature-branch", tracker="query-difftree-metadata")
+
+    payload = json.loads(mock_diff_tree_with_metadata.get_requests()[-1].content)
+    assert payload["operationName"] == "GetDiffTree"
+    assert f"query {payload['operationName']}" in payload["query"]


### PR DESCRIPTION
## Summary

`get_diff_summary()` sent its GraphQL request under `operationName: "GetDiffTree"` - the same operation name `get_diff_tree()` uses. The two methods were therefore indistinguishable in server-side query logs, traces, and any observability tooling keyed on `operationName`, even though they are different queries with different cost profiles.

The summary query's document declared `query GetDiffTree(...)` and both clients hardcoded `operation_name="GetDiffTree"`. This renames the operation to `GetDiffSummary` and sends that name from both the async and sync clients. The `DiffTree` GraphQL field and response parsing are unchanged, so behaviour is otherwise identical.

Note: the payload `operationName` and the operation named in the query document must agree, so both sides were changed together.

Fixes #1313.

## Changes

- `infrahub_sdk/diff.py` - rename the summary query operation `GetDiffTree` -> `GetDiffSummary`.
- `infrahub_sdk/client.py` - send `operation_name="GetDiffSummary"` from async and sync `get_diff_summary()`.
- `tests/unit/sdk/test_diff_summary.py` - regression tests that decode the sent request body and assert `get_diff_summary()` reports `GetDiffSummary` while `get_diff_tree()` still reports `GetDiffTree`, for both clients.

## Testing

- `uv run pytest tests/unit/sdk/test_diff_summary.py tests/unit/sdk/test_priority.py` - 94 passed
- `uv run invoke format lint-code` - clean (ruff, ty, mypy)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `get_diff_summary()` reporting its GraphQL request under the same `operationName` as `get_diff_tree()` (`GetDiffTree`), making the two indistinguishable in server-side query logs, traces, and observability tooling. The summary query now uses `GetDiffSummary` from both async and sync clients, with the query document renamed to match since the payload and document must agree.

<sup>Written for commit 7d97f9aa0ffed4e1d911a5621dc459fbb901c55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

