### PR TITLE
ci: install the lower-bounds lock with --frozen so the job tests the floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,8 +345,6 @@ jobs:
       # Rewrites uv.lock in the checkout, which is discarded with the runner.
       - name: "Re-resolve at the declared lower bounds"
         run: uv lock --resolution lowest-direct
-      # `--frozen`: a plain `uv sync` sees the lock's resolution mode differ from its own default
-      # and re-resolves at `highest`, which installs the newest versions instead of the floors.
       - name: Install dependencies
         run: uv sync --frozen --all-groups --all-extras
       - name: "Report the resolved versions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,8 +345,10 @@ jobs:
       # Rewrites uv.lock in the checkout, which is discarded with the runner.
       - name: "Re-resolve at the declared lower bounds"
         run: uv lock --resolution lowest-direct
+      # `--frozen`: a plain `uv sync` sees the lock's resolution mode differ from its own default
+      # and re-resolves at `highest`, which installs the newest versions instead of the floors.
       - name: Install dependencies
-        run: uv sync --all-groups --all-extras
+        run: uv sync --frozen --all-groups --all-extras
       - name: "Report the resolved versions"
         run: uv pip list
       - name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
       - name: "Report the resolved versions"
         run: uv pip list
       - name: Unit Tests
-        run: uv run pytest --cov infrahub_sdk tests/unit/
+        run: uv run --frozen pytest --cov infrahub_sdk tests/unit/
 
   # Proves a plain install works on every supported interpreter, which the uv.lock-based jobs cannot.
   install-matrix:


### PR DESCRIPTION
## Summary

`dependency-lower-bounds` has not been testing lower bounds. This makes it do so.

## What the job runs

Ubuntu, Python 3.10, uv 0.9.8, then four steps:

```bash
uv lock --resolution lowest-direct        # 1. rewrite uv.lock at the declared floors
uv sync --all-groups --all-extras         # 2. install
uv pip list                               # 3. report what got installed
uv run pytest --cov infrahub_sdk tests/unit/
```

## What was happening

1. `uv lock --resolution lowest-direct` does its job
2. `uv sync` reads that lock, sees its resolution mode differ from the command's own default (`highest`), and discards it: `Ignoring existing lockfile due to change in resolution mode: lowest-direct vs. highest`.
3. `uv pip list` reports faithfully: `rich 15.0.0`. The evidence has been in every run's log.
4. pytest therefore runs against the newest releases, not the floors.

This has been the case since the job's very first run on #1319 (run 34105875106):

```text
Updated rich v13.9.4 -> v12.0.0
Ignoring existing lockfile due to change in resolution mode: `lowest-direct` vs. `highest`
 + rich==15.0.0
```

Reproduced on this branch with `uv sync --dry-run` after the lowest-direct lock:

| Sync | rich installed |
|---|---|
| `uv sync --all-groups --all-extras` | 15.0.0 |
| `uv sync --frozen --all-groups --all-extras` | 12.0.0 |

## Change

One flag, `--frozen`, on step 2.

## Result on this branch

The job now installs the true floors on Python 3.10 (rich 12.0.0, pyarrow 14.0.0, pydantic 2.10.6) and the unit suite passes: no lower-bound regression on `infrahub-develop` today.

## Related

- #1353 fixes the test that this misconfiguration exposed under rich 15 and adds this job to the `ci-gate` rollup.
- #1354 raises the rich floor to 12.6 on `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `dependency-lower-bounds` CI job so it actually installs and tests against the declared lower-bound versions instead of re-resolving at the highest versions. Adds `--frozen` to both `uv sync` and `uv run` because both re-resolve at highest when the lock's resolution mode differs. The job will now fail on tests that only pass with newer versions; each failure is a real lower-bound bug.

<sup>Written for commit 6f8f7d9e70f4ae4aee912c8fc3718837341d0e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-sdk-python/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Second commit: `uv run` needs `--frozen` as well

The first run of this branch showed the sync step installing rich 12.0.0, then the `uv run pytest` step logging the same `Ignoring existing lockfile` line, uninstalling 41 packages and reinstalling the newest ones before the tests started. `uv run` syncs the environment before running the command. The second commit passes `--frozen` there too, so the tests finally execute against the floors.